### PR TITLE
[codex] Add UV and texture mapping tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | create_revolved_liquid_volume | Create inset axisymmetric liquid fill volumes with top and bottom caps inside lathed vessels. |
 | create_cylindrical_detail_band | Create UV-mapped cylindrical bands with generic ridges, grooves, corrugation, knurling, or thread-like detail. |
 | radial_mesh_deform | Apply generic periodic radial grooves, ridges, flutes, or corrugation to polygon meshes. |
+| polar_mesh_deform | Apply coupled angular radial and axial deformation for petal bases, star supports, lobed feet, or cyclic punt details. |
 | localized_radial_pattern_deform | Apply localized repeated dimples, raised dots, or embossed/debossed radial features to cylindrical meshes. |
 | uv_operations | List, create, switch, project, normalize, and lay out UV sets for polygon meshes. |
 | create_curve | Generate NURBS curves for various shapes (line, circle, spiral, helix, star, gear, etc.) |

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | create_material | Create and assign materials with various types (lambert, phong, wood, marble, chrome, glass, etc.) |
 | create_textured_material | Create an image-textured material, connect file and place2dTexture nodes, and optionally assign it to UV-mapped objects. |
 | create_textured_label | Create a UV-mapped curved label mesh around a bottle or cylindrical object and apply an image texture directly through UVs. |
+| create_revolved_mesh | Create UV-mapped lathed polygon meshes from radius/height profiles for bottles, cups, vases, and similar forms. |
 | uv_operations | List, create, switch, project, normalize, and lay out UV sets for polygon meshes. |
 | create_curve | Generate NURBS curves for various shapes (line, circle, spiral, helix, star, gear, etc.) |
 | curve_modeling | Create geometry using curve-based modeling techniques (extrude, loft, revolve, sweep, etc.) |

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | cylindrical_image_deform | Deform a cylindrical or lathed mesh from an image sampled in angle/height space for photo-driven relief or emboss/deboss details. |
 | polar_mesh_deform | Apply coupled angular radial and axial deformation for petal bases, star supports, lobed feet, or cyclic punt details. |
 | localized_radial_pattern_deform | Apply localized repeated dimples, raised dots, or embossed/debossed radial features to cylindrical meshes. |
+| trim_mesh_by_texture | Delete polygon faces by sampling image channels through mesh UVs for alpha cutouts, decals, panels, vents, or masks. |
 | uv_operations | List, create, switch, project, normalize, and lay out UV sets for polygon meshes. |
 | create_curve | Generate NURBS curves for various shapes (line, circle, spiral, helix, star, gear, etc.) |
 | curve_modeling | Create geometry using curve-based modeling techniques (extrude, loft, revolve, sweep, etc.) |

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | create_curved_text | Create text curves, raised tube geometry, or filled polygon text conformed to cylindrical surfaces. |
 | create_revolved_mesh | Create UV-mapped lathed polygon meshes from radius/height profiles, with optional smooth profile resampling. |
 | create_revolved_shell | Create UV-mapped hollow lathed shells from outer and inner profiles, with optional smooth profile resampling. |
+| create_revolved_liquid_volume | Create inset axisymmetric liquid fill volumes with top and bottom caps inside lathed vessels. |
 | create_cylindrical_detail_band | Create UV-mapped cylindrical bands with generic ridges, grooves, corrugation, knurling, or thread-like detail. |
 | radial_mesh_deform | Apply generic periodic radial grooves, ridges, flutes, or corrugation to polygon meshes. |
 | localized_radial_pattern_deform | Apply localized repeated dimples, raised dots, or embossed/debossed radial features to cylindrical meshes. |

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | create_revolved_mesh | Create UV-mapped lathed polygon meshes from radius/height profiles, with optional smooth profile resampling. |
 | create_revolved_shell | Create UV-mapped hollow lathed shells from outer and inner profiles, with optional smooth profile resampling. |
 | create_revolved_liquid_volume | Create inset axisymmetric liquid fill volumes with top and bottom caps inside lathed vessels. |
+| extract_revolved_profile_from_image | Extract a lathe-ready radius/height profile from an image silhouette for reference-driven revolved modeling. |
 | create_cylindrical_detail_band | Create UV-mapped cylindrical bands with generic ridges, grooves, corrugation, knurling, or thread-like detail. |
 | radial_mesh_deform | Apply generic periodic radial grooves, ridges, flutes, or corrugation to polygon meshes. |
 | polar_mesh_deform | Apply coupled angular radial and axial deformation for petal bases, star supports, lobed feet, or cyclic punt details. |

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | extract_image_contours | Extract image-mask component contours and optionally create planar or cylindrical Maya curves. |
 | create_textured_label | Create a UV-mapped curved label mesh around a cylindrical or profiled lathed object and apply an image texture directly through UVs, with optional alpha. |
 | create_curved_text | Create text curves, raised tube geometry, or filled polygon text conformed to cylindrical surfaces. |
+| create_tube_mesh_from_curves | Create polygon tube geometry along curves or point paths for trim, seams, strokes, wires, pipes, or raised outlines. |
 | create_revolved_mesh | Create UV-mapped lathed polygon meshes from radius/height profiles, with optional smooth profile resampling. |
 | create_revolved_shell | Create UV-mapped hollow lathed shells from outer and inner profiles, with optional smooth profile resampling. |
 | create_revolved_liquid_volume | Create inset axisymmetric liquid fill volumes with top and bottom caps inside lathed vessels. |

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | extract_image_region_texture | Crop, optionally background-mask, and remap a reference image region into a reusable texture file for labels, decals, panels, caps, or trim. |
 | extract_image_matte_texture | Extract cropped textures with alpha mattes derived from color, hue, foreground, or alpha image regions. |
 | extract_image_detail_mask | Extract dark, bright, absolute-contrast, or edge detail masks from reference images for texture cleanup or geometry relief. |
-| extract_image_contours | Extract image-mask component contours and optionally create planar or cylindrical Maya curves. |
+| extract_image_contours | Extract traced and filtered image-mask contours and optionally create planar or cylindrical Maya curves. |
 | create_textured_label | Create a UV-mapped curved label mesh around a cylindrical or profiled lathed object and apply an image texture directly through UVs, with optional alpha. |
 | create_curved_text | Create text curves, raised tube geometry, or filled polygon text conformed to cylindrical surfaces. |
 | create_tube_mesh_from_curves | Create polygon tube geometry along curves or point paths for trim, seams, strokes, wires, pipes, or raised outlines. |

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | setup_product_preview_scene | Set up a generic product-preview camera, lights, viewport settings, and optional playblast image; omitted targets auto-frame visible scene geometry. |
 | create_reference_image_plane | Create a textured world-space reference image plane with optional alpha fitted to target objects for silhouette, proportion, or layout comparison. |
 | compare_image_silhouettes | Compare two image silhouettes with normalized overlay, IoU, centroid, aspect, row-width, vertical-band metrics, and optional profile-correction output. |
-| compare_image_appearance | Compare cropped and aligned reference/candidate image appearance with masked RGB and luminance error metrics plus a heatmap diagnostic. |
+| compare_image_appearance | Compare cropped and aligned reference/candidate image appearance with masked RGB/luminance error metrics, optional vertical-band summaries, and a heatmap diagnostic. |
 
 ## Advanced Modeling Tools
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | select_object | Select an object in the scene. |
 | setup_product_preview_scene | Set up a generic product-preview camera, lights, viewport settings, and optional playblast image. |
 | create_reference_image_plane | Create a textured world-space reference image plane with optional alpha fitted to target objects for silhouette, proportion, or layout comparison. |
-| compare_image_silhouettes | Compare two image silhouettes with normalized overlay, IoU, centroid, aspect, row-width, and vertical-band width error metrics. |
+| compare_image_silhouettes | Compare two image silhouettes with normalized overlay, IoU, centroid, aspect, row-width, vertical-band metrics, and optional profile-correction output. |
 
 ## Advanced Modeling Tools
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | create_material | Create and assign materials with various types (lambert, phong, wood, marble, chrome, glass, etc.) |
 | create_pbr_material | Create generic physically-oriented materials with glass, liquid, metal, plastic, rubber, and ceramic presets. |
 | create_textured_material | Create an image-textured material, connect file and place2dTexture nodes, and optionally assign it to UV-mapped objects. |
+| get_material_assignments | Report shading-group and surface-material assignments for scene geometry, optionally including per-component set members. |
 | refresh_file_textures | Refresh Maya file texture nodes, re-enable file loading, touch texture paths, and reset textured viewport display. |
 | extract_image_region_texture | Crop explicitly or by foreground auto-bbox, optionally background-mask, and remap a reference image region into a reusable texture file for labels, decals, panels, caps, silhouettes, or trim. |
 | extract_image_matte_texture | Extract cropped textures with alpha mattes derived from color, hue, foreground, or alpha image regions. |

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | create_pbr_material | Create generic physically-oriented materials with glass, liquid, metal, plastic, rubber, and ceramic presets. |
 | create_textured_material | Create an image-textured material, connect file and place2dTexture nodes, and optionally assign it to UV-mapped objects. |
 | create_textured_label | Create a UV-mapped curved label mesh around a bottle or cylindrical object and apply an image texture directly through UVs. |
+| create_curved_text | Create text curves or raised tube geometry conformed to cylindrical surfaces. |
 | create_revolved_mesh | Create UV-mapped lathed polygon meshes from radius/height profiles for bottles, cups, vases, and similar forms. |
 | create_revolved_shell | Create UV-mapped hollow lathed shells from outer and inner profiles for thick-wall bottles, cups, shades, and vessels. |
 | create_cylindrical_detail_band | Create UV-mapped cylindrical bands with generic ridges, grooves, corrugation, knurling, or thread-like detail. |

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | scene_open | Load in a scene into Maya. | 
 | scene_save | Save the current scene. If the filename is not specified, it will save it as its current name. |
 | select_object | Select an object in the scene. |
+| setup_product_preview_scene | Set up a generic product-preview camera, lights, viewport settings, and optional playblast image. |
 
 ## Advanced Modeling Tools
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | setup_product_preview_scene | Set up a generic product-preview camera, lights, viewport settings, and optional playblast image; omitted targets auto-frame visible scene geometry. |
 | create_reference_image_plane | Create a textured world-space reference image plane with optional alpha fitted to target objects for silhouette, proportion, or layout comparison. |
 | compare_image_silhouettes | Compare two image silhouettes with normalized overlay, IoU, centroid, aspect, row-width, vertical-band metrics, and optional profile-correction output. |
-| compare_image_appearance | Compare cropped and aligned reference/candidate image appearance with masked RGB/luminance error metrics, optional vertical-band summaries, and a heatmap diagnostic. |
+| compare_image_appearance | Compare cropped and aligned reference/candidate image appearance with masked RGB/luminance error metrics, optional band/grid summaries, and a heatmap diagnostic. |
 
 ## Advanced Modeling Tools
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | create_pbr_material | Create generic physically-oriented materials with glass, liquid, metal, plastic, rubber, and ceramic presets. |
 | create_textured_material | Create an image-textured material, connect file and place2dTexture nodes, and optionally assign it to UV-mapped objects. |
 | extract_image_region_texture | Crop, optionally background-mask, and remap a reference image region into a reusable texture file for labels, decals, panels, caps, or trim. |
+| extract_image_matte_texture | Extract cropped textures with alpha mattes derived from color, hue, foreground, or alpha image regions. |
 | extract_image_detail_mask | Extract dark, bright, absolute-contrast, or edge detail masks from reference images for texture cleanup or geometry relief. |
 | create_textured_label | Create a UV-mapped curved label mesh around a cylindrical or profiled lathed object and apply an image texture directly through UVs, with optional alpha. |
 | create_curved_text | Create text curves, raised tube geometry, or filled polygon text conformed to cylindrical surfaces. |

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | scene_save | Save the current scene. If the filename is not specified, it will save it as its current name. |
 | select_object | Select an object in the scene. |
 | setup_product_preview_scene | Set up a generic product-preview camera, lights, viewport settings, and optional playblast image. |
-| create_reference_image_plane | Create a textured world-space reference image plane fitted to target objects for silhouette, proportion, or layout comparison. |
+| create_reference_image_plane | Create a textured world-space reference image plane with optional alpha fitted to target objects for silhouette, proportion, or layout comparison. |
 
 ## Advanced Modeling Tools
 
@@ -35,7 +35,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | create_material | Create and assign materials with various types (lambert, phong, wood, marble, chrome, glass, etc.) |
 | create_pbr_material | Create generic physically-oriented materials with glass, liquid, metal, plastic, rubber, and ceramic presets. |
 | create_textured_material | Create an image-textured material, connect file and place2dTexture nodes, and optionally assign it to UV-mapped objects. |
-| extract_image_region_texture | Crop, optionally background-mask, and remap a reference image region into a reusable texture file for labels, decals, panels, caps, or trim. |
+| extract_image_region_texture | Crop explicitly or by foreground auto-bbox, optionally background-mask, and remap a reference image region into a reusable texture file for labels, decals, panels, caps, silhouettes, or trim. |
 | extract_image_matte_texture | Extract cropped textures with alpha mattes derived from color, hue, foreground, or alpha image regions. |
 | extract_image_detail_mask | Extract dark, bright, absolute-contrast, or edge detail masks from reference images for texture cleanup or geometry relief. |
 | extract_image_contours | Extract traced and filtered image-mask contours and optionally create planar or cylindrical Maya curves. |

--- a/README.md
+++ b/README.md
@@ -47,12 +47,13 @@ Here is a list of some of the tools registered with Maya MCP.
 | create_tube_mesh_from_curves | Create polygon tube geometry along curves or point paths for trim, seams, strokes, wires, pipes, or raised outlines. |
 | create_revolved_mesh | Create UV-mapped lathed polygon meshes from radius/height profiles, with optional smooth profile resampling. |
 | create_revolved_shell | Create UV-mapped hollow lathed shells from outer and inner profiles, with optional smooth profile resampling. |
-| create_revolved_liquid_volume | Create inset axisymmetric liquid fill volumes with top and bottom caps inside lathed vessels. |
+| create_revolved_liquid_volume | Create inset axisymmetric or angular-sector liquid fill volumes with top and bottom caps inside lathed vessels. |
 | extract_revolved_profile_from_image | Extract a lathe-ready radius/height profile from an image silhouette for reference-driven revolved modeling. |
 | extract_image_color_regions | Extract connected color or foreground regions from an image reference and report normalized and product-height-space bounds. |
 | create_cylindrical_detail_band | Create UV-mapped cylindrical bands with generic ridges, grooves, corrugation, knurling, or thread-like detail. |
 | radial_mesh_deform | Apply generic periodic radial grooves, ridges, flutes, or corrugation to polygon meshes. |
 | radial_profile_deform | Apply non-periodic axial radius scale, offset, or target-radius profiles to cylindrical or lathed polygon meshes. |
+| sample_mesh_radial_profile | Sample an axial radial profile from an existing mesh for rebuilding, comparison, or partial-volume generation. |
 | linear_profile_deform | Apply non-radial axial coordinate profiles for tapering decals, panels, ribbons, cards, labels, and other mesh layers. |
 | fit_objects_to_bounds | Fit one or more mesh or curve objects to target world-space bounds by scaling points or transforms. |
 | cylindrical_component_deform | Detect connected components in image masks and apply fitted local relief features to cylindrical or lathed meshes. |

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | scene_open | Load in a scene into Maya. | 
 | scene_save | Save the current scene. If the filename is not specified, it will save it as its current name. |
 | select_object | Select an object in the scene. |
-| setup_product_preview_scene | Set up a generic product-preview camera, lights, viewport settings, and optional playblast image. |
+| setup_product_preview_scene | Set up a generic product-preview camera, lights, viewport settings, and optional playblast image; omitted targets auto-frame visible scene geometry. |
 | create_reference_image_plane | Create a textured world-space reference image plane with optional alpha fitted to target objects for silhouette, proportion, or layout comparison. |
 | compare_image_silhouettes | Compare two image silhouettes with normalized overlay, IoU, centroid, aspect, row-width, vertical-band metrics, and optional profile-correction output. |
 
@@ -36,6 +36,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | create_material | Create and assign materials with various types (lambert, phong, wood, marble, chrome, glass, etc.) |
 | create_pbr_material | Create generic physically-oriented materials with glass, liquid, metal, plastic, rubber, and ceramic presets. |
 | create_textured_material | Create an image-textured material, connect file and place2dTexture nodes, and optionally assign it to UV-mapped objects. |
+| refresh_file_textures | Refresh Maya file texture nodes, re-enable file loading, touch texture paths, and reset textured viewport display. |
 | extract_image_region_texture | Crop explicitly or by foreground auto-bbox, optionally background-mask, and remap a reference image region into a reusable texture file for labels, decals, panels, caps, silhouettes, or trim. |
 | extract_image_matte_texture | Extract cropped textures with alpha mattes derived from color, hue, foreground, or alpha image regions. |
 | extract_image_detail_mask | Extract dark, bright, absolute-contrast, or edge detail masks from reference images for texture cleanup or geometry relief. |
@@ -52,6 +53,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | radial_mesh_deform | Apply generic periodic radial grooves, ridges, flutes, or corrugation to polygon meshes. |
 | radial_profile_deform | Apply non-periodic axial radius scale, offset, or target-radius profiles to cylindrical or lathed polygon meshes. |
 | linear_profile_deform | Apply non-radial axial coordinate profiles for tapering decals, panels, ribbons, cards, labels, and other mesh layers. |
+| fit_objects_to_bounds | Fit one or more mesh or curve objects to target world-space bounds by scaling points or transforms. |
 | cylindrical_component_deform | Detect connected components in image masks and apply fitted local relief features to cylindrical or lathed meshes. |
 | cylindrical_image_deform | Deform a cylindrical or lathed mesh from an image sampled in angle/height space for photo-driven relief or emboss/deboss details. |
 | uv_texture_deform | Deform UV-mapped polygon meshes by sampling an image through vertex UVs along normals, axes, or radial directions. |

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ Here is a list of some of the tools registered with Maya MCP.
 | create_material | Create and assign materials with various types (lambert, phong, wood, marble, chrome, glass, etc.) |
 | create_pbr_material | Create generic physically-oriented materials with glass, liquid, metal, plastic, rubber, and ceramic presets. |
 | create_textured_material | Create an image-textured material, connect file and place2dTexture nodes, and optionally assign it to UV-mapped objects. |
-| extract_image_region_texture | Crop and optionally remap a reference image region into a reusable texture file for labels, decals, panels, caps, or trim. |
+| extract_image_region_texture | Crop, optionally background-mask, and remap a reference image region into a reusable texture file for labels, decals, panels, caps, or trim. |
 | extract_image_detail_mask | Extract dark, bright, absolute-contrast, or edge detail masks from reference images for texture cleanup or geometry relief. |
-| create_textured_label | Create a UV-mapped curved label mesh around a cylindrical or profiled lathed object and apply an image texture directly through UVs. |
+| create_textured_label | Create a UV-mapped curved label mesh around a cylindrical or profiled lathed object and apply an image texture directly through UVs, with optional alpha. |
 | create_curved_text | Create text curves, raised tube geometry, or filled polygon text conformed to cylindrical surfaces. |
 | create_revolved_mesh | Create UV-mapped lathed polygon meshes from radius/height profiles, with optional smooth profile resampling. |
 | create_revolved_shell | Create UV-mapped hollow lathed shells from outer and inner profiles, with optional smooth profile resampling. |
@@ -46,6 +46,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | extract_image_color_regions | Extract connected color or foreground regions from an image reference and report normalized and product-height-space bounds. |
 | create_cylindrical_detail_band | Create UV-mapped cylindrical bands with generic ridges, grooves, corrugation, knurling, or thread-like detail. |
 | radial_mesh_deform | Apply generic periodic radial grooves, ridges, flutes, or corrugation to polygon meshes. |
+| cylindrical_component_deform | Detect connected components in image masks and apply fitted local relief features to cylindrical or lathed meshes. |
 | cylindrical_image_deform | Deform a cylindrical or lathed mesh from an image sampled in angle/height space for photo-driven relief or emboss/deboss details. |
 | polar_mesh_deform | Apply coupled angular radial and axial deformation for petal bases, star supports, lobed feet, or cyclic punt details. |
 | localized_radial_pattern_deform | Apply localized repeated dimples, raised dots, or embossed/debossed radial features to cylindrical meshes. |

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | create_advanced_model | Create complex 3D models like cars, trees, buildings, cups, and chairs with detailed parameters. |
 | mesh_operations | Perform modeling operations such as extrude, bevel, subdivide, boolean, combine, bridge, and split. |
 | create_material | Create and assign materials with various types (lambert, phong, wood, marble, chrome, glass, etc.) |
+| create_pbr_material | Create generic physically-oriented materials with glass, liquid, metal, plastic, rubber, and ceramic presets. |
 | create_textured_material | Create an image-textured material, connect file and place2dTexture nodes, and optionally assign it to UV-mapped objects. |
 | create_textured_label | Create a UV-mapped curved label mesh around a bottle or cylindrical object and apply an image texture directly through UVs. |
 | create_revolved_mesh | Create UV-mapped lathed polygon meshes from radius/height profiles for bottles, cups, vases, and similar forms. |

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | refresh_file_textures | Refresh Maya file texture nodes, re-enable file loading, touch texture paths, and reset textured viewport display. |
 | extract_image_region_texture | Crop explicitly or by foreground auto-bbox, optionally background-mask, and remap a reference image region into a reusable texture file for labels, decals, panels, caps, silhouettes, or trim. |
 | extract_image_matte_texture | Extract cropped textures with alpha mattes derived from color, hue, foreground, or alpha image regions. |
+| adjust_image_colors | Write an adjusted texture copy with channel gain/bias, brightness, contrast, saturation, value, gamma, optional alpha, and alpha/foreground/luminance/HSV masks. |
 | extract_image_detail_mask | Extract dark, bright, absolute-contrast, or edge detail masks from reference images for texture cleanup or geometry relief. |
 | extract_image_contours | Extract traced and filtered image-mask contours and optionally create planar or cylindrical Maya curves. |
 | create_textured_label | Create a UV-mapped curved label mesh around a cylindrical or profiled lathed object and apply an image texture directly through UVs, with optional alpha and opacity. |

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | scene_save | Save the current scene. If the filename is not specified, it will save it as its current name. |
 | select_object | Select an object in the scene. |
 | setup_product_preview_scene | Set up a generic product-preview camera, lights, viewport settings, and optional playblast image; omitted targets auto-frame visible scene geometry. |
+| setup_turntable_preview_scene | Render generic multi-angle product preview frames and a contact sheet, with optional soft texture refresh, angle annotations, and foreground bbox/aspect/coverage diagnostics. |
 | create_reference_image_plane | Create a textured world-space reference image plane with optional alpha fitted to target objects for silhouette, proportion, or layout comparison. |
 | compare_image_silhouettes | Compare two image silhouettes with optional foreground auto-cropping, normalized overlay, IoU, centroid, aspect, row-width, vertical-band metrics, and optional profile-correction output. |
 | compare_image_appearance | Compare cropped and aligned reference/candidate image appearance with masked RGB/luminance error metrics, optional foreground auto-cropping, band/grid summaries, and a heatmap diagnostic. |
@@ -40,6 +41,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | refresh_file_textures | Refresh Maya file texture nodes, re-enable file loading, touch texture paths, and reset textured viewport display. |
 | extract_image_region_texture | Crop explicitly or by foreground auto-bbox, optionally background-mask, and remap a reference image region into a reusable texture file for labels, decals, panels, caps, silhouettes, or trim. |
 | extract_image_matte_texture | Extract cropped textures with alpha mattes derived from color, hue, foreground, or alpha image regions. |
+| compose_image_layers | Compose multiple cropped/scaled/positioned image layers onto a single RGBA texture atlas or wrap texture. |
 | adjust_image_colors | Write an adjusted texture copy with channel gain/bias, brightness, contrast, saturation, value, gamma, optional alpha, and alpha/foreground/luminance/HSV masks. |
 | extract_image_detail_mask | Extract dark, bright, absolute-contrast, or edge detail masks from reference images for texture cleanup or geometry relief. |
 | extract_image_contours | Extract traced and filtered image-mask contours and optionally create planar or cylindrical Maya curves. |

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | extract_image_matte_texture | Extract cropped textures with alpha mattes derived from color, hue, foreground, or alpha image regions. |
 | extract_image_detail_mask | Extract dark, bright, absolute-contrast, or edge detail masks from reference images for texture cleanup or geometry relief. |
 | extract_image_contours | Extract traced and filtered image-mask contours and optionally create planar or cylindrical Maya curves. |
-| create_textured_label | Create a UV-mapped curved label mesh around a cylindrical or profiled lathed object and apply an image texture directly through UVs, with optional alpha. |
+| create_textured_label | Create a UV-mapped curved label mesh around a cylindrical or profiled lathed object and apply an image texture directly through UVs, with optional alpha and opacity. |
 | create_curved_text | Create text curves, raised tube geometry, or filled polygon text conformed to cylindrical surfaces. |
 | create_tube_mesh_from_curves | Create polygon tube geometry along curves or point paths for trim, seams, strokes, wires, pipes, or raised outlines. |
 | create_revolved_mesh | Create UV-mapped lathed polygon meshes from radius/height profiles, with optional smooth profile resampling. |

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | create_material | Create and assign materials with various types (lambert, phong, wood, marble, chrome, glass, etc.) |
 | create_pbr_material | Create generic physically-oriented materials with glass, liquid, metal, plastic, rubber, and ceramic presets. |
 | create_textured_material | Create an image-textured material, connect file and place2dTexture nodes, and optionally assign it to UV-mapped objects. |
+| assign_cylindrical_image_material | Project an image through cylindrical UVs onto selected mesh faces, with optional alpha and opacity for decals, partial wraps, and surface-photo details. |
 | get_material_assignments | Report shading-group and surface-material assignments for scene geometry, optionally including per-component set members. |
 | refresh_file_textures | Refresh Maya file texture nodes, re-enable file loading, touch texture paths, and reset textured viewport display. |
 | extract_image_region_texture | Crop explicitly or by foreground auto-bbox, optionally background-mask, and remap a reference image region into a reusable texture file for labels, decals, panels, caps, silhouettes, or trim. |

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | create_material | Create and assign materials with various types (lambert, phong, wood, marble, chrome, glass, etc.) |
 | create_pbr_material | Create generic physically-oriented materials with glass, liquid, metal, plastic, rubber, and ceramic presets. |
 | create_textured_material | Create an image-textured material, connect file and place2dTexture nodes, and optionally assign it to UV-mapped objects. |
-| create_textured_label | Create a UV-mapped curved label mesh around a bottle or cylindrical object and apply an image texture directly through UVs. |
+| create_textured_label | Create a UV-mapped curved label mesh around a cylindrical or profiled lathed object and apply an image texture directly through UVs. |
 | create_curved_text | Create text curves, raised tube geometry, or filled polygon text conformed to cylindrical surfaces. |
 | create_revolved_mesh | Create UV-mapped lathed polygon meshes from radius/height profiles, with optional smooth profile resampling. |
 | create_revolved_shell | Create UV-mapped hollow lathed shells from outer and inner profiles, with optional smooth profile resampling. |

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | create_revolved_shell | Create UV-mapped hollow lathed shells from outer and inner profiles, with optional smooth profile resampling. |
 | create_cylindrical_detail_band | Create UV-mapped cylindrical bands with generic ridges, grooves, corrugation, knurling, or thread-like detail. |
 | radial_mesh_deform | Apply generic periodic radial grooves, ridges, flutes, or corrugation to polygon meshes. |
+| localized_radial_pattern_deform | Apply localized repeated dimples, raised dots, or embossed/debossed radial features to cylindrical meshes. |
 | uv_operations | List, create, switch, project, normalize, and lay out UV sets for polygon meshes. |
 | create_curve | Generate NURBS curves for various shapes (line, circle, spiral, helix, star, gear, etc.) |
 | curve_modeling | Create geometry using curve-based modeling techniques (extrude, loft, revolve, sweep, etc.) |

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | uv_texture_deform | Deform UV-mapped polygon meshes by sampling an image through vertex UVs along normals, axes, or radial directions. |
 | polar_mesh_deform | Apply coupled angular radial and axial deformation for petal bases, star supports, lobed feet, or cyclic punt details. |
 | localized_radial_pattern_deform | Apply localized repeated dimples, raised dots, or embossed/debossed radial features to cylindrical meshes. |
-| trim_mesh_by_texture | Delete polygon faces by sampling image channels through mesh UVs for alpha cutouts, decals, panels, vents, or masks. |
+| trim_mesh_by_texture | Delete polygon faces by sampling image channels through mesh UVs, with configurable face sample points, for alpha cutouts, decals, panels, vents, or masks. |
 | uv_operations | List, create, switch, project, normalize, and lay out UV sets for polygon meshes. |
 | create_curve | Generate NURBS curves for various shapes (line, circle, spiral, helix, star, gear, etc.) |
 | curve_modeling | Create geometry using curve-based modeling techniques (extrude, loft, revolve, sweep, etc.) |

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | select_object | Select an object in the scene. |
 | setup_product_preview_scene | Set up a generic product-preview camera, lights, viewport settings, and optional playblast image. |
 | create_reference_image_plane | Create a textured world-space reference image plane with optional alpha fitted to target objects for silhouette, proportion, or layout comparison. |
-| compare_image_silhouettes | Compare two image silhouettes with normalized overlay, IoU, centroid, aspect, and row-width error metrics. |
+| compare_image_silhouettes | Compare two image silhouettes with normalized overlay, IoU, centroid, aspect, row-width, and vertical-band width error metrics. |
 
 ## Advanced Modeling Tools
 
@@ -50,6 +50,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | extract_image_color_regions | Extract connected color or foreground regions from an image reference and report normalized and product-height-space bounds. |
 | create_cylindrical_detail_band | Create UV-mapped cylindrical bands with generic ridges, grooves, corrugation, knurling, or thread-like detail. |
 | radial_mesh_deform | Apply generic periodic radial grooves, ridges, flutes, or corrugation to polygon meshes. |
+| radial_profile_deform | Apply non-periodic axial radius scale, offset, or target-radius profiles to cylindrical or lathed polygon meshes. |
 | cylindrical_component_deform | Detect connected components in image masks and apply fitted local relief features to cylindrical or lathed meshes. |
 | cylindrical_image_deform | Deform a cylindrical or lathed mesh from an image sampled in angle/height space for photo-driven relief or emboss/deboss details. |
 | uv_texture_deform | Deform UV-mapped polygon meshes by sampling an image through vertex UVs along normals, axes, or radial directions. |

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | create_textured_label | Create a UV-mapped curved label mesh around a bottle or cylindrical object and apply an image texture directly through UVs. |
 | create_revolved_mesh | Create UV-mapped lathed polygon meshes from radius/height profiles for bottles, cups, vases, and similar forms. |
 | create_revolved_shell | Create UV-mapped hollow lathed shells from outer and inner profiles for thick-wall bottles, cups, shades, and vessels. |
+| create_cylindrical_detail_band | Create UV-mapped cylindrical bands with generic ridges, grooves, corrugation, knurling, or thread-like detail. |
 | radial_mesh_deform | Apply generic periodic radial grooves, ridges, flutes, or corrugation to polygon meshes. |
 | uv_operations | List, create, switch, project, normalize, and lay out UV sets for polygon meshes. |
 | create_curve | Generate NURBS curves for various shapes (line, circle, spiral, helix, star, gear, etc.) |

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ Here is a list of some of the tools registered with Maya MCP.
 | create_advanced_model | Create complex 3D models like cars, trees, buildings, cups, and chairs with detailed parameters. |
 | mesh_operations | Perform modeling operations such as extrude, bevel, subdivide, boolean, combine, bridge, and split. |
 | create_material | Create and assign materials with various types (lambert, phong, wood, marble, chrome, glass, etc.) |
+| create_textured_material | Create an image-textured material, connect file and place2dTexture nodes, and optionally assign it to UV-mapped objects. |
+| create_textured_label | Create a UV-mapped curved label mesh around a bottle or cylindrical object and apply an image texture directly through UVs. |
+| uv_operations | List, create, switch, project, normalize, and lay out UV sets for polygon meshes. |
 | create_curve | Generate NURBS curves for various shapes (line, circle, spiral, helix, star, gear, etc.) |
 | curve_modeling | Create geometry using curve-based modeling techniques (extrude, loft, revolve, sweep, etc.) |
 | organize_objects | Organize objects through grouping, parenting, layout, alignment, and distribution. |

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | refresh_file_textures | Refresh Maya file texture nodes, re-enable file loading, touch texture paths, and reset textured viewport display. |
 | extract_image_region_texture | Crop explicitly or by foreground auto-bbox, optionally background-mask, and remap a reference image region into a reusable texture file for labels, decals, panels, caps, silhouettes, or trim. |
 | extract_image_matte_texture | Extract cropped textures with alpha mattes derived from color, hue, foreground, or alpha image regions. |
+| clean_image_alpha_edges | Remove alpha edge contamination, optionally erode/feather alpha fringes, and fill transparent RGB padding for decal, cutout, projection, and texture assets. |
 | compose_image_layers | Compose multiple cropped/scaled/positioned image layers onto a single RGBA texture atlas or wrap texture. |
 | adjust_image_colors | Write an adjusted texture copy with channel gain/bias, brightness, contrast, saturation, value, gamma, optional alpha, and alpha/foreground/luminance/HSV masks. |
 | extract_image_detail_mask | Extract dark, bright, absolute-contrast, or edge detail masks from reference images for texture cleanup or geometry relief. |

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | create_material | Create and assign materials with various types (lambert, phong, wood, marble, chrome, glass, etc.) |
 | create_pbr_material | Create generic physically-oriented materials with glass, liquid, metal, plastic, rubber, and ceramic presets. |
 | create_textured_material | Create an image-textured material, connect file and place2dTexture nodes, and optionally assign it to UV-mapped objects. |
+| extract_image_region_texture | Crop a reference image region into a reusable texture file for labels, decals, panels, caps, or trim. |
 | create_textured_label | Create a UV-mapped curved label mesh around a cylindrical or profiled lathed object and apply an image texture directly through UVs. |
 | create_curved_text | Create text curves, raised tube geometry, or filled polygon text conformed to cylindrical surfaces. |
 | create_revolved_mesh | Create UV-mapped lathed polygon meshes from radius/height profiles, with optional smooth profile resampling. |

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | scene_save | Save the current scene. If the filename is not specified, it will save it as its current name. |
 | select_object | Select an object in the scene. |
 | setup_product_preview_scene | Set up a generic product-preview camera, lights, viewport settings, and optional playblast image. |
+| create_reference_image_plane | Create a textured world-space reference image plane fitted to target objects for silhouette, proportion, or layout comparison. |
 
 ## Advanced Modeling Tools
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | create_material | Create and assign materials with various types (lambert, phong, wood, marble, chrome, glass, etc.) |
 | create_pbr_material | Create generic physically-oriented materials with glass, liquid, metal, plastic, rubber, and ceramic presets. |
 | create_textured_material | Create an image-textured material, connect file and place2dTexture nodes, and optionally assign it to UV-mapped objects. |
-| extract_image_region_texture | Crop a reference image region into a reusable texture file for labels, decals, panels, caps, or trim. |
+| extract_image_region_texture | Crop and optionally remap a reference image region into a reusable texture file for labels, decals, panels, caps, or trim. |
 | create_textured_label | Create a UV-mapped curved label mesh around a cylindrical or profiled lathed object and apply an image texture directly through UVs. |
 | create_curved_text | Create text curves, raised tube geometry, or filled polygon text conformed to cylindrical surfaces. |
 | create_revolved_mesh | Create UV-mapped lathed polygon meshes from radius/height profiles, with optional smooth profile resampling. |

--- a/README.md
+++ b/README.md
@@ -115,6 +115,24 @@ When the Maya MCP server first attempts to communicate with Maya, you will get t
 
 ![](docs/MayaSecurityWarning-RunScript.jpg)
 
+If the default command port is blocked by Maya security settings, open a
+dedicated Python command port in Maya and point the MCP server at it:
+
+```mel
+commandPort -name ":50009" -sourceType "python" -bufferSize 4096 -outputVar "_mcp_maya_results";
+```
+
+Then set these environment variables for the MCP server process:
+
+```json
+{
+  "env": {
+    "MAYA_MCP_COMMAND_PORT": "50009",
+    "MAYA_MCP_COMMAND_SOURCE_TYPE": "python"
+  }
+}
+```
+
 
 ## Developer Notes
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | create_textured_material | Create an image-textured material, connect file and place2dTexture nodes, and optionally assign it to UV-mapped objects. |
 | create_textured_label | Create a UV-mapped curved label mesh around a bottle or cylindrical object and apply an image texture directly through UVs. |
 | create_revolved_mesh | Create UV-mapped lathed polygon meshes from radius/height profiles for bottles, cups, vases, and similar forms. |
+| create_revolved_shell | Create UV-mapped hollow lathed shells from outer and inner profiles for thick-wall bottles, cups, shades, and vessels. |
 | radial_mesh_deform | Apply generic periodic radial grooves, ridges, flutes, or corrugation to polygon meshes. |
 | uv_operations | List, create, switch, project, normalize, and lay out UV sets for polygon meshes. |
 | create_curve | Generate NURBS curves for various shapes (line, circle, spiral, helix, star, gear, etc.) |

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | create_pbr_material | Create generic physically-oriented materials with glass, liquid, metal, plastic, rubber, and ceramic presets. |
 | create_textured_material | Create an image-textured material, connect file and place2dTexture nodes, and optionally assign it to UV-mapped objects. |
 | create_textured_label | Create a UV-mapped curved label mesh around a bottle or cylindrical object and apply an image texture directly through UVs. |
-| create_curved_text | Create text curves or raised tube geometry conformed to cylindrical surfaces. |
+| create_curved_text | Create text curves, raised tube geometry, or filled polygon text conformed to cylindrical surfaces. |
 | create_revolved_mesh | Create UV-mapped lathed polygon meshes from radius/height profiles for bottles, cups, vases, and similar forms. |
 | create_revolved_shell | Create UV-mapped hollow lathed shells from outer and inner profiles for thick-wall bottles, cups, shades, and vessels. |
 | create_cylindrical_detail_band | Create UV-mapped cylindrical bands with generic ridges, grooves, corrugation, knurling, or thread-like detail. |

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | extract_image_color_regions | Extract connected color or foreground regions from an image reference and report normalized and product-height-space bounds. |
 | create_cylindrical_detail_band | Create UV-mapped cylindrical bands with generic ridges, grooves, corrugation, knurling, or thread-like detail. |
 | radial_mesh_deform | Apply generic periodic radial grooves, ridges, flutes, or corrugation to polygon meshes. |
+| cylindrical_image_deform | Deform a cylindrical or lathed mesh from an image sampled in angle/height space for photo-driven relief or emboss/deboss details. |
 | polar_mesh_deform | Apply coupled angular radial and axial deformation for petal bases, star supports, lobed feet, or cyclic punt details. |
 | localized_radial_pattern_deform | Apply localized repeated dimples, raised dots, or embossed/debossed radial features to cylindrical meshes. |
 | uv_operations | List, create, switch, project, normalize, and lay out UV sets for polygon meshes. |

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | radial_mesh_deform | Apply generic periodic radial grooves, ridges, flutes, or corrugation to polygon meshes. |
 | cylindrical_component_deform | Detect connected components in image masks and apply fitted local relief features to cylindrical or lathed meshes. |
 | cylindrical_image_deform | Deform a cylindrical or lathed mesh from an image sampled in angle/height space for photo-driven relief or emboss/deboss details. |
+| uv_texture_deform | Deform UV-mapped polygon meshes by sampling an image through vertex UVs along normals, axes, or radial directions. |
 | polar_mesh_deform | Apply coupled angular radial and axial deformation for petal bases, star supports, lobed feet, or cyclic punt details. |
 | localized_radial_pattern_deform | Apply localized repeated dimples, raised dots, or embossed/debossed radial features to cylindrical meshes. |
 | trim_mesh_by_texture | Delete polygon faces by sampling image channels through mesh UVs for alpha cutouts, decals, panels, vents, or masks. |

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ Here is a list of some of the tools registered with Maya MCP.
 
 | Tool | Description |
 |------|-------------|
-| list_objects_by_type | Get a list of objects in the scene. Use filter_by to filter for certain objects such as "cameras", "lights", "materials", or "shapes". |
+| list_objects_by_type | List scene nodes by common categories such as meshes, curves, geometry, cameras, lights, materials, textures, file textures, shading groups, and shapes. |
 | create_object | Create an object in the Maya scene. Object types available are cube, cone, sphere, cylinder, camera, spotLight, pointLight, directionalLight. |
 | get_object_attributes | Get a list of attributes on a Maya object. | 
-| set_object_attributes | Set an object's attribute with a specific value. |
+| set_object_attribute | Set an object's scalar, string, boolean, or 3-channel vector attribute, optionally disconnecting incoming attribute links first. |
 | scene_new | Create a new scene in Maya. Use the force argument to force a new scene when an existing scene is loaded and has been modified. |
 | scene_open | Load in a scene into Maya. | 
 | scene_save | Save the current scene. If the filename is not specified, it will save it as its current name. |
@@ -26,6 +26,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | setup_product_preview_scene | Set up a generic product-preview camera, lights, viewport settings, and optional playblast image; omitted targets auto-frame visible scene geometry. |
 | create_reference_image_plane | Create a textured world-space reference image plane with optional alpha fitted to target objects for silhouette, proportion, or layout comparison. |
 | compare_image_silhouettes | Compare two image silhouettes with normalized overlay, IoU, centroid, aspect, row-width, vertical-band metrics, and optional profile-correction output. |
+| compare_image_appearance | Compare cropped and aligned reference/candidate image appearance with masked RGB and luminance error metrics plus a heatmap diagnostic. |
 
 ## Advanced Modeling Tools
 

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Here is a list of some of the tools registered with Maya MCP.
 | create_textured_material | Create an image-textured material, connect file and place2dTexture nodes, and optionally assign it to UV-mapped objects. |
 | create_textured_label | Create a UV-mapped curved label mesh around a bottle or cylindrical object and apply an image texture directly through UVs. |
 | create_curved_text | Create text curves, raised tube geometry, or filled polygon text conformed to cylindrical surfaces. |
-| create_revolved_mesh | Create UV-mapped lathed polygon meshes from radius/height profiles for bottles, cups, vases, and similar forms. |
-| create_revolved_shell | Create UV-mapped hollow lathed shells from outer and inner profiles for thick-wall bottles, cups, shades, and vessels. |
+| create_revolved_mesh | Create UV-mapped lathed polygon meshes from radius/height profiles, with optional smooth profile resampling. |
+| create_revolved_shell | Create UV-mapped hollow lathed shells from outer and inner profiles, with optional smooth profile resampling. |
 | create_cylindrical_detail_band | Create UV-mapped cylindrical bands with generic ridges, grooves, corrugation, knurling, or thread-like detail. |
 | radial_mesh_deform | Apply generic periodic radial grooves, ridges, flutes, or corrugation to polygon meshes. |
 | uv_operations | List, create, switch, project, normalize, and lay out UV sets for polygon meshes. |

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | create_revolved_shell | Create UV-mapped hollow lathed shells from outer and inner profiles, with optional smooth profile resampling. |
 | create_revolved_liquid_volume | Create inset axisymmetric liquid fill volumes with top and bottom caps inside lathed vessels. |
 | extract_revolved_profile_from_image | Extract a lathe-ready radius/height profile from an image silhouette for reference-driven revolved modeling. |
+| extract_image_color_regions | Extract connected color or foreground regions from an image reference and report normalized and product-height-space bounds. |
 | create_cylindrical_detail_band | Create UV-mapped cylindrical bands with generic ridges, grooves, corrugation, knurling, or thread-like detail. |
 | radial_mesh_deform | Apply generic periodic radial grooves, ridges, flutes, or corrugation to polygon meshes. |
 | polar_mesh_deform | Apply coupled angular radial and axial deformation for petal bases, star supports, lobed feet, or cyclic punt details. |

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | create_cylindrical_detail_band | Create UV-mapped cylindrical bands with generic ridges, grooves, corrugation, knurling, or thread-like detail. |
 | radial_mesh_deform | Apply generic periodic radial grooves, ridges, flutes, or corrugation to polygon meshes. |
 | radial_profile_deform | Apply non-periodic axial radius scale, offset, or target-radius profiles to cylindrical or lathed polygon meshes. |
+| linear_profile_deform | Apply non-radial axial coordinate profiles for tapering decals, panels, ribbons, cards, labels, and other mesh layers. |
 | cylindrical_component_deform | Detect connected components in image masks and apply fitted local relief features to cylindrical or lathed meshes. |
 | cylindrical_image_deform | Deform a cylindrical or lathed mesh from an image sampled in angle/height space for photo-driven relief or emboss/deboss details. |
 | uv_texture_deform | Deform UV-mapped polygon meshes by sampling an image through vertex UVs along normals, axes, or radial directions. |

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | select_object | Select an object in the scene. |
 | setup_product_preview_scene | Set up a generic product-preview camera, lights, viewport settings, and optional playblast image; omitted targets auto-frame visible scene geometry. |
 | create_reference_image_plane | Create a textured world-space reference image plane with optional alpha fitted to target objects for silhouette, proportion, or layout comparison. |
-| compare_image_silhouettes | Compare two image silhouettes with normalized overlay, IoU, centroid, aspect, row-width, vertical-band metrics, and optional profile-correction output. |
+| compare_image_silhouettes | Compare two image silhouettes with optional foreground auto-cropping, normalized overlay, IoU, centroid, aspect, row-width, vertical-band metrics, and optional profile-correction output. |
 | compare_image_appearance | Compare cropped and aligned reference/candidate image appearance with masked RGB/luminance error metrics, optional foreground auto-cropping, band/grid summaries, and a heatmap diagnostic. |
 
 ## Advanced Modeling Tools

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | create_textured_material | Create an image-textured material, connect file and place2dTexture nodes, and optionally assign it to UV-mapped objects. |
 | create_textured_label | Create a UV-mapped curved label mesh around a bottle or cylindrical object and apply an image texture directly through UVs. |
 | create_revolved_mesh | Create UV-mapped lathed polygon meshes from radius/height profiles for bottles, cups, vases, and similar forms. |
+| radial_mesh_deform | Apply generic periodic radial grooves, ridges, flutes, or corrugation to polygon meshes. |
 | uv_operations | List, create, switch, project, normalize, and lay out UV sets for polygon meshes. |
 | create_curve | Generate NURBS curves for various shapes (line, circle, spiral, helix, star, gear, etc.) |
 | curve_modeling | Create geometry using curve-based modeling techniques (extrude, loft, revolve, sweep, etc.) |

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | get_object_attributes | Get a list of attributes on a Maya object. | 
 | set_object_attribute | Set an object's scalar, string, boolean, or 3-channel vector attribute, optionally disconnecting incoming attribute links first. |
 | scene_new | Create a new scene in Maya. Use the force argument to force a new scene when an existing scene is loaded and has been modified. |
-| scene_open | Load in a scene into Maya. | 
+| scene_open | Load in a scene into Maya, optionally forcing open when unsaved changes exist. |
 | scene_save | Save the current scene. If the filename is not specified, it will save it as its current name. |
 | select_object | Select an object in the scene. |
 | setup_product_preview_scene | Set up a generic product-preview camera, lights, viewport settings, and optional playblast image; omitted targets auto-frame visible scene geometry. |

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | extract_image_region_texture | Crop, optionally background-mask, and remap a reference image region into a reusable texture file for labels, decals, panels, caps, or trim. |
 | extract_image_matte_texture | Extract cropped textures with alpha mattes derived from color, hue, foreground, or alpha image regions. |
 | extract_image_detail_mask | Extract dark, bright, absolute-contrast, or edge detail masks from reference images for texture cleanup or geometry relief. |
+| extract_image_contours | Extract image-mask component contours and optionally create planar or cylindrical Maya curves. |
 | create_textured_label | Create a UV-mapped curved label mesh around a cylindrical or profiled lathed object and apply an image texture directly through UVs, with optional alpha. |
 | create_curved_text | Create text curves, raised tube geometry, or filled polygon text conformed to cylindrical surfaces. |
 | create_revolved_mesh | Create UV-mapped lathed polygon meshes from radius/height profiles, with optional smooth profile resampling. |

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | select_object | Select an object in the scene. |
 | setup_product_preview_scene | Set up a generic product-preview camera, lights, viewport settings, and optional playblast image. |
 | create_reference_image_plane | Create a textured world-space reference image plane with optional alpha fitted to target objects for silhouette, proportion, or layout comparison. |
+| compare_image_silhouettes | Compare two image silhouettes with normalized overlay, IoU, centroid, aspect, and row-width error metrics. |
 
 ## Advanced Modeling Tools
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | setup_product_preview_scene | Set up a generic product-preview camera, lights, viewport settings, and optional playblast image; omitted targets auto-frame visible scene geometry. |
 | create_reference_image_plane | Create a textured world-space reference image plane with optional alpha fitted to target objects for silhouette, proportion, or layout comparison. |
 | compare_image_silhouettes | Compare two image silhouettes with normalized overlay, IoU, centroid, aspect, row-width, vertical-band metrics, and optional profile-correction output. |
-| compare_image_appearance | Compare cropped and aligned reference/candidate image appearance with masked RGB/luminance error metrics, optional band/grid summaries, and a heatmap diagnostic. |
+| compare_image_appearance | Compare cropped and aligned reference/candidate image appearance with masked RGB/luminance error metrics, optional foreground auto-cropping, band/grid summaries, and a heatmap diagnostic. |
 
 ## Advanced Modeling Tools
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Here is a list of some of the tools registered with Maya MCP.
 | create_pbr_material | Create generic physically-oriented materials with glass, liquid, metal, plastic, rubber, and ceramic presets. |
 | create_textured_material | Create an image-textured material, connect file and place2dTexture nodes, and optionally assign it to UV-mapped objects. |
 | extract_image_region_texture | Crop and optionally remap a reference image region into a reusable texture file for labels, decals, panels, caps, or trim. |
+| extract_image_detail_mask | Extract dark, bright, absolute-contrast, or edge detail masks from reference images for texture cleanup or geometry relief. |
 | create_textured_label | Create a UV-mapped curved label mesh around a cylindrical or profiled lathed object and apply an image texture directly through UVs. |
 | create_curved_text | Create text curves, raised tube geometry, or filled polygon text conformed to cylindrical surfaces. |
 | create_revolved_mesh | Create UV-mapped lathed polygon meshes from radius/height profiles, with optional smooth profile resampling. |

--- a/codex_handoff_notes.md
+++ b/codex_handoff_notes.md
@@ -1,0 +1,11 @@
+# MayaMCP handoff notes
+
+- Branch: `codex/add-uv-texture-tools`.
+- Latest pushed generic-tool commit: `5808736 Use VP2 texture reload for previews`.
+- Current generic tool work: texture preview refresh now uses VP2's native `ogs -reset` / `ogs -reloadTextures` path, touches file texture paths in place, and preserves Maya-friendly forward-slash texture paths. This touches `refresh_file_textures`, `setup_product_preview_scene`, and `setup_turntable_preview_scene`.
+- Validation done: `py_compile` and `git diff --check` passed. Maya visual recheck passed with `v132_product_refresh_true.png` and `turntable_v132_refresh_true/v132_refresh_true_contact.png`.
+- Important visual state: texture refresh is now verified for the label in both product preview and 0/45/90/135/180 turntable contact sheet. The bottle model itself is still not final.
+- Safer bottle scene to resume from: `mayamcp_official_layered_bottle_v117_multiside_label.ma`. The `v118_deep_base` scene has a darker base experiment but was not visually proven better.
+- Latest measured v117 silhouette comparison against the official 20 oz reference: IoU `0.9630`, aspect error `0.0071`, mean absolute width error `0.0135`. Largest remaining band error is shoulder/upper-label transition `0.18-0.34` normalized height; model is still too wide there and slightly too narrow in the top cap/neck band.
+- Next validation: continue from v117 or a cleaned v118, then focus on bottle shape/material realism instead of texture-cache debugging. Validate from at least one off-front camera angle before accepting a visual change.
+- Worktree note: generated `.png` / `.ma` assets are intentionally untracked. Existing tracked dirty files in `src/mayatools/object/create_advanced_model.py`, `src/mayatools/object/curve_modeling.py`, `src/mayatools/scene/generate_scene.py`, and `src/mayatools/scene/scene_save.py` were not part of the final texture-refresh commit and should not be staged without reviewing their origin.

--- a/src/maya_mcp_server.py
+++ b/src/maya_mcp_server.py
@@ -56,7 +56,8 @@ class MayaConnection:
 
     @staticmethod
     def _encode_python_to_mel_python(python_code:str) -> str:
-        mel = python_code.replace('"', '\\"')
+        mel = python_code.replace('\\', '\\\\')
+        mel = mel.replace('"', '\\"')
         mel = mel.replace('\n', '\\n')
         return f'python("{mel}")'
 
@@ -253,10 +254,7 @@ def load_maya_tool_source(
     results += f"\n_mcp_maya_results = _mcp_maya_scope("
     params = []
     for k,v in vars.items():
-        if isinstance(v, str):
-            params.append(f"{k}='{v}'")
-        else:
-            params.append(f"{k}={v}")
+        params.append(f"{k}={repr(v)}")
     results += ','.join(params)
     results += ")\n\n"
 

--- a/src/maya_mcp_server.py
+++ b/src/maya_mcp_server.py
@@ -50,9 +50,19 @@ _operation_manager = None
 class MayaConnection:
     """ connection to the Maya instance """
 
-    def __init__(self, host:str=LOCAL_HOST, port:int=DEFAULT_COMMAND_PORT):
+    def __init__(self, host:str=None, port:int=None, source_type:str=None):
+        if host is None:
+            host = os.environ.get("MAYA_MCP_COMMAND_HOST", LOCAL_HOST)
+        if port is None:
+            port = int(os.environ.get("MAYA_MCP_COMMAND_PORT", DEFAULT_COMMAND_PORT))
+        if source_type is None:
+            source_type = os.environ.get("MAYA_MCP_COMMAND_SOURCE_TYPE", "mel")
+        source_type = source_type.lower().strip()
+        if source_type not in {"mel", "python"}:
+            raise ValueError("MAYA_MCP_COMMAND_SOURCE_TYPE must be mel or python.")
         self.host = host
         self.port = port
+        self.source_type = source_type
 
     @staticmethod
     def _encode_python_to_mel_python(python_code:str) -> str:
@@ -77,9 +87,13 @@ _mcp_maya_results = _mcp_io_buf.getvalue()
         client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         client.connect((self.host, self.port))
 
-        mel = MayaConnection._encode_python_to_mel_python(python_script)
+        if self.source_type == "python":
+            command = python_script
+        else:
+            command = MayaConnection._encode_python_to_mel_python(python_script)
 
-        client.send(mel.encode('utf-8'))
+        client.sendall(command.encode('utf-8'))
+        client.shutdown(socket.SHUT_WR)
 
         result = data = client.recv(1024)
         while len(data) == 1024:

--- a/src/mayatools/material/adjust_image_colors.py
+++ b/src/mayatools/material/adjust_image_colors.py
@@ -1,0 +1,293 @@
+from typing import Dict, List, Any
+
+
+def adjust_image_colors(
+    image_path: str,
+    output_path: str = None,
+    channel_gain: List[float] = [1.0, 1.0, 1.0],
+    channel_bias: List[float] = [0.0, 0.0, 0.0],
+    gamma: List[float] = [1.0, 1.0, 1.0],
+    brightness: float = 0.0,
+    contrast: float = 1.0,
+    saturation: float = 1.0,
+    value_gain: float = 1.0,
+    alpha_gain: float = 1.0,
+    alpha_bias: float = 0.0,
+    preserve_alpha: bool = True,
+    mask_mode: str = "alpha",
+    alpha_threshold: float = 0.0,
+    background_color: List[float] = None,
+    background_tolerance: float = 0.06,
+    luminance_range: List[float] = None,
+    hue_range: List[float] = None,
+    saturation_range: List[float] = None,
+    value_range: List[float] = None,
+    mix: float = 1.0,
+    overwrite: bool = True,
+) -> Dict[str, Any]:
+    """Adjust image texture color channels and optional alpha.
+
+    This is a generic texture-prep tool for decals, cards, product-photo
+    cutouts, labels, sprites, reference projections, and other image textures.
+    It writes an adjusted copy of an image using channel gain/bias, brightness,
+    contrast, saturation, value gain, gamma, and optional alpha adjustment.
+    Pixels can be limited by alpha, foreground/background color, luminance
+    range, or HSV ranges so local texture tuning does not require editing the
+    original source image.
+    """
+    import colorsys
+    import os
+
+    try:
+        from PySide6.QtGui import QImage, QColor
+    except Exception:
+        try:
+            from PySide2.QtGui import QImage, QColor
+        except Exception as exc:
+            raise RuntimeError("PySide QImage is required to adjust image colors.") from exc
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _clamp(value, lower=0.0, upper=1.0):
+        return max(lower, min(upper, value))
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(value) for value in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(value) for value in values]
+
+    def _validate_color(values, arg_name):
+        color = _validate_vector(values, 3, arg_name)
+        if max(color) > 1.0:
+            color = [value / 255.0 for value in color]
+        return [_clamp(value) for value in color]
+
+    def _validate_range(values, arg_name):
+        if values is None:
+            return None
+        clean = _validate_vector(values, 2, arg_name)
+        if clean[0] > clean[1]:
+            clean = [clean[1], clean[0]]
+        return [_clamp(clean[0]), _clamp(clean[1])]
+
+    def _estimate_background(image_value):
+        width = image_value.width()
+        height = image_value.height()
+        samples = []
+        radius = max(1, min(width, height, 8))
+        corners = [
+            (0, 0),
+            (width - 1, 0),
+            (0, height - 1),
+            (width - 1, height - 1),
+        ]
+        for corner_x, corner_y in corners:
+            for dy in range(-radius, radius + 1):
+                for dx in range(-radius, radius + 1):
+                    x = max(0, min(width - 1, corner_x + dx))
+                    y = max(0, min(height - 1, corner_y + dy))
+                    color = image_value.pixelColor(x, y)
+                    if color.alphaF() > 0.0:
+                        samples.append([color.redF(), color.greenF(), color.blueF()])
+        if not samples:
+            return [1.0, 1.0, 1.0]
+        result = []
+        for index in range(3):
+            values = sorted(sample[index] for sample in samples)
+            result.append(values[len(values) // 2])
+        return result
+
+    def _color_distance(color_a, color_b):
+        dr = color_a[0] - color_b[0]
+        dg = color_a[1] - color_b[1]
+        db = color_a[2] - color_b[2]
+        return (dr * dr + dg * dg + db * db) ** 0.5
+
+    def _in_range(value, value_range):
+        if value_range is None:
+            return True
+        return value_range[0] <= value <= value_range[1]
+
+    def _in_hue_range(value, value_range):
+        if value_range is None:
+            return True
+        start, end = value_range
+        if start <= end:
+            return start <= value <= end
+        return value >= start or value <= end
+
+    def _matches_mask(red, green, blue, alpha, background):
+        if alpha < alpha_threshold:
+            return False
+        if mask_mode == "all":
+            return True
+        if mask_mode == "alpha":
+            return True
+        luminance = 0.2126 * red + 0.7152 * green + 0.0722 * blue
+        hue, hsv_saturation, hsv_value = colorsys.rgb_to_hsv(red, green, blue)
+        if mask_mode == "foreground":
+            return _color_distance([red, green, blue], background) > background_tolerance
+        if mask_mode == "luminance_range":
+            return _in_range(luminance, clean_luminance_range)
+        if mask_mode == "hsv_range":
+            return (
+                _in_hue_range(hue, clean_hue_range)
+                and _in_range(hsv_saturation, clean_saturation_range)
+                and _in_range(hsv_value, clean_value_range)
+            )
+        return False
+
+    if not image_path:
+        raise ValueError("image_path is required.")
+    normalized_image_path = os.path.normpath(image_path)
+    if not os.path.isfile(normalized_image_path):
+        raise ValueError(f"Image path does not exist: {image_path}")
+    if output_path is None:
+        root, _ = os.path.splitext(normalized_image_path)
+        output_path = f"{root}_adjusted.png"
+    normalized_output_path = os.path.normpath(output_path)
+    if os.path.exists(normalized_output_path) and not overwrite:
+        raise ValueError(f"Output path already exists: {output_path}")
+
+    channel_gain = _validate_vector(channel_gain, 3, "channel_gain")
+    channel_bias = _validate_vector(channel_bias, 3, "channel_bias")
+    gamma = _validate_vector(gamma, 3, "gamma")
+    if any(value <= 0.0 for value in gamma):
+        raise ValueError("gamma values must be greater than zero.")
+    brightness = _validate_scalar(brightness, "brightness")
+    contrast = _validate_scalar(contrast, "contrast")
+    if contrast < 0.0:
+        raise ValueError("contrast must be greater than or equal to zero.")
+    saturation = _validate_scalar(saturation, "saturation")
+    if saturation < 0.0:
+        raise ValueError("saturation must be greater than or equal to zero.")
+    value_gain = _validate_scalar(value_gain, "value_gain")
+    if value_gain < 0.0:
+        raise ValueError("value_gain must be greater than or equal to zero.")
+    alpha_gain = _validate_scalar(alpha_gain, "alpha_gain")
+    alpha_bias = _validate_scalar(alpha_bias, "alpha_bias")
+    if not isinstance(preserve_alpha, bool):
+        raise ValueError("preserve_alpha must be a boolean.")
+    mask_mode = mask_mode.lower().strip()
+    if mask_mode not in {"all", "alpha", "foreground", "luminance_range", "hsv_range"}:
+        raise ValueError("mask_mode must be all, alpha, foreground, luminance_range, or hsv_range.")
+    alpha_threshold = _clamp(_validate_scalar(alpha_threshold, "alpha_threshold"))
+    background_tolerance = _validate_scalar(background_tolerance, "background_tolerance")
+    if background_tolerance < 0.0:
+        raise ValueError("background_tolerance must be greater than or equal to zero.")
+    clean_luminance_range = _validate_range(luminance_range, "luminance_range")
+    clean_hue_range = _validate_range(hue_range, "hue_range")
+    clean_saturation_range = _validate_range(saturation_range, "saturation_range")
+    clean_value_range = _validate_range(value_range, "value_range")
+    mix = _clamp(_validate_scalar(mix, "mix"))
+
+    image = QImage(normalized_image_path)
+    if image.isNull():
+        raise ValueError(f"Unable to load image: {image_path}")
+    image = image.convertToFormat(QImage.Format_ARGB32)
+
+    clean_background = (
+        _validate_color(background_color, "background_color")
+        if background_color is not None
+        else _estimate_background(image)
+    )
+
+    modified_pixels = 0
+    skipped_pixels = 0
+    before_rgb_sum = [0.0, 0.0, 0.0]
+    after_rgb_sum = [0.0, 0.0, 0.0]
+    before_alpha_sum = 0.0
+    after_alpha_sum = 0.0
+
+    width = image.width()
+    height = image.height()
+    for y in range(height):
+        for x in range(width):
+            pixel = image.pixelColor(x, y)
+            red = pixel.redF()
+            green = pixel.greenF()
+            blue = pixel.blueF()
+            alpha = pixel.alphaF()
+            if not _matches_mask(red, green, blue, alpha, clean_background):
+                skipped_pixels += 1
+                continue
+
+            original = [red, green, blue]
+            adjusted = [red, green, blue]
+            for index in range(3):
+                adjusted[index] = adjusted[index] * channel_gain[index] + channel_bias[index]
+                adjusted[index] = (adjusted[index] - 0.5) * contrast + 0.5 + brightness
+
+            luminance = 0.2126 * adjusted[0] + 0.7152 * adjusted[1] + 0.0722 * adjusted[2]
+            for index in range(3):
+                adjusted[index] = luminance + (adjusted[index] - luminance) * saturation
+                adjusted[index] *= value_gain
+                adjusted[index] = _clamp(adjusted[index])
+                adjusted[index] = _clamp(pow(adjusted[index], 1.0 / gamma[index]))
+                adjusted[index] = original[index] * (1.0 - mix) + adjusted[index] * mix
+
+            adjusted_alpha = alpha
+            if not preserve_alpha:
+                adjusted_alpha = _clamp(alpha * alpha_gain + alpha_bias)
+                adjusted_alpha = alpha * (1.0 - mix) + adjusted_alpha * mix
+
+            out = QColor()
+            out.setRgbF(
+                _clamp(adjusted[0]),
+                _clamp(adjusted[1]),
+                _clamp(adjusted[2]),
+                _clamp(adjusted_alpha),
+            )
+            image.setPixelColor(x, y, out)
+
+            modified_pixels += 1
+            before_alpha_sum += alpha
+            after_alpha_sum += adjusted_alpha
+            for index in range(3):
+                before_rgb_sum[index] += original[index]
+                after_rgb_sum[index] += adjusted[index]
+
+    output_directory = os.path.dirname(normalized_output_path)
+    if output_directory and not os.path.isdir(output_directory):
+        os.makedirs(output_directory)
+    if not image.save(normalized_output_path):
+        raise RuntimeError(f"Failed to save adjusted image: {output_path}")
+
+    inv = 1.0 / float(modified_pixels) if modified_pixels else 0.0
+    return {
+        "success": True,
+        "image_path": normalized_image_path,
+        "output_path": normalized_output_path,
+        "width": width,
+        "height": height,
+        "modified_pixels": modified_pixels,
+        "skipped_pixels": skipped_pixels,
+        "mask_mode": mask_mode,
+        "background_color": clean_background,
+        "alpha_threshold": alpha_threshold,
+        "luminance_range": clean_luminance_range,
+        "hue_range": clean_hue_range,
+        "saturation_range": clean_saturation_range,
+        "value_range": clean_value_range,
+        "channel_gain": channel_gain,
+        "channel_bias": channel_bias,
+        "gamma": gamma,
+        "brightness": brightness,
+        "contrast": contrast,
+        "saturation": saturation,
+        "value_gain": value_gain,
+        "alpha_gain": alpha_gain,
+        "alpha_bias": alpha_bias,
+        "preserve_alpha": preserve_alpha,
+        "mix": mix,
+        "mean_before_rgb": [value * inv for value in before_rgb_sum],
+        "mean_after_rgb": [value * inv for value in after_rgb_sum],
+        "mean_before_alpha": before_alpha_sum * inv,
+        "mean_after_alpha": after_alpha_sum * inv,
+    }

--- a/src/mayatools/material/assign_cylindrical_image_material.py
+++ b/src/mayatools/material/assign_cylindrical_image_material.py
@@ -1,0 +1,481 @@
+from typing import Dict, List, Any
+
+
+def assign_cylindrical_image_material(
+    object_name: str,
+    image_path: str,
+    name: str = None,
+    uv_set: str = "map1",
+    center: List[float] = [0.0, 0.0, 0.0],
+    axis: str = "y",
+    axis_range: List[float] = None,
+    angle_range_degrees: List[float] = [-60.0, 60.0],
+    outside_angle_mode: str = "ignore",
+    sample_channel: str = "alpha",
+    threshold: float = 0.05,
+    assign_above: bool = True,
+    face_sample_mode: str = "center",
+    sample_aggregation: str = "mean",
+    flip_u: bool = False,
+    flip_v: bool = False,
+    material_name: str = None,
+    material_type: str = "lambert",
+    color_attribute: str = "color",
+    use_alpha: bool = False,
+    link_uv_set: bool = True,
+    min_assign_faces: int = 1,
+    dry_run: bool = False,
+) -> Dict[str, Any]:
+    """Assign a textured material to mesh faces selected by cylindrical image sampling.
+
+    The tool writes deterministic cylindrical UVs to the mesh, links the file
+    texture to that UV set, samples an image in the same angle/axis space, and
+    assigns a texture material only to faces whose sampled channel crosses the
+    threshold. It is generic infrastructure for projection decals, labels,
+    panels, surface markings, trim masks, partial wraps, and photo-to-surface
+    workflows on bottles, cans, tubes, cups, and other near-lathed meshes
+    without relying on separate floating cards.
+    """
+    import math
+    import os
+    import maya.cmds as cmds
+
+    try:
+        from PySide6.QtGui import QImage
+    except Exception:
+        try:
+            from PySide2.QtGui import QImage
+        except Exception as exc:
+            raise RuntimeError("PySide QImage is required to sample image pixels in Maya.") from exc
+
+    try:
+        import maya.api.OpenMaya as om
+    except Exception as exc:
+        raise RuntimeError("maya.api.OpenMaya is required to edit mesh UVs.") from exc
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(value) for value in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(value) for value in values]
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return value
+
+    def _clamp(value, lower=0.0, upper=1.0):
+        return max(lower, min(upper, value))
+
+    def _positive_span(start_degrees, end_degrees):
+        span = (end_degrees - start_degrees) % 360.0
+        return 360.0 if abs(span) < 1e-8 else span
+
+    def _angle_delta(angle_degrees, start_degrees):
+        return (angle_degrees - start_degrees) % 360.0
+
+    def _angle_t(angle_degrees, start_degrees, span_degrees):
+        delta = _angle_delta(angle_degrees, start_degrees)
+        if span_degrees >= 360.0 - 1e-8:
+            return delta / 360.0
+        if delta <= span_degrees:
+            return delta / span_degrees
+        if outside_angle_mode == "ignore":
+            return None
+        if outside_angle_mode == "wrap":
+            return (delta / span_degrees) % 1.0
+        if outside_angle_mode == "clamp":
+            distance_to_start = min(delta, 360.0 - delta)
+            distance_to_end = abs(delta - span_degrees)
+            return 0.0 if distance_to_start < distance_to_end else 1.0
+        return delta / span_degrees
+
+    def _shape_dag_path(node_name):
+        selection = om.MSelectionList()
+        selection.add(node_name)
+        dag_path = selection.getDagPath(0)
+        if dag_path.node().hasFn(om.MFn.kTransform):
+            dag_path.extendToShape()
+        if not dag_path.node().hasFn(om.MFn.kMesh):
+            raise ValueError(f"{object_name} is not a polygon mesh transform or mesh shape.")
+        return dag_path
+
+    def _mesh_shape_name():
+        if cmds.objectType(object_name) == "mesh":
+            return object_name
+        shapes = cmds.listRelatives(object_name, shapes=True, fullPath=True) or []
+        for shape in shapes:
+            if cmds.objectType(shape) == "mesh":
+                return shape
+        raise ValueError(f"{object_name} is not a polygon mesh transform or mesh shape.")
+
+    def _uv_set_plug(shape_name, uv_set_name):
+        indices = cmds.getAttr(f"{shape_name}.uvSet", multiIndices=True) or []
+        for index in indices:
+            plug = f"{shape_name}.uvSet[{index}].uvSetName"
+            try:
+                if cmds.getAttr(plug) == uv_set_name:
+                    return plug
+            except Exception:
+                continue
+        uv_names = cmds.polyUVSet(object_name, query=True, allUVSets=True) or []
+        if uv_set_name in uv_names:
+            return f"{shape_name}.uvSet[{uv_names.index(uv_set_name)}].uvSetName"
+        return None
+
+    def _link_texture_to_uv_set(file_node_name):
+        if not link_uv_set:
+            return None, False
+        shape_name = _mesh_shape_name()
+        plug = _uv_set_plug(shape_name, uv_set)
+        if not plug:
+            raise ValueError(f"Unable to resolve UV set plug for {uv_set} on {object_name}.")
+        try:
+            cmds.uvLink(uvSet=plug, texture=file_node_name)
+        except Exception as exc:
+            if uv_set != "map1":
+                raise RuntimeError(f"Unable to link texture {file_node_name} to UV set {uv_set}.") from exc
+            return plug, False
+        return plug, True
+
+    def _pixel_rgb_alpha(image_value, x, y):
+        color = image_value.pixelColor(int(x), int(y))
+        return color.redF(), color.greenF(), color.blueF(), color.alphaF()
+
+    def _sample_bilinear(image_value, u, v):
+        width = image_value.width()
+        height = image_value.height()
+        u = _clamp(u)
+        v = _clamp(v)
+        x = u * float(width - 1)
+        y = (1.0 - v) * float(height - 1)
+        x0 = int(math.floor(x))
+        y0 = int(math.floor(y))
+        x1 = min(width - 1, x0 + 1)
+        y1 = min(height - 1, y0 + 1)
+        tx = x - x0
+        ty = y - y0
+        c00 = _pixel_rgb_alpha(image_value, x0, y0)
+        c10 = _pixel_rgb_alpha(image_value, x1, y0)
+        c01 = _pixel_rgb_alpha(image_value, x0, y1)
+        c11 = _pixel_rgb_alpha(image_value, x1, y1)
+        channels = []
+        for index in range(4):
+            top = c00[index] * (1.0 - tx) + c10[index] * tx
+            bottom = c01[index] * (1.0 - tx) + c11[index] * tx
+            channels.append(top * (1.0 - ty) + bottom * ty)
+        return channels
+
+    def _rgb_to_hsv(red, green, blue):
+        max_value = max(red, green, blue)
+        min_value = min(red, green, blue)
+        delta = max_value - min_value
+        if delta == 0.0:
+            hue = 0.0
+        elif max_value == red:
+            hue = ((green - blue) / delta) % 6.0
+        elif max_value == green:
+            hue = ((blue - red) / delta) + 2.0
+        else:
+            hue = ((red - green) / delta) + 4.0
+        hue /= 6.0
+        saturation = 0.0 if max_value == 0.0 else delta / max_value
+        return hue, saturation, max_value
+
+    def _channel_value(channels):
+        red, green, blue, alpha = channels
+        if sample_channel == "red":
+            return red
+        if sample_channel == "green":
+            return green
+        if sample_channel == "blue":
+            return blue
+        if sample_channel == "alpha":
+            return alpha
+        if sample_channel == "value":
+            return max(red, green, blue)
+        if sample_channel == "saturation":
+            return _rgb_to_hsv(red, green, blue)[1]
+        return 0.2126 * red + 0.7152 * green + 0.0722 * blue
+
+    def _aggregate(values):
+        if sample_aggregation == "min":
+            return min(values)
+        if sample_aggregation == "max":
+            return max(values)
+        return sum(values) / float(len(values))
+
+    def _project_point(point):
+        local_axis = point[axis_index] - center[axis_index]
+        delta_a = point[radial_a] - center[radial_a]
+        delta_b = point[radial_b] - center[radial_b]
+        angle_degrees = math.degrees(math.atan2(delta_a, delta_b))
+        u = _angle_t(angle_degrees, angle_start, angle_span)
+        if u is None:
+            return None
+        v = (local_axis - axis_start) / axis_span
+        if flip_u:
+            u = 1.0 - u
+        if flip_v:
+            v = 1.0 - v
+        return u, v
+
+    def _make_texture_material(shader_name):
+        shader = cmds.shadingNode(material_type, asShader=True, name=shader_name)
+        file_node = cmds.shadingNode("file", asTexture=True, name=f"{shader_name}_file")
+        place2d = cmds.shadingNode("place2dTexture", asUtility=True, name=f"{shader_name}_place2d")
+        for attr in ["outUV", "outUvFilterSize"]:
+            destination = "uvCoord" if attr == "outUV" else "uvFilterSize"
+            cmds.connectAttr(f"{place2d}.{attr}", f"{file_node}.{destination}", force=True)
+        for attr in [
+            "coverage",
+            "translateFrame",
+            "rotateFrame",
+            "mirrorU",
+            "mirrorV",
+            "stagger",
+            "wrapU",
+            "wrapV",
+            "repeatUV",
+            "offset",
+            "rotateUV",
+            "noiseUV",
+            "vertexUvOne",
+            "vertexUvTwo",
+            "vertexUvThree",
+            "vertexCameraOne",
+        ]:
+            if cmds.attributeQuery(attr, node=place2d, exists=True) and cmds.attributeQuery(attr, node=file_node, exists=True):
+                cmds.connectAttr(f"{place2d}.{attr}", f"{file_node}.{attr}", force=True)
+        cmds.setAttr(f"{file_node}.fileTextureName", normalized_image_path, type="string")
+        target_attribute = "outColor" if material_type == "surfaceShader" else color_attribute
+        if not cmds.attributeQuery(target_attribute, node=shader, exists=True):
+            raise ValueError(f"Shader {shader} does not have attribute {target_attribute}.")
+        cmds.connectAttr(f"{file_node}.outColor", f"{shader}.{target_attribute}", force=True)
+        alpha_node = None
+        if use_alpha and material_type != "surfaceShader" and cmds.attributeQuery("transparency", node=shader, exists=True):
+            alpha_node = cmds.shadingNode("reverse", asUtility=True, name=f"{shader_name}_alpha_reverse")
+            for channel in ["X", "Y", "Z"]:
+                cmds.connectAttr(f"{file_node}.outAlpha", f"{alpha_node}.input{channel}", force=True)
+            cmds.connectAttr(f"{alpha_node}.output", f"{shader}.transparency", force=True)
+        shading_group = cmds.sets(name=f"{shader_name}SG", empty=True, renderable=True, noSurfaceShader=True)
+        cmds.connectAttr(f"{shader}.outColor", f"{shading_group}.surfaceShader", force=True)
+        uv_link_plug, uv_linked = _link_texture_to_uv_set(file_node)
+        return shader, file_node, place2d, alpha_node, shading_group, uv_link_plug, uv_linked
+
+    if not object_name:
+        raise ValueError("object_name is required.")
+    if not cmds.objExists(object_name):
+        raise ValueError(f"Object does not exist: {object_name}")
+    if not image_path:
+        raise ValueError("image_path is required.")
+    normalized_image_path = os.path.normpath(image_path)
+    if not os.path.isfile(normalized_image_path):
+        raise ValueError(f"Image path does not exist: {image_path}")
+    if not uv_set:
+        raise ValueError("uv_set is required.")
+
+    center = _validate_vector(center, 3, "center")
+    if axis_range is not None:
+        axis_range = _validate_vector(axis_range, 2, "axis_range")
+    angle_range_degrees = _validate_vector(angle_range_degrees, 2, "angle_range_degrees")
+    threshold = _clamp(_validate_scalar(threshold, "threshold"))
+    min_assign_faces = _validate_int(min_assign_faces, "min_assign_faces", 0)
+
+    axis = axis.lower().strip()
+    axes = {
+        "x": (0, 1, 2),
+        "y": (1, 0, 2),
+        "z": (2, 0, 1),
+    }
+    if axis not in axes:
+        raise ValueError("axis must be one of x, y, or z.")
+    axis_index, radial_a, radial_b = axes[axis]
+
+    outside_angle_mode = outside_angle_mode.lower().strip()
+    if outside_angle_mode not in {"ignore", "wrap", "clamp", "extend"}:
+        raise ValueError("outside_angle_mode must be ignore, wrap, clamp, or extend.")
+    sample_channel = sample_channel.lower().strip()
+    if sample_channel not in {"alpha", "luminance", "red", "green", "blue", "value", "saturation"}:
+        raise ValueError("sample_channel must be one of alpha, luminance, red, green, blue, value, or saturation.")
+    face_sample_mode = face_sample_mode.lower().strip()
+    if face_sample_mode not in {"center", "vertices", "center_vertices"}:
+        raise ValueError("face_sample_mode must be center, vertices, or center_vertices.")
+    sample_aggregation = sample_aggregation.lower().strip()
+    if sample_aggregation not in {"mean", "min", "max"}:
+        raise ValueError("sample_aggregation must be mean, min, or max.")
+    material_type = material_type.strip()
+    if material_type not in {"lambert", "phong", "blinn", "surfaceShader"}:
+        raise ValueError("material_type must be lambert, phong, blinn, or surfaceShader.")
+
+    image = QImage(normalized_image_path)
+    if image.isNull():
+        raise ValueError(f"Unable to load image: {image_path}")
+    if image.width() < 2 or image.height() < 2:
+        raise ValueError("image must be at least 2x2 pixels.")
+
+    dag_path = _shape_dag_path(object_name)
+    mesh_fn = om.MFnMesh(dag_path)
+    uv_sets = list(mesh_fn.getUVSetNames())
+    if uv_set not in uv_sets:
+        mesh_fn.createUVSet(uv_set)
+    try:
+        mesh_fn.setCurrentUVSetName(uv_set)
+    except Exception:
+        cmds.polyUVSet(object_name, currentUVSet=True, uvSet=uv_set)
+
+    points = mesh_fn.getPoints(om.MSpace.kWorld)
+    face_counts, vertex_ids = mesh_fn.getVertices()
+    if not face_counts:
+        raise ValueError(f"No polygon faces found on {object_name}.")
+
+    if axis_range is None:
+        axis_values = [point[axis_index] - center[axis_index] for point in points]
+        axis_start = min(axis_values)
+        axis_end = max(axis_values)
+    else:
+        axis_start, axis_end = axis_range
+        if axis_start > axis_end:
+            axis_start, axis_end = axis_end, axis_start
+    axis_span = axis_end - axis_start
+    if axis_span <= 1e-12:
+        raise ValueError("axis_range must cover a positive span.")
+
+    angle_start, angle_end = angle_range_degrees
+    angle_span = _positive_span(angle_start, angle_end)
+
+    u_values = []
+    v_values = []
+    uv_ids = []
+    matched_faces = []
+    skipped_outside_faces = 0
+    sample_values = []
+    cursor = 0
+
+    for face_index, count in enumerate(face_counts):
+        projected_vertices = []
+        positions = []
+        for _ in range(count):
+            vertex_id = vertex_ids[cursor]
+            point = points[vertex_id]
+            positions.append(point)
+            projected = _project_point(point)
+            if projected is None:
+                if outside_angle_mode == "ignore":
+                    projected = (0.0, (point[axis_index] - center[axis_index] - axis_start) / axis_span)
+                else:
+                    projected = (0.0, 0.0)
+            u_values.append(float(projected[0]))
+            v_values.append(float(projected[1]))
+            uv_ids.append(len(u_values) - 1)
+            projected_vertices.append(projected)
+            cursor += 1
+
+        center_point = om.MPoint()
+        for point in positions:
+            center_point += point
+        center_point = center_point / float(len(positions))
+
+        sample_uvs = []
+        if face_sample_mode in {"center", "center_vertices"}:
+            center_projected = _project_point(center_point)
+            if center_projected is not None:
+                sample_uvs.append(center_projected)
+        if face_sample_mode in {"vertices", "center_vertices"}:
+            sample_uvs.extend([
+                projected
+                for projected in (_project_point(point) for point in positions)
+                if projected is not None
+            ])
+
+        if not sample_uvs:
+            skipped_outside_faces += 1
+            continue
+        values = [_channel_value(_sample_bilinear(image, uv[0], uv[1])) for uv in sample_uvs]
+        value = _aggregate(values)
+        sample_values.append(value)
+        matched = value >= threshold if assign_above else value <= threshold
+        if matched:
+            matched_faces.append(face_index)
+
+    try:
+        mesh_fn.clearUVs(uv_set)
+    except Exception:
+        pass
+    mesh_fn.setUVs(u_values, v_values, uv_set)
+    mesh_fn.assignUVs(face_counts, uv_ids, uv_set)
+    mesh_fn.updateSurface()
+    try:
+        cmds.polyUVSet(object_name, currentUVSet=True, uvSet=uv_set)
+    except Exception:
+        pass
+
+    if len(matched_faces) < min_assign_faces:
+        raise ValueError(f"Only {len(matched_faces)} faces matched, below min_assign_faces={min_assign_faces}.")
+
+    shader = None
+    file_node = None
+    place2d = None
+    alpha_node = None
+    shading_group = None
+    uv_link_plug = None
+    uv_linked = False
+    assigned_components = []
+    if matched_faces and not dry_run:
+        if material_name is None:
+            base_name = os.path.splitext(os.path.basename(normalized_image_path))[0] or "projected"
+            material_name = name or f"{base_name}_cylindrical_projected_mat"
+        shader, file_node, place2d, alpha_node, shading_group, uv_link_plug, uv_linked = _make_texture_material(material_name)
+        for start in range(0, len(matched_faces), 1000):
+            batch = matched_faces[start:start + 1000]
+            components = [f"{object_name}.f[{face_index}]" for face_index in batch]
+            cmds.sets(components, edit=True, forceElement=shading_group)
+            assigned_components.extend(components)
+
+    return {
+        "success": True,
+        "object_name": object_name,
+        "image_path": normalized_image_path,
+        "image_width": image.width(),
+        "image_height": image.height(),
+        "uv_set": uv_set,
+        "center": center,
+        "axis": axis,
+        "axis_range": [axis_start, axis_end],
+        "angle_range_degrees": angle_range_degrees,
+        "angle_span_degrees": angle_span,
+        "outside_angle_mode": outside_angle_mode,
+        "sample_channel": sample_channel,
+        "threshold": threshold,
+        "assign_above": bool(assign_above),
+        "face_sample_mode": face_sample_mode,
+        "sample_aggregation": sample_aggregation,
+        "flip_u": bool(flip_u),
+        "flip_v": bool(flip_v),
+        "link_uv_set": bool(link_uv_set),
+        "dry_run": bool(dry_run),
+        "face_count": len(face_counts),
+        "uv_count": len(u_values),
+        "sampled_face_count": len(sample_values),
+        "skipped_outside_face_count": skipped_outside_faces,
+        "matched_face_count": len(matched_faces),
+        "assigned_face_count": 0 if dry_run else len(assigned_components),
+        "min_sample_value": min(sample_values) if sample_values else 0.0,
+        "max_sample_value": max(sample_values) if sample_values else 0.0,
+        "mean_sample_value": sum(sample_values) / float(len(sample_values)) if sample_values else 0.0,
+        "material": shader,
+        "file_node": file_node,
+        "place2d": place2d,
+        "alpha_node": alpha_node,
+        "shading_group": shading_group,
+        "uv_link_plug": uv_link_plug,
+        "uv_linked": bool(uv_linked),
+        "matched_faces_preview": matched_faces[:20],
+    }

--- a/src/mayatools/material/assign_cylindrical_image_material.py
+++ b/src/mayatools/material/assign_cylindrical_image_material.py
@@ -10,6 +10,7 @@ def assign_cylindrical_image_material(
     axis: str = "y",
     axis_range: List[float] = None,
     angle_range_degrees: List[float] = [-60.0, 60.0],
+    outside_axis_mode: str = "extend",
     outside_angle_mode: str = "ignore",
     sample_channel: str = "alpha",
     threshold: float = 0.05,
@@ -35,6 +36,10 @@ def assign_cylindrical_image_material(
     panels, surface markings, trim masks, partial wraps, and photo-to-surface
     workflows on bottles, cans, tubes, cups, and other near-lathed meshes
     without relying on separate floating cards.
+
+    outside_axis_mode controls how samples beyond axis_range are handled:
+    "extend" preserves unclamped coordinates, "clamp" pins them to the nearest
+    edge, and "ignore" excludes out-of-range faces from material assignment.
     """
     import math
     import os
@@ -96,6 +101,16 @@ def assign_cylindrical_image_material(
             distance_to_end = abs(delta - span_degrees)
             return 0.0 if distance_to_start < distance_to_end else 1.0
         return delta / span_degrees
+
+    def _axis_t(local_axis, axis_start, axis_span):
+        value = (local_axis - axis_start) / axis_span
+        if 0.0 <= value <= 1.0:
+            return value
+        if outside_axis_mode == "ignore":
+            return None
+        if outside_axis_mode == "clamp":
+            return _clamp(value)
+        return value
 
     def _shape_dag_path(node_name):
         selection = om.MSelectionList()
@@ -220,7 +235,9 @@ def assign_cylindrical_image_material(
         u = _angle_t(angle_degrees, angle_start, angle_span)
         if u is None:
             return None
-        v = (local_axis - axis_start) / axis_span
+        v = _axis_t(local_axis, axis_start, axis_span)
+        if v is None:
+            return None
         if flip_u:
             u = 1.0 - u
         if flip_v:
@@ -302,6 +319,9 @@ def assign_cylindrical_image_material(
     outside_angle_mode = outside_angle_mode.lower().strip()
     if outside_angle_mode not in {"ignore", "wrap", "clamp", "extend"}:
         raise ValueError("outside_angle_mode must be ignore, wrap, clamp, or extend.")
+    outside_axis_mode = outside_axis_mode.lower().strip()
+    if outside_axis_mode not in {"ignore", "clamp", "extend"}:
+        raise ValueError("outside_axis_mode must be ignore, clamp, or extend.")
     sample_channel = sample_channel.lower().strip()
     if sample_channel not in {"alpha", "luminance", "red", "green", "blue", "value", "saturation"}:
         raise ValueError("sample_channel must be one of alpha, luminance, red, green, blue, value, or saturation.")
@@ -451,6 +471,7 @@ def assign_cylindrical_image_material(
         "axis_range": [axis_start, axis_end],
         "angle_range_degrees": angle_range_degrees,
         "angle_span_degrees": angle_span,
+        "outside_axis_mode": outside_axis_mode,
         "outside_angle_mode": outside_angle_mode,
         "sample_channel": sample_channel,
         "threshold": threshold,

--- a/src/mayatools/material/assign_cylindrical_image_material.py
+++ b/src/mayatools/material/assign_cylindrical_image_material.py
@@ -23,6 +23,7 @@ def assign_cylindrical_image_material(
     material_type: str = "lambert",
     color_attribute: str = "color",
     use_alpha: bool = False,
+    opacity: float = 1.0,
     link_uv_set: bool = True,
     min_assign_faces: int = 1,
     dry_run: bool = False,
@@ -35,7 +36,9 @@ def assign_cylindrical_image_material(
     threshold. It is generic infrastructure for projection decals, labels,
     panels, surface markings, trim masks, partial wraps, and photo-to-surface
     workflows on bottles, cans, tubes, cups, and other near-lathed meshes
-    without relying on separate floating cards.
+    without relying on separate floating cards. opacity controls the material's
+    overall visibility; when use_alpha is enabled it multiplies the texture
+    alpha before driving transparency.
 
     outside_axis_mode controls how samples beyond axis_range are handled:
     "extend" preserves unclamped coordinates, "clamp" pins them to the nearest
@@ -277,15 +280,26 @@ def assign_cylindrical_image_material(
             raise ValueError(f"Shader {shader} does not have attribute {target_attribute}.")
         cmds.connectAttr(f"{file_node}.outColor", f"{shader}.{target_attribute}", force=True)
         alpha_node = None
+        alpha_opacity_node = None
         if use_alpha and material_type != "surfaceShader" and cmds.attributeQuery("transparency", node=shader, exists=True):
+            alpha_source = f"{file_node}.outAlpha"
+            if opacity < 1.0:
+                alpha_opacity_node = cmds.shadingNode("multiplyDivide", asUtility=True, name=f"{shader_name}_alpha_opacity")
+                cmds.setAttr(f"{alpha_opacity_node}.input2", opacity, opacity, opacity, type="double3")
+                for channel in ["X", "Y", "Z"]:
+                    cmds.connectAttr(alpha_source, f"{alpha_opacity_node}.input1{channel}", force=True)
+                alpha_source = f"{alpha_opacity_node}.outputX"
             alpha_node = cmds.shadingNode("reverse", asUtility=True, name=f"{shader_name}_alpha_reverse")
             for channel in ["X", "Y", "Z"]:
-                cmds.connectAttr(f"{file_node}.outAlpha", f"{alpha_node}.input{channel}", force=True)
+                cmds.connectAttr(alpha_source, f"{alpha_node}.input{channel}", force=True)
             cmds.connectAttr(f"{alpha_node}.output", f"{shader}.transparency", force=True)
+        elif opacity < 1.0 and material_type != "surfaceShader" and cmds.attributeQuery("transparency", node=shader, exists=True):
+            transparency = 1.0 - opacity
+            cmds.setAttr(f"{shader}.transparency", transparency, transparency, transparency, type="double3")
         shading_group = cmds.sets(name=f"{shader_name}SG", empty=True, renderable=True, noSurfaceShader=True)
         cmds.connectAttr(f"{shader}.outColor", f"{shading_group}.surfaceShader", force=True)
         uv_link_plug, uv_linked = _link_texture_to_uv_set(file_node)
-        return shader, file_node, place2d, alpha_node, shading_group, uv_link_plug, uv_linked
+        return shader, file_node, place2d, alpha_node, alpha_opacity_node, shading_group, uv_link_plug, uv_linked
 
     if not object_name:
         raise ValueError("object_name is required.")
@@ -304,6 +318,7 @@ def assign_cylindrical_image_material(
         axis_range = _validate_vector(axis_range, 2, "axis_range")
     angle_range_degrees = _validate_vector(angle_range_degrees, 2, "angle_range_degrees")
     threshold = _clamp(_validate_scalar(threshold, "threshold"))
+    opacity = _clamp(_validate_scalar(opacity, "opacity"))
     min_assign_faces = _validate_int(min_assign_faces, "min_assign_faces", 0)
 
     axis = axis.lower().strip()
@@ -444,6 +459,7 @@ def assign_cylindrical_image_material(
     file_node = None
     place2d = None
     alpha_node = None
+    alpha_opacity_node = None
     shading_group = None
     uv_link_plug = None
     uv_linked = False
@@ -452,7 +468,7 @@ def assign_cylindrical_image_material(
         if material_name is None:
             base_name = os.path.splitext(os.path.basename(normalized_image_path))[0] or "projected"
             material_name = name or f"{base_name}_cylindrical_projected_mat"
-        shader, file_node, place2d, alpha_node, shading_group, uv_link_plug, uv_linked = _make_texture_material(material_name)
+        shader, file_node, place2d, alpha_node, alpha_opacity_node, shading_group, uv_link_plug, uv_linked = _make_texture_material(material_name)
         for start in range(0, len(matched_faces), 1000):
             batch = matched_faces[start:start + 1000]
             components = [f"{object_name}.f[{face_index}]" for face_index in batch]
@@ -480,6 +496,7 @@ def assign_cylindrical_image_material(
         "sample_aggregation": sample_aggregation,
         "flip_u": bool(flip_u),
         "flip_v": bool(flip_v),
+        "opacity": opacity,
         "link_uv_set": bool(link_uv_set),
         "dry_run": bool(dry_run),
         "face_count": len(face_counts),
@@ -495,6 +512,7 @@ def assign_cylindrical_image_material(
         "file_node": file_node,
         "place2d": place2d,
         "alpha_node": alpha_node,
+        "alpha_opacity_node": alpha_opacity_node,
         "shading_group": shading_group,
         "uv_link_plug": uv_link_plug,
         "uv_linked": bool(uv_linked),

--- a/src/mayatools/material/assign_materials_by_uv_image.py
+++ b/src/mayatools/material/assign_materials_by_uv_image.py
@@ -1,0 +1,435 @@
+from typing import Dict, List, Any
+
+
+def assign_materials_by_uv_image(
+    object_name: str,
+    image_path: str,
+    material_rules: List[Dict[str, Any]],
+    uv_set: str = None,
+    match_mode: str = "nearest",
+    unmatched_mode: str = "skip",
+    default_rule_index: int = None,
+    face_sample_mode: str = "center",
+    sample_aggregation: str = "mean",
+    flip_v: bool = True,
+    wrap_u: bool = False,
+    wrap_v: bool = False,
+    create_if_missing: bool = True,
+    dry_run: bool = False,
+    select_result: bool = False,
+    max_preview: int = 50,
+) -> Dict[str, Any]:
+    """Assign mesh faces to materials by sampling an image through existing UVs.
+
+    This is a generic UV/material workflow tool for Maya-style face-level work:
+    labels, decals, low-poly texture previews, color-ID masks, surface panels,
+    and viewport-stable material bakes. It does not create or reshape geometry.
+    It reads each face's UVs, samples image color, classifies the face against
+    user-provided material rules, and assigns the matched faces to shading
+    groups.
+
+    material_rules entries support:
+    - name: optional rule label
+    - target_color: RGB list in 0..1 or 0..255 space
+    - tolerance: color distance for tolerance modes
+    - material_name: material to use or create
+    - shading_group_name: shading group to use or create
+    - material_type: lambert, blinn, phong, surface_shader, ai_standard_surface
+    - material_color: RGB material color, defaults to target_color
+    - material_parameters: optional shader attributes to set on creation
+
+    match_mode:
+    - nearest: assign every sampled face to the nearest target color
+    - tolerance: assign to the first rule whose color distance is within tolerance
+    - nearest_with_tolerance: assign to nearest rule only if within tolerance
+
+    unmatched_mode controls faces not matched by tolerance modes: skip, error,
+    or default. default_rule_index is used only when unmatched_mode is default.
+    """
+    import math
+    import os
+    import re
+    import maya.cmds as cmds
+
+    try:
+        from PySide6.QtGui import QImage
+    except Exception:
+        try:
+            from PySide2.QtGui import QImage
+        except Exception as exc:
+            raise RuntimeError("PySide QImage is required to sample image pixels in Maya.") from exc
+
+    try:
+        import maya.api.OpenMaya as om
+    except Exception as exc:
+        raise RuntimeError("maya.api.OpenMaya is required to inspect mesh UVs.") from exc
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return int(value)
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(item) for item in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(item) for item in values]
+
+    def _clamp(value, lower=0.0, upper=1.0):
+        return max(lower, min(upper, value))
+
+    def _normalize_color(values, arg_name):
+        color = _validate_vector(values, 3, arg_name)
+        if max(color) > 1.0:
+            color = [item / 255.0 for item in color]
+        return [_clamp(item) for item in color]
+
+    def _normalize_tolerance(value):
+        tolerance = _validate_scalar(value, "tolerance")
+        if tolerance > 1.0:
+            tolerance /= 255.0
+        if tolerance < 0.0:
+            raise ValueError("tolerance values must be greater than or equal to zero.")
+        return tolerance
+
+    def _safe_name(value, fallback):
+        text = str(value or fallback).strip()
+        text = re.sub(r"[^A-Za-z0-9_]+", "_", text)
+        text = text.strip("_")
+        return text or fallback
+
+    def _mesh_shape(node):
+        if not cmds.objExists(node):
+            raise ValueError(f"Object does not exist: {node}")
+        if cmds.objectType(node) == "mesh":
+            return node
+        shapes = cmds.listRelatives(node, shapes=True, fullPath=True) or []
+        mesh_shapes = []
+        for shape in shapes:
+            if cmds.objectType(shape) != "mesh":
+                continue
+            try:
+                if cmds.attributeQuery("intermediateObject", node=shape, exists=True) and cmds.getAttr(f"{shape}.intermediateObject"):
+                    continue
+            except Exception:
+                pass
+            mesh_shapes.append(shape)
+        if not mesh_shapes:
+            raise ValueError(f"{node} is not a polygon mesh transform or mesh shape.")
+        return mesh_shapes[0]
+
+    def _prefix(shape):
+        parents = cmds.listRelatives(shape, parent=True, fullPath=False) or []
+        return parents[0] if parents else object_name
+
+    def _mesh_fn(shape):
+        selection = om.MSelectionList()
+        selection.add(shape)
+        return om.MFnMesh(selection.getDagPath(0))
+
+    def _wrap_or_clamp(value, wrap):
+        return value % 1.0 if wrap else _clamp(value)
+
+    def _pixel_rgb_alpha(image_value, x, y):
+        color = image_value.pixelColor(int(x), int(y))
+        return color.redF(), color.greenF(), color.blueF(), color.alphaF()
+
+    def _sample_bilinear(image_value, u_value, v_value):
+        width = image_value.width()
+        height = image_value.height()
+        u_value = _wrap_or_clamp(u_value, wrap_u)
+        v_value = _wrap_or_clamp(v_value, wrap_v)
+        if flip_v:
+            v_value = 1.0 - v_value
+        x = u_value * float(width - 1)
+        y = v_value * float(height - 1)
+        x0 = int(math.floor(x))
+        y0 = int(math.floor(y))
+        x1 = min(width - 1, x0 + 1)
+        y1 = min(height - 1, y0 + 1)
+        tx = x - x0
+        ty = y - y0
+        c00 = _pixel_rgb_alpha(image_value, x0, y0)
+        c10 = _pixel_rgb_alpha(image_value, x1, y0)
+        c01 = _pixel_rgb_alpha(image_value, x0, y1)
+        c11 = _pixel_rgb_alpha(image_value, x1, y1)
+        result = []
+        for index in range(4):
+            top = c00[index] * (1.0 - tx) + c10[index] * tx
+            bottom = c01[index] * (1.0 - tx) + c11[index] * tx
+            result.append(top * (1.0 - ty) + bottom * ty)
+        return result
+
+    def _mean_uv(pairs):
+        return (
+            sum(pair[0] for pair in pairs) / float(len(pairs)),
+            sum(pair[1] for pair in pairs) / float(len(pairs)),
+        )
+
+    def _face_uv_samples(face_id):
+        vertices = mesh_fn.getPolygonVertices(face_id)
+        pairs = []
+        for local_index in range(len(vertices)):
+            try:
+                uv_id = mesh_fn.getPolygonUVid(face_id, local_index, active_uv_set)
+                u_value, v_value = mesh_fn.getUV(uv_id, active_uv_set)
+                pairs.append((float(u_value), float(v_value)))
+            except Exception:
+                pass
+        if not pairs:
+            return []
+        center = _mean_uv(pairs)
+        if face_sample_mode == "center":
+            return [center]
+        if face_sample_mode == "vertices":
+            return pairs
+        return [center] + pairs
+
+    def _aggregate_colors(colors):
+        if not colors:
+            return None
+        if sample_aggregation == "mean":
+            return [sum(color[index] for color in colors) / float(len(colors)) for index in range(4)]
+        if sample_aggregation == "min":
+            return [min(color[index] for color in colors) for index in range(4)]
+        return [max(color[index] for color in colors) for index in range(4)]
+
+    def _distance(color_a, color_b):
+        dr = color_a[0] - color_b[0]
+        dg = color_a[1] - color_b[1]
+        db = color_a[2] - color_b[2]
+        return (dr * dr + dg * dg + db * db) ** 0.5
+
+    def _set_attr_if_exists(node, attr, value):
+        if not cmds.attributeQuery(attr, node=node, exists=True):
+            return False
+        if isinstance(value, list) and len(value) == 3 and all(_is_number(item) for item in value):
+            attr_type = cmds.getAttr(f"{node}.{attr}", type=True)
+            if attr_type in {"double3", "float3"}:
+                cmds.setAttr(f"{node}.{attr}", float(value[0]), float(value[1]), float(value[2]), type=attr_type)
+            else:
+                cmds.setAttr(f"{node}.{attr}", float(value[0]), float(value[1]), float(value[2]))
+        else:
+            cmds.setAttr(f"{node}.{attr}", value)
+        return True
+
+    def _create_material(shader_name, sg_name, rule):
+        shader_type = str(rule.get("material_type", "lambert") or "lambert").strip().lower()
+        type_map = {
+            "lambert": "lambert",
+            "blinn": "blinn",
+            "phong": "phong",
+            "surface_shader": "surfaceShader",
+            "surfaceshader": "surfaceShader",
+            "ai_standard_surface": "aiStandardSurface",
+            "aistandardsurface": "aiStandardSurface",
+        }
+        if shader_type not in type_map:
+            raise ValueError("material_type must be lambert, blinn, phong, surface_shader, or ai_standard_surface.")
+        node_type = type_map[shader_type]
+        shader = cmds.shadingNode(node_type, asShader=True, name=shader_name)
+        material_color = rule.get("material_color", rule["target_color"])
+        color = _normalize_color(material_color, "material_color")
+        if not _set_attr_if_exists(shader, "color", color):
+            _set_attr_if_exists(shader, "baseColor", color)
+        if node_type == "aiStandardSurface":
+            _set_attr_if_exists(shader, "base", 1.0)
+        for attr, value in (rule.get("material_parameters") or {}).items():
+            _set_attr_if_exists(shader, attr, value)
+        shading_group = cmds.sets(name=sg_name, empty=True, renderable=True, noSurfaceShader=True)
+        output_attr = "outColor" if cmds.attributeQuery("outColor", node=shader, exists=True) else "outValue"
+        cmds.connectAttr(f"{shader}.{output_attr}", f"{shading_group}.surfaceShader", force=True)
+        return shader, shading_group, True
+
+    def _material_to_shading_group(shader, sg_name):
+        groups = cmds.listConnections(shader, type="shadingEngine") or []
+        if groups:
+            return groups[0], False
+        shading_group = cmds.sets(name=sg_name, empty=True, renderable=True, noSurfaceShader=True)
+        output_attr = "outColor" if cmds.attributeQuery("outColor", node=shader, exists=True) else "outValue"
+        cmds.connectAttr(f"{shader}.{output_attr}", f"{shading_group}.surfaceShader", force=True)
+        return shading_group, True
+
+    def _resolve_rule_material(rule, index):
+        if dry_run:
+            planned_name = rule.get("shading_group_name") or f"{rule['material_name']}SG"
+            return rule["material_name"], planned_name, False
+        sg_name = rule.get("shading_group_name")
+        if sg_name and cmds.objExists(sg_name):
+            if cmds.objectType(sg_name) != "shadingEngine":
+                raise ValueError(f"{sg_name} is not a shadingEngine.")
+            return None, sg_name, False
+        material_name = rule["material_name"]
+        if cmds.objExists(material_name):
+            sg, created_sg = _material_to_shading_group(material_name, sg_name or f"{material_name}SG")
+            return material_name, sg, created_sg
+        if not create_if_missing:
+            raise ValueError(f"Material does not exist: {material_name}")
+        shader, sg, created = _create_material(material_name, sg_name or f"{material_name}SG", rule)
+        return shader, sg, created
+
+    def _prepare_rules():
+        if not isinstance(material_rules, list) or not material_rules:
+            raise ValueError("material_rules must be a non-empty list.")
+        prepared = []
+        for index, rule in enumerate(material_rules):
+            if not isinstance(rule, dict):
+                raise ValueError("Each material_rules entry must be a dictionary.")
+            if "target_color" not in rule:
+                raise ValueError("Each material_rules entry requires target_color.")
+            name = _safe_name(rule.get("name"), f"rule_{index}")
+            target_color = _normalize_color(rule.get("target_color"), f"material_rules[{index}].target_color")
+            clean_rule = dict(rule)
+            clean_rule["index"] = index
+            clean_rule["name"] = name
+            clean_rule["target_color"] = target_color
+            clean_rule["tolerance"] = _normalize_tolerance(rule.get("tolerance", 0.12))
+            clean_rule["material_name"] = rule.get("material_name") or f"{_safe_name(object_name, 'mesh')}_{name}_mat"
+            prepared.append(clean_rule)
+        return prepared
+
+    def _match_rule(color):
+        distances = [(_distance(color, rule["target_color"]), rule) for rule in rules]
+        distances.sort(key=lambda item: (item[0], item[1]["index"]))
+        nearest_distance, nearest_rule = distances[0]
+        if match_mode == "nearest":
+            return nearest_rule, nearest_distance
+        if match_mode == "nearest_with_tolerance":
+            return (nearest_rule, nearest_distance) if nearest_distance <= nearest_rule["tolerance"] else (None, nearest_distance)
+        for rule in rules:
+            distance = _distance(color, rule["target_color"])
+            if distance <= rule["tolerance"]:
+                return rule, distance
+        return None, nearest_distance
+
+    def _assign_components(components, shading_group):
+        if dry_run or not components:
+            return
+        for start in range(0, len(components), 5000):
+            cmds.sets(components[start:start + 5000], edit=True, forceElement=shading_group)
+
+    if not object_name:
+        raise ValueError("object_name is required.")
+    if not image_path:
+        raise ValueError("image_path is required.")
+    normalized_image_path = os.path.normpath(image_path)
+    if not os.path.isfile(normalized_image_path):
+        raise ValueError(f"Image path does not exist: {image_path}")
+    match_mode = match_mode.lower().strip()
+    if match_mode not in {"nearest", "tolerance", "nearest_with_tolerance"}:
+        raise ValueError("match_mode must be nearest, tolerance, or nearest_with_tolerance.")
+    unmatched_mode = unmatched_mode.lower().strip()
+    if unmatched_mode not in {"skip", "error", "default"}:
+        raise ValueError("unmatched_mode must be skip, error, or default.")
+    face_sample_mode = face_sample_mode.lower().strip()
+    if face_sample_mode not in {"center", "vertices", "center_vertices"}:
+        raise ValueError("face_sample_mode must be center, vertices, or center_vertices.")
+    sample_aggregation = sample_aggregation.lower().strip()
+    if sample_aggregation not in {"mean", "min", "max"}:
+        raise ValueError("sample_aggregation must be mean, min, or max.")
+    max_preview = _validate_int(max_preview, "max_preview", 1)
+
+    rules = _prepare_rules()
+    if default_rule_index is not None:
+        default_rule_index = _validate_int(default_rule_index, "default_rule_index", 0)
+        if default_rule_index >= len(rules):
+            raise ValueError(f"default_rule_index must be in range 0..{len(rules) - 1}.")
+    elif unmatched_mode == "default":
+        raise ValueError("default_rule_index is required when unmatched_mode is default.")
+
+    image = QImage(normalized_image_path)
+    if image.isNull():
+        raise ValueError(f"Unable to load image: {image_path}")
+    if image.width() < 2 or image.height() < 2:
+        raise ValueError("image must be at least 2x2 pixels.")
+
+    shape_name = _mesh_shape(object_name)
+    prefix_name = _prefix(shape_name)
+    mesh_fn = _mesh_fn(shape_name)
+    uv_sets = list(mesh_fn.getUVSetNames())
+    active_uv_set = uv_set or (mesh_fn.currentUVSetName() if uv_sets else None)
+    if not active_uv_set or active_uv_set not in uv_sets:
+        raise ValueError(f"UV set does not exist on {object_name}: {active_uv_set}")
+    if mesh_fn.numUVs(active_uv_set) <= 0:
+        raise ValueError(f"UV set has no UVs: {active_uv_set}")
+
+    rule_components = {rule["index"]: [] for rule in rules}
+    rule_records = {rule["index"]: [] for rule in rules}
+    unmatched = []
+    sampled_count = 0
+
+    for face_id in range(int(mesh_fn.numPolygons)):
+        samples = _face_uv_samples(face_id)
+        if not samples:
+            unmatched.append({"face": face_id, "reason": "missing_uv"})
+            continue
+        colors = [_sample_bilinear(image, sample[0], sample[1]) for sample in samples]
+        color = _aggregate_colors(colors)
+        sampled_count += 1
+        rule, distance = _match_rule(color)
+        if rule is None:
+            if unmatched_mode == "error":
+                raise ValueError(f"Face {face_id} did not match any material rule.")
+            if unmatched_mode == "default":
+                rule = rules[default_rule_index]
+            else:
+                unmatched.append({"face": face_id, "reason": "no_match", "sample_color": color[:3], "nearest_distance": distance})
+                continue
+        component = f"{prefix_name}.f[{face_id}]"
+        rule_components[rule["index"]].append(component)
+        if len(rule_records[rule["index"]]) < max_preview:
+            rule_records[rule["index"]].append({
+                "face": face_id,
+                "component": component,
+                "sample_color": color[:3],
+                "distance": distance,
+            })
+
+    resolved_materials = {}
+    assignments = []
+    assigned_components = []
+    for rule in rules:
+        components = rule_components[rule["index"]]
+        material_name, shading_group, created = _resolve_rule_material(rule, rule["index"])
+        _assign_components(components, shading_group)
+        assigned_components.extend(components)
+        resolved_materials[rule["index"]] = {"material": material_name, "shading_group": shading_group}
+        assignments.append({
+            "rule_index": rule["index"],
+            "rule_name": rule["name"],
+            "target_color": rule["target_color"],
+            "tolerance": rule["tolerance"],
+            "material_name": material_name,
+            "shading_group_name": shading_group,
+            "created_material_or_shading_group": bool(created),
+            "face_count": len(components),
+            "faces_preview": rule_records[rule["index"]],
+        })
+
+    if select_result and assigned_components and not dry_run:
+        cmds.select(assigned_components, replace=True)
+
+    return {
+        "success": True,
+        "object_name": object_name,
+        "shape_name": shape_name,
+        "image_path": normalized_image_path,
+        "uv_set": active_uv_set,
+        "match_mode": match_mode,
+        "unmatched_mode": unmatched_mode,
+        "face_sample_mode": face_sample_mode,
+        "sample_aggregation": sample_aggregation,
+        "dry_run": dry_run,
+        "sampled_face_count": sampled_count,
+        "assigned_face_count": sum(item["face_count"] for item in assignments),
+        "unmatched_face_count": len(unmatched),
+        "unmatched_preview": unmatched[:max_preview],
+        "assignments": assignments,
+    }

--- a/src/mayatools/material/assign_mesh_region_material.py
+++ b/src/mayatools/material/assign_mesh_region_material.py
@@ -1,0 +1,221 @@
+from typing import Dict, List, Any
+
+
+def assign_mesh_region_material(
+    object_name: str,
+    material_name: str = None,
+    shading_group_name: str = None,
+    material_type: str = "phong",
+    material_color: List[float] = None,
+    material_parameters: Dict[str, Any] = None,
+    center: List[float] = [0.0, 0.0, 0.0],
+    axis: str = "y",
+    axis_range: List[float] = None,
+    angle_range_degrees: List[float] = None,
+    radial_range: List[float] = None,
+    include_partial_faces: bool = False,
+    invert: bool = False,
+    preview_only: bool = False,
+) -> Dict[str, Any]:
+    """Assign a material to mesh faces selected by cylindrical/axial bounds.
+
+    Faces are selected by testing their center, or optionally any vertex, against
+    an axis range, angular range around a center, and/or radial range. This is
+    generic infrastructure for local material overrides on lathed or cylindrical
+    assets: bottle shoulders, lower bands, caps, panel zones, grip areas, trim,
+    inserts, or any mesh region that should be material-tuned without replacing
+    the whole object or relying on image masks.
+    """
+    import math
+    import maya.cmds as cmds
+
+    try:
+        import maya.api.OpenMaya as om
+    except Exception as exc:
+        raise RuntimeError("maya.api.OpenMaya is required to inspect mesh faces.") from exc
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(value) for value in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(value) for value in values]
+
+    def _validate_range(values, arg_name):
+        clean = _validate_vector(values, 2, arg_name)
+        if clean[0] > clean[1]:
+            clean = [clean[1], clean[0]]
+        return clean
+
+    def _positive_span(start_degrees, end_degrees):
+        span = (end_degrees - start_degrees) % 360.0
+        return 360.0 if abs(span) < 1e-8 else span
+
+    def _angle_in_range(angle, start_degrees, span_degrees):
+        delta = (angle - start_degrees) % 360.0
+        return delta <= span_degrees + 1e-8
+
+    def _point_metrics(point):
+        values = [point.x, point.y, point.z]
+        axis_value = values[axis_index] - center[axis_index]
+        delta_a = values[radial_a] - center[radial_a]
+        delta_b = values[radial_b] - center[radial_b]
+        radius = math.sqrt(delta_a * delta_a + delta_b * delta_b)
+        angle = math.degrees(math.atan2(delta_a, delta_b))
+        return axis_value, radius, angle
+
+    def _matches(point):
+        axis_value, radius, angle = _point_metrics(point)
+        if clean_axis_range is not None and not (clean_axis_range[0] <= axis_value <= clean_axis_range[1]):
+            return False
+        if clean_radial_range is not None and not (clean_radial_range[0] <= radius <= clean_radial_range[1]):
+            return False
+        if clean_angle_range is not None and not _angle_in_range(angle, clean_angle_range[0], angle_span):
+            return False
+        return True
+
+    def _make_material():
+        shader_type = str(material_type or "phong").lower().strip()
+        if shader_type not in {"lambert", "phong", "blinn"}:
+            raise ValueError("material_type must be one of lambert, phong, or blinn.")
+        color = material_color if material_color is not None else [0.5, 0.5, 0.5]
+        color = _validate_vector(color, 3, "material_color")
+        shader = cmds.shadingNode(shader_type, asShader=True, name=material_name or f"{object_name}_region_mat")
+        cmds.setAttr(f"{shader}.color", color[0], color[1], color[2], type="double3")
+        if shader_type in {"phong", "blinn"}:
+            if cmds.attributeQuery("specularColor", node=shader, exists=True):
+                cmds.setAttr(f"{shader}.specularColor", 0.5, 0.5, 0.5, type="double3")
+            if cmds.attributeQuery("reflectivity", node=shader, exists=True):
+                cmds.setAttr(f"{shader}.reflectivity", 0.2)
+        for attr, value in (material_parameters or {}).items():
+            if not cmds.attributeQuery(attr, node=shader, exists=True):
+                continue
+            if isinstance(value, list) and len(value) == 3 and all(_is_number(item) for item in value):
+                attr_type = cmds.getAttr(f"{shader}.{attr}", type=True)
+                cmds.setAttr(f"{shader}.{attr}", float(value[0]), float(value[1]), float(value[2]), type=attr_type)
+            else:
+                cmds.setAttr(f"{shader}.{attr}", value)
+        sg = cmds.sets(name=shading_group_name or f"{shader}SG", empty=True, renderable=True, noSurfaceShader=True)
+        cmds.connectAttr(f"{shader}.outColor", f"{sg}.surfaceShader", force=True)
+        return shader, sg, True
+
+    def _resolve_material():
+        if shading_group_name:
+            if not cmds.objExists(shading_group_name):
+                raise ValueError(f"Shading group does not exist: {shading_group_name}")
+            return None, shading_group_name, False
+        if material_name and cmds.objExists(material_name):
+            groups = cmds.listConnections(material_name, type="shadingEngine") or []
+            if groups:
+                return material_name, groups[0], False
+            sg = cmds.sets(name=f"{material_name}SG", empty=True, renderable=True, noSurfaceShader=True)
+            cmds.connectAttr(f"{material_name}.outColor", f"{sg}.surfaceShader", force=True)
+            return material_name, sg, False
+        return _make_material()
+
+    if not object_name:
+        raise ValueError("object_name is required.")
+    if not cmds.objExists(object_name):
+        raise ValueError(f"Object does not exist: {object_name}")
+
+    center = _validate_vector(center, 3, "center")
+    clean_axis_range = _validate_range(axis_range, "axis_range") if axis_range is not None else None
+    clean_radial_range = _validate_range(radial_range, "radial_range") if radial_range is not None else None
+    clean_angle_range = _validate_vector(angle_range_degrees, 2, "angle_range_degrees") if angle_range_degrees is not None else None
+    angle_span = _positive_span(clean_angle_range[0], clean_angle_range[1]) if clean_angle_range is not None else None
+    if clean_axis_range is None and clean_radial_range is None and clean_angle_range is None:
+        raise ValueError("At least one of axis_range, radial_range, or angle_range_degrees is required.")
+
+    axis = str(axis).lower().strip()
+    axes = {
+        "x": (0, 1, 2),
+        "y": (1, 0, 2),
+        "z": (2, 0, 1),
+    }
+    if axis not in axes:
+        raise ValueError("axis must be one of x, y, or z.")
+    axis_index, radial_a, radial_b = axes[axis]
+
+    if cmds.objectType(object_name) == "mesh":
+        mesh_shape = object_name
+        component_prefix = object_name
+    else:
+        shapes = cmds.listRelatives(object_name, shapes=True, fullPath=True) or []
+        mesh_shapes = [shape for shape in shapes if cmds.objectType(shape) == "mesh"]
+        if not mesh_shapes:
+            raise ValueError(f"{object_name} is not a polygon mesh transform or mesh shape.")
+        mesh_shape = mesh_shapes[0]
+        component_prefix = object_name
+
+    selection = om.MSelectionList()
+    selection.add(mesh_shape)
+    dag_path = selection.getDagPath(0)
+    mesh_fn = om.MFnMesh(dag_path)
+    points = mesh_fn.getPoints(om.MSpace.kWorld)
+    face_counts, vertex_ids = mesh_fn.getVertices()
+
+    matched_faces = []
+    matched_axis_values = []
+    matched_radii = []
+    matched_angles = []
+    cursor = 0
+    for face_index, count in enumerate(face_counts):
+        face_vertex_ids = vertex_ids[cursor: cursor + count]
+        cursor += count
+        face_points = [points[vertex_id] for vertex_id in face_vertex_ids]
+        if include_partial_faces:
+            is_match = any(_matches(point) for point in face_points)
+            metric_points = [point for point in face_points if _matches(point)] or face_points
+        else:
+            center_point = om.MPoint()
+            for point in face_points:
+                center_point += point
+            center_point = center_point / float(max(1, len(face_points)))
+            is_match = _matches(center_point)
+            metric_points = [center_point]
+        if bool(is_match) == bool(invert):
+            continue
+        matched_faces.append(face_index)
+        for point in metric_points:
+            axis_value, radius, angle = _point_metrics(point)
+            matched_axis_values.append(axis_value)
+            matched_radii.append(radius)
+            matched_angles.append(angle)
+
+    material = None
+    shading_group = None
+    created_material = False
+    assigned_components = []
+    if matched_faces and not preview_only:
+        material, shading_group, created_material = _resolve_material()
+        assigned_components = [f"{component_prefix}.f[{face_index}]" for face_index in matched_faces]
+        cmds.sets(assigned_components, edit=True, forceElement=shading_group)
+
+    return {
+        "success": True,
+        "object_name": object_name,
+        "mesh_shape": mesh_shape,
+        "axis": axis,
+        "center": center,
+        "axis_range": clean_axis_range,
+        "angle_range_degrees": clean_angle_range,
+        "angle_span_degrees": angle_span,
+        "radial_range": clean_radial_range,
+        "include_partial_faces": bool(include_partial_faces),
+        "invert": bool(invert),
+        "preview_only": bool(preview_only),
+        "total_face_count": int(mesh_fn.numPolygons),
+        "matched_face_count": len(matched_faces),
+        "matched_faces_sample": matched_faces[:50],
+        "material": material,
+        "shading_group": shading_group,
+        "created_material": created_material,
+        "assigned_component_count": len(assigned_components),
+        "matched_axis_min": min(matched_axis_values) if matched_axis_values else None,
+        "matched_axis_max": max(matched_axis_values) if matched_axis_values else None,
+        "matched_radius_min": min(matched_radii) if matched_radii else None,
+        "matched_radius_max": max(matched_radii) if matched_radii else None,
+        "matched_angle_min": min(matched_angles) if matched_angles else None,
+        "matched_angle_max": max(matched_angles) if matched_angles else None,
+    }

--- a/src/mayatools/material/clean_image_alpha_edges.py
+++ b/src/mayatools/material/clean_image_alpha_edges.py
@@ -9,6 +9,7 @@ def clean_image_alpha_edges(
     unmatte_background: bool = False,
     unmatte_strength: float = 1.0,
     erode_alpha_pixels: int = 0,
+    feather_alpha_pixels: int = 0,
     fill_transparent_rgb: bool = True,
     overwrite: bool = True,
 ) -> Dict[str, Any]:
@@ -20,7 +21,9 @@ def clean_image_alpha_edges(
     viewport filtering does not reveal black or empty padding. When the source
     is known to be premultiplied or matted over a background, it can also remove
     matte/background color contamination from semi-transparent pixels and
-    optionally erode a thin alpha fringe.
+    optionally erode a thin alpha fringe. feather_alpha_pixels fades the
+    remaining alpha near transparent edges, which is useful for projected
+    decals or partial photo textures that should not end with a hard boundary.
     """
     import os
     from collections import deque
@@ -108,6 +111,57 @@ def clean_image_alpha_edges(
                     result[y][x] = 1
         return result
 
+    def _feather_alpha(mask, radius):
+        if radius <= 0:
+            return 0
+        max_distance = radius + 1
+        distances = [[-1 for _ in range(width)] for _ in range(height)]
+        queue = deque()
+        for y in range(height):
+            for x in range(width):
+                if not mask[y][x]:
+                    continue
+                touches_transparent = False
+                for dx, dy in [(-1, 0), (1, 0), (0, -1), (0, 1)]:
+                    nx = x + dx
+                    ny = y + dy
+                    if nx < 0 or nx >= width or ny < 0 or ny >= height or not mask[ny][nx]:
+                        touches_transparent = True
+                        break
+                if touches_transparent:
+                    distances[y][x] = 1
+                    queue.append((x, y, 1))
+
+        while queue:
+            x, y, distance = queue.popleft()
+            if distance >= max_distance:
+                continue
+            next_distance = distance + 1
+            for dx, dy in [(-1, 0), (1, 0), (0, -1), (0, 1)]:
+                nx = x + dx
+                ny = y + dy
+                if nx < 0 or nx >= width or ny < 0 or ny >= height:
+                    continue
+                if not mask[ny][nx] or distances[ny][nx] != -1:
+                    continue
+                distances[ny][nx] = next_distance
+                queue.append((nx, ny, next_distance))
+
+        feathered = 0
+        for y in range(height):
+            for x in range(width):
+                distance = distances[y][x]
+                if distance <= 0 or distance >= max_distance:
+                    continue
+                color = image.pixelColor(x, y)
+                original_alpha = color.alpha()
+                faded_alpha = int(round(original_alpha * (distance / float(max_distance))))
+                if faded_alpha != original_alpha:
+                    color.setAlpha(max(0, min(255, faded_alpha)))
+                    image.setPixelColor(x, y, color)
+                    feathered += 1
+        return feathered
+
     if not image_path:
         raise ValueError("image_path is required.")
     normalized_image_path = os.path.normpath(image_path)
@@ -117,6 +171,7 @@ def clean_image_alpha_edges(
     alpha_threshold = _clamp(_validate_scalar(alpha_threshold, "alpha_threshold"))
     unmatte_strength = _clamp(_validate_scalar(unmatte_strength, "unmatte_strength"))
     erode_alpha_pixels = _validate_int(erode_alpha_pixels, "erode_alpha_pixels", 0)
+    feather_alpha_pixels = _validate_int(feather_alpha_pixels, "feather_alpha_pixels", 0)
     if not isinstance(unmatte_background, bool):
         raise ValueError("unmatte_background must be a boolean.")
     if not isinstance(fill_transparent_rgb, bool):
@@ -175,6 +230,8 @@ def clean_image_alpha_edges(
                         image.setPixelColor(x, y, color)
                         thresholded_alpha_pixels += 1
         visible_mask = eroded
+
+    feathered_alpha_pixels = _feather_alpha(visible_mask, feather_alpha_pixels)
 
     filled_rgb_pixels = 0
     if fill_transparent_rgb:
@@ -238,8 +295,10 @@ def clean_image_alpha_edges(
         "unmatte_background": bool(unmatte_background),
         "unmatte_strength": unmatte_strength,
         "erode_alpha_pixels": erode_alpha_pixels,
+        "feather_alpha_pixels": feather_alpha_pixels,
         "fill_transparent_rgb": bool(fill_transparent_rgb),
         "thresholded_alpha_pixels": thresholded_alpha_pixels,
+        "feathered_alpha_pixels": feathered_alpha_pixels,
         "unmatte_pixels": unmatte_pixels,
         "filled_rgb_pixels": filled_rgb_pixels,
         "visible_pixels": visible_pixels,

--- a/src/mayatools/material/clean_image_alpha_edges.py
+++ b/src/mayatools/material/clean_image_alpha_edges.py
@@ -1,0 +1,248 @@
+from typing import Dict, List, Any
+
+
+def clean_image_alpha_edges(
+    image_path: str,
+    output_path: str = None,
+    background_color: List[float] = None,
+    alpha_threshold: float = 0.01,
+    unmatte_background: bool = False,
+    unmatte_strength: float = 1.0,
+    erode_alpha_pixels: int = 0,
+    fill_transparent_rgb: bool = True,
+    overwrite: bool = True,
+) -> Dict[str, Any]:
+    """Clean alpha-texture edge contamination and transparent RGB padding.
+
+    This is a generic texture-prep utility for decals, cards, labels, leaves,
+    sprites, product-photo cutouts, and other RGBA assets used on real geometry.
+    It can flood-fill fully transparent RGB from nearby visible pixels so
+    viewport filtering does not reveal black or empty padding. When the source
+    is known to be premultiplied or matted over a background, it can also remove
+    matte/background color contamination from semi-transparent pixels and
+    optionally erode a thin alpha fringe.
+    """
+    import os
+    from collections import deque
+
+    try:
+        from PySide6.QtGui import QImage, QColor
+    except Exception:
+        try:
+            from PySide2.QtGui import QImage, QColor
+        except Exception as exc:
+            raise RuntimeError("PySide QImage is required to clean image alpha edges.") from exc
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _clamp(value, lower=0.0, upper=1.0):
+        return max(lower, min(upper, value))
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return value
+
+    def _validate_color(values, arg_name):
+        if not isinstance(values, list) or len(values) != 3 or not all(_is_number(value) for value in values):
+            raise ValueError(f"{arg_name} must be a list of 3 numeric values.")
+        color = [float(values[0]), float(values[1]), float(values[2])]
+        if max(color) > 1.0:
+            color = [value / 255.0 for value in color]
+        return [_clamp(value) for value in color]
+
+    def _estimate_background(image):
+        width = image.width()
+        height = image.height()
+        samples = []
+        radius = max(1, min(width, height, 8))
+        corners = [
+            (0, 0),
+            (width - 1, 0),
+            (0, height - 1),
+            (width - 1, height - 1),
+        ]
+        for corner_x, corner_y in corners:
+            for dy in range(-radius, radius + 1):
+                for dx in range(-radius, radius + 1):
+                    x = max(0, min(width - 1, corner_x + dx))
+                    y = max(0, min(height - 1, corner_y + dy))
+                    color = image.pixelColor(x, y)
+                    if color.alphaF() > 0.0:
+                        samples.append([color.redF(), color.greenF(), color.blueF()])
+        if not samples:
+            return [1.0, 1.0, 1.0]
+        channels = []
+        for index in range(3):
+            values = sorted(sample[index] for sample in samples)
+            channels.append(values[len(values) // 2])
+        return channels
+
+    def _eroded_mask(mask, radius):
+        if radius <= 0:
+            return [bytearray(row) for row in mask]
+        height = len(mask)
+        width = len(mask[0]) if height else 0
+        result = [bytearray(width) for _ in range(height)]
+        for y in range(height):
+            for x in range(width):
+                if not mask[y][x]:
+                    continue
+                keep = True
+                for dy in range(-radius, radius + 1):
+                    if not keep:
+                        break
+                    for dx in range(-radius, radius + 1):
+                        nx = x + dx
+                        ny = y + dy
+                        if nx < 0 or nx >= width or ny < 0 or ny >= height or not mask[ny][nx]:
+                            keep = False
+                            break
+                if keep:
+                    result[y][x] = 1
+        return result
+
+    if not image_path:
+        raise ValueError("image_path is required.")
+    normalized_image_path = os.path.normpath(image_path)
+    if not os.path.isfile(normalized_image_path):
+        raise ValueError(f"Image path does not exist: {image_path}")
+
+    alpha_threshold = _clamp(_validate_scalar(alpha_threshold, "alpha_threshold"))
+    unmatte_strength = _clamp(_validate_scalar(unmatte_strength, "unmatte_strength"))
+    erode_alpha_pixels = _validate_int(erode_alpha_pixels, "erode_alpha_pixels", 0)
+    if not isinstance(unmatte_background, bool):
+        raise ValueError("unmatte_background must be a boolean.")
+    if not isinstance(fill_transparent_rgb, bool):
+        raise ValueError("fill_transparent_rgb must be a boolean.")
+    if not isinstance(overwrite, bool):
+        raise ValueError("overwrite must be a boolean.")
+
+    image = QImage(normalized_image_path)
+    if image.isNull():
+        raise ValueError(f"Unable to load image: {image_path}")
+    image = image.convertToFormat(QImage.Format_ARGB32)
+    width = image.width()
+    height = image.height()
+    if width < 1 or height < 1:
+        raise ValueError("image must not be empty.")
+
+    clean_background = (
+        _validate_color(background_color, "background_color")
+        if background_color is not None
+        else _estimate_background(image)
+    )
+
+    visible_mask = [bytearray(width) for _ in range(height)]
+    thresholded_alpha_pixels = 0
+    unmatte_pixels = 0
+    for y in range(height):
+        for x in range(width):
+            color = image.pixelColor(x, y)
+            alpha = color.alphaF()
+            if alpha <= alpha_threshold:
+                if color.alpha() != 0:
+                    thresholded_alpha_pixels += 1
+                color.setAlpha(0)
+                image.setPixelColor(x, y, color)
+                continue
+
+            visible_mask[y][x] = 1
+            if unmatte_background and alpha < 1.0 and alpha > 1e-6:
+                source = [color.redF(), color.greenF(), color.blueF()]
+                cleaned = []
+                for index, channel in enumerate(source):
+                    unmatted = (channel - clean_background[index] * (1.0 - alpha)) / alpha
+                    cleaned.append(channel + (_clamp(unmatted) - channel) * unmatte_strength)
+                color.setRgbF(cleaned[0], cleaned[1], cleaned[2], alpha)
+                image.setPixelColor(x, y, color)
+                unmatte_pixels += 1
+
+    if erode_alpha_pixels > 0:
+        eroded = _eroded_mask(visible_mask, erode_alpha_pixels)
+        for y in range(height):
+            for x in range(width):
+                if visible_mask[y][x] and not eroded[y][x]:
+                    color = image.pixelColor(x, y)
+                    if color.alpha() != 0:
+                        color.setAlpha(0)
+                        image.setPixelColor(x, y, color)
+                        thresholded_alpha_pixels += 1
+        visible_mask = eroded
+
+    filled_rgb_pixels = 0
+    if fill_transparent_rgb:
+        visited = [bytearray(width) for _ in range(height)]
+        queue = deque()
+        for y in range(height):
+            for x in range(width):
+                color = image.pixelColor(x, y)
+                if color.alphaF() > alpha_threshold:
+                    visited[y][x] = 1
+                    queue.append((x, y, color.red(), color.green(), color.blue()))
+
+        while queue:
+            x, y, red, green, blue = queue.popleft()
+            for dx, dy in [(-1, 0), (1, 0), (0, -1), (0, 1)]:
+                nx = x + dx
+                ny = y + dy
+                if nx < 0 or nx >= width or ny < 0 or ny >= height or visited[ny][nx]:
+                    continue
+                visited[ny][nx] = 1
+                color = image.pixelColor(nx, ny)
+                image.setPixelColor(nx, ny, QColor(red, green, blue, color.alpha()))
+                queue.append((nx, ny, red, green, blue))
+                filled_rgb_pixels += 1
+
+    if output_path is None:
+        base_name = os.path.splitext(os.path.basename(normalized_image_path))[0] or "image"
+        output_path = os.path.join(os.path.dirname(normalized_image_path), f"{base_name}_alpha_clean.png")
+    normalized_output_path = os.path.normpath(output_path)
+    if not os.path.splitext(normalized_output_path)[1]:
+        normalized_output_path += ".png"
+    output_dir = os.path.dirname(normalized_output_path)
+    if output_dir and not os.path.isdir(output_dir):
+        os.makedirs(output_dir)
+    if os.path.exists(normalized_output_path) and not overwrite:
+        raise ValueError(f"Output path already exists: {output_path}")
+    if not image.save(normalized_output_path):
+        raise RuntimeError(f"Failed to save cleaned alpha texture: {output_path}")
+
+    visible_pixels = 0
+    transparent_pixels = 0
+    semi_transparent_pixels = 0
+    for y in range(height):
+        for x in range(width):
+            alpha = image.pixelColor(x, y).alpha()
+            if alpha == 0:
+                transparent_pixels += 1
+            else:
+                visible_pixels += 1
+                if alpha < 255:
+                    semi_transparent_pixels += 1
+
+    return {
+        "success": True,
+        "image_path": normalized_image_path,
+        "output_path": normalized_output_path,
+        "image_width": width,
+        "image_height": height,
+        "background_color": clean_background,
+        "alpha_threshold": alpha_threshold,
+        "unmatte_background": bool(unmatte_background),
+        "unmatte_strength": unmatte_strength,
+        "erode_alpha_pixels": erode_alpha_pixels,
+        "fill_transparent_rgb": bool(fill_transparent_rgb),
+        "thresholded_alpha_pixels": thresholded_alpha_pixels,
+        "unmatte_pixels": unmatte_pixels,
+        "filled_rgb_pixels": filled_rgb_pixels,
+        "visible_pixels": visible_pixels,
+        "transparent_pixels": transparent_pixels,
+        "semi_transparent_pixels": semi_transparent_pixels,
+    }

--- a/src/mayatools/material/compose_image_layers.py
+++ b/src/mayatools/material/compose_image_layers.py
@@ -1,0 +1,212 @@
+from typing import Dict, List, Any
+
+
+def compose_image_layers(
+    output_path: str,
+    width: int,
+    height: int,
+    background_color: List[float] = [0.0, 0.0, 0.0, 0.0],
+    layers: List[Dict[str, Any]] = None,
+    overwrite: bool = True,
+) -> Dict[str, Any]:
+    """Compose multiple image layers into a single RGBA texture.
+
+    This is a generic texture-atlas and decal-prep utility for labels, panels,
+    sprites, UI textures, reference cards, product wraps, and material masks.
+    Each layer can crop a source image with pixel or normalized coordinates,
+    resize it, position it with pixel or normalized coordinates, preserve aspect
+    if requested, and apply opacity before it is drawn onto the output canvas.
+    """
+    import os
+
+    try:
+        from PySide6.QtCore import Qt, QRectF
+        from PySide6.QtGui import QImage, QPainter, QColor
+    except Exception:
+        try:
+            from PySide2.QtCore import Qt, QRectF
+            from PySide2.QtGui import QImage, QPainter, QColor
+        except Exception as exc:
+            raise RuntimeError("PySide QImage is required to compose image layers in Maya.") from exc
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _clamp(value, lower=0.0, upper=1.0):
+        return max(lower, min(upper, value))
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return value
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(value) for value in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(value) for value in values]
+
+    def _validate_color(values, arg_name):
+        color = _validate_vector(values, 4, arg_name)
+        if max(color) > 1.0:
+            color = [value / 255.0 for value in color]
+        return [_clamp(value) for value in color]
+
+    def _make_color(values):
+        color = QColor()
+        color.setRgbF(values[0], values[1], values[2], values[3])
+        return color
+
+    def _bbox_from_layer(layer, image):
+        bbox_pixels = layer.get("source_bbox_pixels")
+        bbox_normalized = layer.get("source_bbox_normalized")
+        if bbox_pixels is not None and bbox_normalized is not None:
+            raise ValueError("Layer cannot provide both source_bbox_pixels and source_bbox_normalized.")
+        if bbox_normalized is not None:
+            bbox = _validate_vector(bbox_normalized, 4, "source_bbox_normalized")
+            x0 = int(round(_clamp(bbox[0]) * (image.width() - 1)))
+            y0 = int(round(_clamp(bbox[1]) * (image.height() - 1)))
+            x1 = int(round(_clamp(bbox[2]) * (image.width() - 1)))
+            y1 = int(round(_clamp(bbox[3]) * (image.height() - 1)))
+        elif bbox_pixels is not None:
+            bbox = _validate_vector(bbox_pixels, 4, "source_bbox_pixels")
+            x0, y0, x1, y1 = [int(round(value)) for value in bbox]
+        else:
+            x0, y0, x1, y1 = 0, 0, image.width() - 1, image.height() - 1
+        x0 = max(0, min(image.width() - 1, x0))
+        x1 = max(0, min(image.width() - 1, x1))
+        y0 = max(0, min(image.height() - 1, y0))
+        y1 = max(0, min(image.height() - 1, y1))
+        if x1 < x0:
+            x0, x1 = x1, x0
+        if y1 < y0:
+            y0, y1 = y1, y0
+        return [x0, y0, x1, y1]
+
+    def _resolve_size(layer, source_width, source_height):
+        size_pixels = layer.get("size_pixels")
+        size_normalized = layer.get("size_normalized")
+        if size_pixels is not None and size_normalized is not None:
+            raise ValueError("Layer cannot provide both size_pixels and size_normalized.")
+        if size_normalized is not None:
+            clean = _validate_vector(size_normalized, 2, "size_normalized")
+            target_width = int(round(clean[0] * width))
+            target_height = int(round(clean[1] * height))
+        elif size_pixels is not None:
+            clean = _validate_vector(size_pixels, 2, "size_pixels")
+            target_width = int(round(clean[0]))
+            target_height = int(round(clean[1]))
+        else:
+            target_width = source_width
+            target_height = source_height
+        if target_width <= 0 or target_height <= 0:
+            raise ValueError("Layer size must resolve to positive dimensions.")
+        return target_width, target_height
+
+    def _resolve_position(layer, target_width, target_height):
+        position_pixels = layer.get("position_pixels")
+        position_normalized = layer.get("position_normalized")
+        if position_pixels is not None and position_normalized is not None:
+            raise ValueError("Layer cannot provide both position_pixels and position_normalized.")
+        if position_normalized is not None:
+            clean = _validate_vector(position_normalized, 2, "position_normalized")
+            x = clean[0] * width
+            y = clean[1] * height
+        elif position_pixels is not None:
+            clean = _validate_vector(position_pixels, 2, "position_pixels")
+            x = clean[0]
+            y = clean[1]
+        else:
+            x = 0.0
+            y = 0.0
+
+        anchor = str(layer.get("anchor", "top_left")).lower().strip()
+        if anchor == "center":
+            x -= target_width * 0.5
+            y -= target_height * 0.5
+        elif anchor == "top_right":
+            x -= target_width
+        elif anchor == "bottom_left":
+            y -= target_height
+        elif anchor == "bottom_right":
+            x -= target_width
+            y -= target_height
+        elif anchor != "top_left":
+            raise ValueError("Layer anchor must be top_left, center, top_right, bottom_left, or bottom_right.")
+        return x, y
+
+    if not output_path:
+        raise ValueError("output_path is required.")
+    width = _validate_int(width, "width", 1)
+    height = _validate_int(height, "height", 1)
+    clean_background = _validate_color(background_color, "background_color")
+    if layers is None:
+        layers = []
+    if not isinstance(layers, list):
+        raise ValueError("layers must be a list of layer dictionaries.")
+
+    normalized_output_path = os.path.normpath(output_path)
+    if os.path.exists(normalized_output_path) and not overwrite:
+        raise ValueError(f"Output path already exists: {output_path}")
+
+    canvas = QImage(width, height, QImage.Format_ARGB32)
+    canvas.fill(_make_color(clean_background))
+    painter = QPainter(canvas)
+    written_layers = []
+
+    for index, layer in enumerate(layers):
+        if not isinstance(layer, dict):
+            raise ValueError("Each layer must be a dictionary.")
+        image_path = layer.get("image_path")
+        if not image_path:
+            raise ValueError("Each layer requires image_path.")
+        normalized_image_path = os.path.normpath(image_path)
+        if not os.path.isfile(normalized_image_path):
+            raise ValueError(f"Layer image path does not exist: {image_path}")
+
+        image = QImage(normalized_image_path)
+        if image.isNull():
+            raise ValueError(f"Unable to load layer image: {image_path}")
+        image = image.convertToFormat(QImage.Format_ARGB32)
+        x0, y0, x1, y1 = _bbox_from_layer(layer, image)
+        cropped = image.copy(x0, y0, x1 - x0 + 1, y1 - y0 + 1)
+        target_width, target_height = _resolve_size(layer, cropped.width(), cropped.height())
+        keep_aspect = bool(layer.get("keep_aspect", False))
+        transform_mode = Qt.SmoothTransformation if bool(layer.get("smooth", True)) else Qt.FastTransformation
+        aspect_mode = Qt.KeepAspectRatio if keep_aspect else Qt.IgnoreAspectRatio
+        scaled = cropped.scaled(target_width, target_height, aspect_mode, transform_mode)
+        x, y = _resolve_position(layer, scaled.width(), scaled.height())
+        opacity = _clamp(_validate_scalar(layer.get("opacity", 1.0), "opacity"))
+
+        painter.setOpacity(opacity)
+        painter.drawImage(QRectF(x, y, scaled.width(), scaled.height()), scaled)
+        written_layers.append({
+            "index": index,
+            "image_path": normalized_image_path,
+            "source_bbox_pixels": [x0, y0, x1, y1],
+            "draw_rect_pixels": [x, y, x + scaled.width(), y + scaled.height()],
+            "opacity": opacity,
+        })
+
+    painter.setOpacity(1.0)
+    painter.end()
+
+    directory = os.path.dirname(normalized_output_path)
+    if directory and not os.path.isdir(directory):
+        os.makedirs(directory)
+    if not canvas.save(normalized_output_path):
+        raise RuntimeError(f"Unable to write composed image: {output_path}")
+
+    return {
+        "success": True,
+        "output_path": normalized_output_path,
+        "width": width,
+        "height": height,
+        "background_color": clean_background,
+        "layer_count": len(layers),
+        "layers": written_layers,
+    }

--- a/src/mayatools/material/create_pbr_material.py
+++ b/src/mayatools/material/create_pbr_material.py
@@ -1,0 +1,284 @@
+from typing import Dict, List, Any, Union
+
+
+def create_pbr_material(
+    name: str = None,
+    preset: str = "generic",
+    shader_type: str = "auto",
+    base_color: List[float] = None,
+    opacity: Union[float, List[float]] = None,
+    metalness: float = None,
+    roughness: float = None,
+    specular: float = None,
+    specular_color: List[float] = None,
+    transmission: float = None,
+    transmission_color: List[float] = None,
+    ior: float = None,
+    coat: float = None,
+    coat_roughness: float = None,
+    emission: float = None,
+    emission_color: List[float] = None,
+    thin_walled: bool = None,
+    parameters: Dict[str, Any] = None,
+    assign_to: Union[str, List[str]] = None,
+) -> Dict[str, Any]:
+    """Create a physically-oriented material and optionally assign it to objects.
+
+    The tool prefers Arnold aiStandardSurface when available, falls back to
+    Maya standardSurface, and finally uses phong for older scenes. Presets are
+    generic material starting points; direct arguments override preset values.
+    Supported presets: generic, glass, liquid, metal, plastic, rubber, ceramic.
+    """
+    import random
+    import maya.cmds as cmds
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_color(values, arg_name):
+        if not isinstance(values, list) or len(values) != 3 or not all(_is_number(v) for v in values):
+            raise ValueError(f"{arg_name} must be a list of 3 numeric values.")
+        return [float(values[0]), float(values[1]), float(values[2])]
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _validate_opacity(value):
+        if isinstance(value, list):
+            return _validate_color(value, "opacity")
+        return [_validate_scalar(value, "opacity")] * 3
+
+    preset_defaults = {
+        "generic": {
+            "base_color": [0.8, 0.8, 0.8],
+            "opacity": [1.0, 1.0, 1.0],
+            "metalness": 0.0,
+            "roughness": 0.35,
+            "specular": 0.5,
+        },
+        "glass": {
+            "base_color": [0.75, 0.62, 0.45],
+            "opacity": [0.28, 0.28, 0.28],
+            "metalness": 0.0,
+            "roughness": 0.02,
+            "specular": 1.0,
+            "specular_color": [1.0, 1.0, 1.0],
+            "transmission": 0.85,
+            "transmission_color": [0.75, 0.62, 0.45],
+            "ior": 1.52,
+            "coat": 0.15,
+            "coat_roughness": 0.02,
+            "thin_walled": False,
+        },
+        "liquid": {
+            "base_color": [0.12, 0.045, 0.015],
+            "opacity": [0.72, 0.72, 0.72],
+            "metalness": 0.0,
+            "roughness": 0.06,
+            "specular": 0.65,
+            "transmission": 0.35,
+            "transmission_color": [0.18, 0.06, 0.015],
+            "ior": 1.33,
+            "thin_walled": False,
+        },
+        "metal": {
+            "base_color": [0.8, 0.8, 0.8],
+            "opacity": [1.0, 1.0, 1.0],
+            "metalness": 1.0,
+            "roughness": 0.18,
+            "specular": 1.0,
+        },
+        "plastic": {
+            "base_color": [0.8, 0.05, 0.05],
+            "opacity": [1.0, 1.0, 1.0],
+            "metalness": 0.0,
+            "roughness": 0.32,
+            "specular": 0.55,
+            "coat": 0.25,
+            "coat_roughness": 0.08,
+        },
+        "rubber": {
+            "base_color": [0.02, 0.02, 0.02],
+            "opacity": [1.0, 1.0, 1.0],
+            "metalness": 0.0,
+            "roughness": 0.78,
+            "specular": 0.18,
+        },
+        "ceramic": {
+            "base_color": [0.85, 0.82, 0.76],
+            "opacity": [1.0, 1.0, 1.0],
+            "metalness": 0.0,
+            "roughness": 0.22,
+            "specular": 0.65,
+            "coat": 0.35,
+            "coat_roughness": 0.04,
+        },
+    }
+
+    preset = preset.lower()
+    if preset not in preset_defaults:
+        raise ValueError(f"Unsupported preset {preset}. Use one of {sorted(preset_defaults)}")
+
+    settings = dict(preset_defaults[preset])
+    overrides = {
+        "base_color": _validate_color(base_color, "base_color") if base_color is not None else None,
+        "opacity": _validate_opacity(opacity) if opacity is not None else None,
+        "metalness": _validate_scalar(metalness, "metalness") if metalness is not None else None,
+        "roughness": _validate_scalar(roughness, "roughness") if roughness is not None else None,
+        "specular": _validate_scalar(specular, "specular") if specular is not None else None,
+        "specular_color": _validate_color(specular_color, "specular_color") if specular_color is not None else None,
+        "transmission": _validate_scalar(transmission, "transmission") if transmission is not None else None,
+        "transmission_color": _validate_color(transmission_color, "transmission_color") if transmission_color is not None else None,
+        "ior": _validate_scalar(ior, "ior") if ior is not None else None,
+        "coat": _validate_scalar(coat, "coat") if coat is not None else None,
+        "coat_roughness": _validate_scalar(coat_roughness, "coat_roughness") if coat_roughness is not None else None,
+        "emission": _validate_scalar(emission, "emission") if emission is not None else None,
+        "emission_color": _validate_color(emission_color, "emission_color") if emission_color is not None else None,
+        "thin_walled": bool(thin_walled) if thin_walled is not None else None,
+    }
+    for key, value in overrides.items():
+        if value is not None:
+            settings[key] = value
+
+    if parameters is None:
+        parameters = {}
+    if name is None:
+        name = f"{preset}_pbr_mat_{int(random.random() * 1000)}"
+
+    def _has_attr(node, attr):
+        return cmds.attributeQuery(attr, node=node, exists=True)
+
+    def _set_scalar(node, attr, value):
+        if value is not None and _has_attr(node, attr):
+            cmds.setAttr(f"{node}.{attr}", float(value))
+            return True
+        return False
+
+    def _set_bool(node, attr, value):
+        if value is not None and _has_attr(node, attr):
+            cmds.setAttr(f"{node}.{attr}", bool(value))
+            return True
+        return False
+
+    def _set_color(node, attr, value):
+        if value is not None and _has_attr(node, attr):
+            values = _validate_color(value, attr)
+            cmds.setAttr(f"{node}.{attr}", values[0], values[1], values[2], type="double3")
+            return True
+        return False
+
+    def _try_load_arnold():
+        try:
+            if not cmds.pluginInfo("mtoa", query=True, loaded=True):
+                cmds.loadPlugin("mtoa", quiet=True)
+            return cmds.pluginInfo("mtoa", query=True, loaded=True)
+        except Exception:
+            return False
+
+    def _create_shader(node_type):
+        shader = cmds.shadingNode(node_type, asShader=True, name=name)
+        if node_type in {"aiStandardSurface", "standardSurface"} and not _has_attr(shader, "baseColor"):
+            cmds.delete(shader)
+            raise RuntimeError(f"{node_type} is not available in this Maya session.")
+        if node_type == "phong" and not _has_attr(shader, "color"):
+            cmds.delete(shader)
+            raise RuntimeError("phong is not available in this Maya session.")
+        return shader
+
+    shader_type = shader_type.strip()
+    if shader_type == "auto":
+        candidates = []
+        if _try_load_arnold():
+            candidates.append("aiStandardSurface")
+        candidates.extend(["standardSurface", "phong"])
+    else:
+        supported_shader_types = {"aiStandardSurface", "standardSurface", "phong"}
+        if shader_type not in supported_shader_types:
+            raise ValueError(f"Unsupported shader_type {shader_type}. Use auto, aiStandardSurface, standardSurface, or phong.")
+        if shader_type == "aiStandardSurface":
+            _try_load_arnold()
+        candidates = [shader_type]
+
+    shader = None
+    created_shader_type = None
+    errors = []
+    for candidate in candidates:
+        try:
+            shader = _create_shader(candidate)
+            created_shader_type = candidate
+            break
+        except Exception as exc:
+            errors.append(f"{candidate}: {exc}")
+    if shader is None:
+        raise RuntimeError("Unable to create a supported PBR shader. " + "; ".join(errors))
+
+    applied_attributes = {}
+
+    def _record(attr, applied):
+        if applied:
+            applied_attributes[attr] = True
+
+    if created_shader_type in {"aiStandardSurface", "standardSurface"}:
+        _record("base", _set_scalar(shader, "base", 1.0))
+        _record("baseColor", _set_color(shader, "baseColor", settings.get("base_color")))
+        _record("metalness", _set_scalar(shader, "metalness", settings.get("metalness")))
+        _record("specular", _set_scalar(shader, "specular", settings.get("specular")))
+        _record("specularColor", _set_color(shader, "specularColor", settings.get("specular_color", [1.0, 1.0, 1.0])))
+        _record("specularRoughness", _set_scalar(shader, "specularRoughness", settings.get("roughness")))
+        _record("specularIOR", _set_scalar(shader, "specularIOR", settings.get("ior")))
+        _record("transmission", _set_scalar(shader, "transmission", settings.get("transmission")))
+        _record("transmissionColor", _set_color(shader, "transmissionColor", settings.get("transmission_color")))
+        _record("opacity", _set_color(shader, "opacity", settings.get("opacity")))
+        _record("thinWalled", _set_bool(shader, "thinWalled", settings.get("thin_walled")))
+        _record("coat", _set_scalar(shader, "coat", settings.get("coat")))
+        _record("coatRoughness", _set_scalar(shader, "coatRoughness", settings.get("coat_roughness")))
+        _record("emission", _set_scalar(shader, "emission", settings.get("emission")))
+        _record("emissionColor", _set_color(shader, "emissionColor", settings.get("emission_color")))
+    else:
+        opacity_values = settings.get("opacity", [1.0, 1.0, 1.0])
+        transparency = [1.0 - max(0.0, min(1.0, value)) for value in opacity_values]
+        _record("color", _set_color(shader, "color", settings.get("base_color")))
+        _record("specularColor", _set_color(shader, "specularColor", settings.get("specular_color", [1.0, 1.0, 1.0])))
+        _record("transparency", _set_color(shader, "transparency", transparency))
+        _record("reflectivity", _set_scalar(shader, "reflectivity", settings.get("specular")))
+        _record("eccentricity", _set_scalar(shader, "eccentricity", settings.get("roughness")))
+
+    for attr, value in parameters.items():
+        if not _has_attr(shader, attr):
+            continue
+        if isinstance(value, list) and len(value) == 3:
+            _set_color(shader, attr, value)
+        elif isinstance(value, bool):
+            cmds.setAttr(f"{shader}.{attr}", value)
+        elif _is_number(value):
+            cmds.setAttr(f"{shader}.{attr}", float(value))
+        elif isinstance(value, str):
+            cmds.setAttr(f"{shader}.{attr}", value, type="string")
+        applied_attributes[attr] = True
+
+    shading_group = cmds.sets(name=f"{name}SG", empty=True, renderable=True, noSurfaceShader=True)
+    cmds.connectAttr(f"{shader}.outColor", f"{shading_group}.surfaceShader", force=True)
+
+    assigned_to = []
+    if assign_to:
+        objects = assign_to if isinstance(assign_to, list) else [assign_to]
+        for obj in objects:
+            if not cmds.objExists(obj):
+                raise ValueError(f"Object does not exist: {obj}")
+        cmds.sets(objects, edit=True, forceElement=shading_group)
+        assigned_to = objects
+
+    return {
+        "success": True,
+        "name": name,
+        "preset": preset,
+        "requested_shader_type": shader_type,
+        "shader_type": created_shader_type,
+        "shader": shader,
+        "shading_group": shading_group,
+        "settings": settings,
+        "applied_attributes": applied_attributes,
+        "assigned_to": assigned_to,
+    }

--- a/src/mayatools/material/create_textured_material.py
+++ b/src/mayatools/material/create_textured_material.py
@@ -1,0 +1,123 @@
+from typing import Dict, List, Any, Union
+
+
+def create_textured_material(
+    texture_path: str,
+    name: str = None,
+    material_type: str = "lambert",
+    assign_to: Union[str, List[str]] = None,
+    color_attribute: str = "color",
+    repeat_uv: List[float] = [1.0, 1.0],
+    offset_uv: List[float] = [0.0, 0.0],
+    rotate_uv: float = 0.0,
+    use_alpha: bool = False,
+) -> Dict[str, Any]:
+    """Create a material driven by an image texture and optionally assign it to objects.
+
+    Supported material types are lambert, phong, blinn, and surfaceShader.
+    The target mesh should already have usable UVs. Use uv_operations to create
+    or adjust UVs before assigning this material when needed.
+    """
+    import os
+    import maya.cmds as cmds
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_vector2(values: List[float], arg_name: str):
+        if not isinstance(values, list) or len(values) != 2 or not all(_is_number(v) for v in values):
+            raise ValueError(f"{arg_name} must be a list of 2 float values.")
+        return [float(values[0]), float(values[1])]
+
+    repeat_uv = _validate_vector2(repeat_uv, "repeat_uv")
+    offset_uv = _validate_vector2(offset_uv, "offset_uv")
+
+    if not texture_path:
+        raise ValueError("texture_path is required.")
+
+    normalized_texture_path = os.path.normpath(texture_path)
+    if not os.path.exists(normalized_texture_path):
+        raise ValueError(f"Texture path does not exist: {texture_path}")
+
+    material_type = material_type.strip()
+    supported = {"lambert", "phong", "blinn", "surfaceShader"}
+    if material_type not in supported:
+        raise ValueError(f"Unsupported material_type {material_type}. Use one of {sorted(supported)}")
+
+    if name is None:
+        base_name = os.path.splitext(os.path.basename(texture_path))[0] or "textured"
+        name = f"{base_name}_{material_type}_mat"
+
+    shader = cmds.shadingNode(material_type, asShader=True, name=name)
+    file_node = cmds.shadingNode("file", asTexture=True, name=f"{name}_file")
+    place2d = cmds.shadingNode("place2dTexture", asUtility=True, name=f"{name}_place2d")
+
+    for attr in ["outUV", "outUvFilterSize"]:
+        destination = "uvCoord" if attr == "outUV" else "uvFilterSize"
+        cmds.connectAttr(f"{place2d}.{attr}", f"{file_node}.{destination}", force=True)
+
+    passthrough_attrs = [
+        "coverage",
+        "translateFrame",
+        "rotateFrame",
+        "mirrorU",
+        "mirrorV",
+        "stagger",
+        "wrapU",
+        "wrapV",
+        "repeatUV",
+        "offset",
+        "rotateUV",
+        "noiseUV",
+        "vertexUvOne",
+        "vertexUvTwo",
+        "vertexUvThree",
+        "vertexCameraOne",
+    ]
+    for attr in passthrough_attrs:
+        if cmds.attributeQuery(attr, node=place2d, exists=True) and cmds.attributeQuery(attr, node=file_node, exists=True):
+            cmds.connectAttr(f"{place2d}.{attr}", f"{file_node}.{attr}", force=True)
+
+    cmds.setAttr(f"{file_node}.fileTextureName", normalized_texture_path, type="string")
+    cmds.setAttr(f"{place2d}.repeatU", repeat_uv[0])
+    cmds.setAttr(f"{place2d}.repeatV", repeat_uv[1])
+    cmds.setAttr(f"{place2d}.offsetU", offset_uv[0])
+    cmds.setAttr(f"{place2d}.offsetV", offset_uv[1])
+    cmds.setAttr(f"{place2d}.rotateUV", rotate_uv)
+
+    if material_type == "surfaceShader":
+        target_attribute = "outColor"
+    else:
+        target_attribute = color_attribute
+
+    if not cmds.attributeQuery(target_attribute, node=shader, exists=True):
+        raise ValueError(f"Shader {shader} does not have attribute {target_attribute}")
+
+    cmds.connectAttr(f"{file_node}.outColor", f"{shader}.{target_attribute}", force=True)
+
+    if use_alpha and material_type != "surfaceShader" and cmds.attributeQuery("transparency", node=shader, exists=True):
+        cmds.connectAttr(f"{file_node}.outTransparency", f"{shader}.transparency", force=True)
+
+    shading_group = cmds.sets(name=f"{name}SG", empty=True, renderable=True, noSurfaceShader=True)
+    source_attr = "outColor" if material_type != "surfaceShader" else "outColor"
+    cmds.connectAttr(f"{shader}.{source_attr}", f"{shading_group}.surfaceShader", force=True)
+
+    assigned_to = []
+    if assign_to:
+        objects = assign_to if isinstance(assign_to, list) else [assign_to]
+        for obj in objects:
+            if not cmds.objExists(obj):
+                raise ValueError(f"Object does not exist: {obj}")
+        cmds.sets(objects, edit=True, forceElement=shading_group)
+        assigned_to = objects
+
+    return {
+        "success": True,
+        "name": name,
+        "shader": shader,
+        "file_node": file_node,
+        "place2d": place2d,
+        "shading_group": shading_group,
+        "texture_path": normalized_texture_path,
+        "assigned_to": assigned_to,
+    }

--- a/src/mayatools/material/create_textured_material.py
+++ b/src/mayatools/material/create_textured_material.py
@@ -95,8 +95,15 @@ def create_textured_material(
 
     cmds.connectAttr(f"{file_node}.outColor", f"{shader}.{target_attribute}", force=True)
 
+    alpha_node = None
     if use_alpha and material_type != "surfaceShader" and cmds.attributeQuery("transparency", node=shader, exists=True):
-        cmds.connectAttr(f"{file_node}.outTransparency", f"{shader}.transparency", force=True)
+        if cmds.attributeQuery("outAlpha", node=file_node, exists=True):
+            alpha_node = cmds.shadingNode("reverse", asUtility=True, name=f"{name}_alpha_reverse")
+            for channel in ["X", "Y", "Z"]:
+                cmds.connectAttr(f"{file_node}.outAlpha", f"{alpha_node}.input{channel}", force=True)
+            cmds.connectAttr(f"{alpha_node}.output", f"{shader}.transparency", force=True)
+        elif cmds.attributeQuery("outTransparency", node=file_node, exists=True):
+            cmds.connectAttr(f"{file_node}.outTransparency", f"{shader}.transparency", force=True)
 
     shading_group = cmds.sets(name=f"{name}SG", empty=True, renderable=True, noSurfaceShader=True)
     source_attr = "outColor" if material_type != "surfaceShader" else "outColor"
@@ -117,6 +124,7 @@ def create_textured_material(
         "shader": shader,
         "file_node": file_node,
         "place2d": place2d,
+        "alpha_node": alpha_node,
         "shading_group": shading_group,
         "texture_path": normalized_texture_path,
         "assigned_to": assigned_to,

--- a/src/mayatools/material/draw_image_primitives.py
+++ b/src/mayatools/material/draw_image_primitives.py
@@ -1,0 +1,310 @@
+from typing import Dict, List, Any
+
+
+def draw_image_primitives(
+    output_path: str,
+    width: int,
+    height: int,
+    background_color: List[float] = [0.0, 0.0, 0.0, 0.0],
+    primitives: List[Dict[str, Any]] = None,
+    overwrite: bool = True,
+) -> Dict[str, Any]:
+    """Draw simple vector primitives into an RGBA image.
+
+    This is a generic procedural texture helper for labels, decals, masks,
+    signs, UI textures, packaging mockups, material debugging, and annotation
+    plates. Supported primitive types are rect, ellipse, line, polygon, and
+    text. Coordinates can be provided in pixels or normalized image space.
+    """
+    import os
+
+    try:
+        from PySide6.QtCore import Qt, QRectF, QPointF
+        from PySide6.QtGui import QImage, QPainter, QColor, QPen, QBrush, QFont, QPolygonF
+    except Exception:
+        try:
+            from PySide2.QtCore import Qt, QRectF, QPointF
+            from PySide2.QtGui import QImage, QPainter, QColor, QPen, QBrush, QFont, QPolygonF
+        except Exception as exc:
+            raise RuntimeError("PySide QImage is required to draw image primitives in Maya.") from exc
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _clamp(value, lower=0.0, upper=1.0):
+        return max(lower, min(upper, value))
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return value
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(value) for value in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(value) for value in values]
+
+    def _validate_color(values, arg_name):
+        color = _validate_vector(values, 4, arg_name)
+        if max(color) > 1.0:
+            color = [value / 255.0 for value in color]
+        return [_clamp(value) for value in color]
+
+    def _make_color(values):
+        color = QColor()
+        color.setRgbF(values[0], values[1], values[2], values[3])
+        return color
+
+    def _qt_enum(group_name, value_name, fallback_name=None):
+        if hasattr(Qt, value_name):
+            return getattr(Qt, value_name)
+        if hasattr(Qt, group_name):
+            group = getattr(Qt, group_name)
+            if hasattr(group, value_name):
+                return getattr(group, value_name)
+            if fallback_name and hasattr(group, fallback_name):
+                return getattr(group, fallback_name)
+        raise AttributeError(value_name)
+
+    def _set_antialiasing(painter):
+        try:
+            painter.setRenderHint(QPainter.Antialiasing, True)
+        except AttributeError:
+            painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+
+    def _rect_from_primitive(primitive, arg_prefix):
+        bbox_pixels = primitive.get("bbox_pixels")
+        bbox_normalized = primitive.get("bbox_normalized")
+        if bbox_pixels is not None and bbox_normalized is not None:
+            raise ValueError(f"{arg_prefix} cannot provide both bbox_pixels and bbox_normalized.")
+        if bbox_normalized is not None:
+            values = _validate_vector(bbox_normalized, 4, f"{arg_prefix}.bbox_normalized")
+            x0 = values[0] * width
+            y0 = values[1] * height
+            x1 = values[2] * width
+            y1 = values[3] * height
+        elif bbox_pixels is not None:
+            values = _validate_vector(bbox_pixels, 4, f"{arg_prefix}.bbox_pixels")
+            x0, y0, x1, y1 = values
+        else:
+            raise ValueError(f"{arg_prefix} requires bbox_pixels or bbox_normalized.")
+        if x1 < x0:
+            x0, x1 = x1, x0
+        if y1 < y0:
+            y0, y1 = y1, y0
+        return QRectF(x0, y0, max(0.0, x1 - x0), max(0.0, y1 - y0)), [x0, y0, x1, y1]
+
+    def _points_from_primitive(primitive, arg_prefix):
+        points_pixels = primitive.get("points_pixels")
+        points_normalized = primitive.get("points_normalized")
+        if points_pixels is not None and points_normalized is not None:
+            raise ValueError(f"{arg_prefix} cannot provide both points_pixels and points_normalized.")
+        if points_normalized is not None:
+            source = points_normalized
+            normalized = True
+        elif points_pixels is not None:
+            source = points_pixels
+            normalized = False
+        else:
+            raise ValueError(f"{arg_prefix} requires points_pixels or points_normalized.")
+        if not isinstance(source, list) or len(source) < 2:
+            raise ValueError(f"{arg_prefix} points must contain at least two [x, y] pairs.")
+        points = []
+        clean = []
+        for index, point in enumerate(source):
+            values = _validate_vector(point, 2, f"{arg_prefix}.points[{index}]")
+            x = values[0] * width if normalized else values[0]
+            y = values[1] * height if normalized else values[1]
+            points.append(QPointF(x, y))
+            clean.append([x, y])
+        return points, clean
+
+    def _position_from_primitive(primitive, arg_prefix):
+        position_pixels = primitive.get("position_pixels")
+        position_normalized = primitive.get("position_normalized")
+        if position_pixels is not None and position_normalized is not None:
+            raise ValueError(f"{arg_prefix} cannot provide both position_pixels and position_normalized.")
+        if position_normalized is not None:
+            values = _validate_vector(position_normalized, 2, f"{arg_prefix}.position_normalized")
+            return [values[0] * width, values[1] * height]
+        if position_pixels is not None:
+            return _validate_vector(position_pixels, 2, f"{arg_prefix}.position_pixels")
+        raise ValueError(f"{arg_prefix} requires position_pixels or position_normalized.")
+
+    def _pen(color_values, line_width):
+        pen = QPen(_make_color(color_values))
+        pen.setWidthF(max(0.0, line_width))
+        return pen
+
+    def _fill_brush(primitive):
+        fill_color = primitive.get("fill_color")
+        if fill_color is None:
+            return QBrush(_qt_enum("BrushStyle", "NoBrush"))
+        return QBrush(_make_color(_validate_color(fill_color, "fill_color")))
+
+    def _outline_pen(primitive):
+        outline_color = primitive.get("outline_color")
+        if outline_color is None:
+            return QPen(_qt_enum("PenStyle", "NoPen"))
+        outline_width = _validate_scalar(primitive.get("outline_width", 1.0), "outline_width")
+        return _pen(_validate_color(outline_color, "outline_color"), outline_width)
+
+    def _text_flags(primitive):
+        alignment = str(primitive.get("align", "left")).lower().strip()
+        vertical_align = str(primitive.get("vertical_align", "center")).lower().strip()
+        if alignment == "center":
+            horizontal = _qt_enum("AlignmentFlag", "AlignHCenter")
+        elif alignment == "right":
+            horizontal = _qt_enum("AlignmentFlag", "AlignRight")
+        elif alignment == "left":
+            horizontal = _qt_enum("AlignmentFlag", "AlignLeft")
+        else:
+            raise ValueError("text align must be left, center, or right.")
+        if vertical_align == "top":
+            vertical = _qt_enum("AlignmentFlag", "AlignTop")
+        elif vertical_align == "bottom":
+            vertical = _qt_enum("AlignmentFlag", "AlignBottom")
+        elif vertical_align == "center":
+            vertical = _qt_enum("AlignmentFlag", "AlignVCenter")
+        else:
+            raise ValueError("text vertical_align must be top, center, or bottom.")
+        flags = horizontal | vertical
+        if bool(primitive.get("word_wrap", False)):
+            flags = flags | _qt_enum("TextFlag", "TextWordWrap")
+        return flags
+
+    def _anchor_offset(anchor, box_width, box_height):
+        anchor = str(anchor or "top_left").lower().strip()
+        offsets = {
+            "top_left": (0.0, 0.0),
+            "top_right": (-box_width, 0.0),
+            "bottom_left": (0.0, -box_height),
+            "bottom_right": (-box_width, -box_height),
+            "center": (-box_width * 0.5, -box_height * 0.5),
+            "middle_left": (0.0, -box_height * 0.5),
+            "middle_right": (-box_width, -box_height * 0.5),
+            "top_middle": (-box_width * 0.5, 0.0),
+            "bottom_middle": (-box_width * 0.5, -box_height),
+        }
+        if anchor not in offsets:
+            raise ValueError("anchor must be top_left, top_right, bottom_left, bottom_right, center, middle_left, middle_right, top_middle, or bottom_middle.")
+        return offsets[anchor]
+
+    if not output_path:
+        raise ValueError("output_path is required.")
+    width = _validate_int(width, "width", 1)
+    height = _validate_int(height, "height", 1)
+    clean_background = _validate_color(background_color, "background_color")
+    if primitives is None:
+        primitives = []
+    if not isinstance(primitives, list):
+        raise ValueError("primitives must be a list of dictionaries.")
+
+    normalized_output_path = os.path.normpath(output_path)
+    if os.path.exists(normalized_output_path) and not overwrite:
+        raise ValueError(f"Output path already exists: {output_path}")
+
+    canvas = QImage(width, height, QImage.Format_ARGB32)
+    canvas.fill(_make_color(clean_background))
+    painter = QPainter(canvas)
+    _set_antialiasing(painter)
+
+    written_primitives = []
+    for index, primitive in enumerate(primitives):
+        if not isinstance(primitive, dict):
+            raise ValueError("Each primitive must be a dictionary.")
+        primitive_type = str(primitive.get("type", "")).lower().strip()
+        if not primitive_type:
+            raise ValueError("Each primitive requires type.")
+        opacity = _clamp(_validate_scalar(primitive.get("opacity", 1.0), "opacity"))
+        painter.save()
+        painter.setOpacity(opacity)
+        record = {"index": index, "type": primitive_type, "opacity": opacity}
+
+        if primitive_type in {"rect", "rectangle", "ellipse"}:
+            rect, bbox = _rect_from_primitive(primitive, f"primitives[{index}]")
+            painter.setBrush(_fill_brush(primitive))
+            painter.setPen(_outline_pen(primitive))
+            if primitive_type == "ellipse":
+                painter.drawEllipse(rect)
+            else:
+                painter.drawRect(rect)
+            record["bbox_pixels"] = bbox
+        elif primitive_type == "line":
+            points, clean_points = _points_from_primitive(primitive, f"primitives[{index}]")
+            color = _validate_color(primitive.get("color", [1.0, 1.0, 1.0, 1.0]), "color")
+            line_width = _validate_scalar(primitive.get("width", 1.0), "width")
+            painter.setPen(_pen(color, line_width))
+            for point_index in range(len(points) - 1):
+                painter.drawLine(points[point_index], points[point_index + 1])
+            record["points_pixels"] = clean_points
+        elif primitive_type == "polygon":
+            points, clean_points = _points_from_primitive(primitive, f"primitives[{index}]")
+            painter.setBrush(_fill_brush(primitive))
+            painter.setPen(_outline_pen(primitive))
+            painter.drawPolygon(QPolygonF(points))
+            record["points_pixels"] = clean_points
+        elif primitive_type == "text":
+            text = primitive.get("text")
+            if text is None:
+                raise ValueError("text primitive requires text.")
+            text = str(text)
+            position = _position_from_primitive(primitive, f"primitives[{index}]")
+            font_family = str(primitive.get("font_family", "Arial"))
+            font_size = _validate_scalar(primitive.get("font_size", 24.0), "font_size")
+            if font_size <= 0.0:
+                raise ValueError("font_size must be greater than zero.")
+            font = QFont(font_family)
+            font.setPixelSize(int(round(font_size)))
+            font.setBold(bool(primitive.get("bold", False)))
+            font.setItalic(bool(primitive.get("italic", False)))
+            painter.setFont(font)
+            painter.setPen(_pen(_validate_color(primitive.get("color", [1.0, 1.0, 1.0, 1.0]), "color"), 1.0))
+            metrics = painter.fontMetrics()
+            lines = text.splitlines() or [text]
+            max_width = primitive.get("max_width_pixels")
+            max_height = primitive.get("max_height_pixels")
+            if max_width is None:
+                max_width = max(1, max(metrics.horizontalAdvance(line) for line in lines))
+            else:
+                max_width = _validate_scalar(max_width, "max_width_pixels")
+            if max_height is None:
+                max_height = max(1, metrics.height() * max(1, len(lines)))
+            else:
+                max_height = _validate_scalar(max_height, "max_height_pixels")
+            offset_x, offset_y = _anchor_offset(primitive.get("anchor", "top_left"), max_width, max_height)
+            rotation = _validate_scalar(primitive.get("rotation_degrees", 0.0), "rotation_degrees")
+            painter.translate(position[0], position[1])
+            if rotation:
+                painter.rotate(rotation)
+            painter.drawText(QRectF(offset_x, offset_y, max_width, max_height), _text_flags(primitive), text)
+            record["position_pixels"] = position
+            record["text_box_pixels"] = [position[0] + offset_x, position[1] + offset_y, position[0] + offset_x + max_width, position[1] + offset_y + max_height]
+        else:
+            raise ValueError("primitive type must be rect, ellipse, line, polygon, or text.")
+
+        painter.restore()
+        written_primitives.append(record)
+
+    painter.end()
+
+    directory = os.path.dirname(normalized_output_path)
+    if directory and not os.path.isdir(directory):
+        os.makedirs(directory)
+    if not canvas.save(normalized_output_path):
+        raise RuntimeError(f"Unable to write primitive image: {output_path}")
+
+    return {
+        "success": True,
+        "output_path": normalized_output_path,
+        "width": width,
+        "height": height,
+        "background_color": clean_background,
+        "primitive_count": len(primitives),
+        "primitives": written_primitives,
+    }

--- a/src/mayatools/material/edit_material_assignments.py
+++ b/src/mayatools/material/edit_material_assignments.py
@@ -1,0 +1,291 @@
+from typing import Dict, List, Any, Union
+
+
+def edit_material_assignments(
+    object_name: str,
+    operation: str = "query",
+    material_name: str = None,
+    shading_group_name: str = None,
+    material_type: str = "lambert",
+    material_color: List[float] = None,
+    material_parameters: Dict[str, Any] = None,
+    component_type: str = None,
+    indices: List[int] = None,
+    components: Union[str, List[str]] = None,
+    assign_scope: str = "components",
+    create_if_missing: bool = True,
+    use_selection: bool = True,
+    select_result: bool = False,
+    include_components: bool = True,
+    max_preview: int = 50,
+) -> Dict[str, Any]:
+    """Query, assign, and select material assignments on objects or mesh faces.
+
+    Operations:
+    - query: report shadingEngine and material assignments for an object
+    - assign: assign a material or shading group to an object or resolved faces
+    - select_by_material: select members of a material assignment on the object
+
+    This is the explicit Maya-style material assignment workflow: select faces,
+    assign them to a shading group, and inspect or reselect those assignments.
+    It complements region-based tools without encoding any product-specific
+    selection logic.
+    """
+    import maya.cmds as cmds
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return int(value)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(item) for item in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(item) for item in values]
+
+    def _mesh_shape(node):
+        if not cmds.objExists(node):
+            raise ValueError(f"Object does not exist: {node}")
+        if cmds.objectType(node) == "mesh":
+            return node
+        shapes = cmds.listRelatives(node, shapes=True, fullPath=True) or []
+        mesh_shapes = []
+        for shape in shapes:
+            if cmds.objectType(shape) != "mesh":
+                continue
+            try:
+                if cmds.attributeQuery("intermediateObject", node=shape, exists=True) and cmds.getAttr(f"{shape}.intermediateObject"):
+                    continue
+            except Exception:
+                pass
+            mesh_shapes.append(shape)
+        if not mesh_shapes:
+            raise ValueError(f"{node} is not a polygon mesh transform or mesh shape.")
+        return mesh_shapes[0]
+
+    def _prefix(shape):
+        parents = cmds.listRelatives(shape, parent=True, fullPath=False) or []
+        return parents[0] if parents else object_name
+
+    def _flatten(value):
+        if value is None:
+            return []
+        if isinstance(value, str):
+            value = [value]
+        if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+            raise ValueError("components must be a string, a list of strings, or None.")
+        return cmds.ls(value, flatten=True) or []
+
+    def _unique(items):
+        result = []
+        seen = set()
+        for item in cmds.ls(items, flatten=True) or []:
+            if item not in seen:
+                seen.add(item)
+                result.append(item)
+        return result
+
+    def _selected_components():
+        if not use_selection:
+            return []
+        selected = cmds.ls(selection=True, flatten=True) or []
+        object_tokens = {object_name, prefix_name, shape_name}
+        return [item for item in selected if item.split(".", 1)[0] in object_tokens]
+
+    def _components_from_indices(kind):
+        if indices is None:
+            return []
+        if not isinstance(indices, list) or not all(isinstance(index, int) and not isinstance(index, bool) for index in indices):
+            raise ValueError("indices must be a list of integers.")
+        return [f"{prefix_name}.{kind}[{index}]" for index in indices]
+
+    def _resolve_components():
+        scope = str(assign_scope or "components").lower().strip()
+        if scope == "all":
+            return [object_name]
+        if scope != "components":
+            raise ValueError("assign_scope must be components or all.")
+        clean_type = (component_type or "face").lower().strip()
+        kind_map = {"vertex": "vtx", "edge": "e", "face": "f", "uv": "map", "vertex_face": "vtxFace"}
+        if components is not None:
+            resolved = _flatten(components)
+        elif clean_type in kind_map and indices is not None:
+            resolved = _components_from_indices(kind_map[clean_type])
+        else:
+            resolved = _selected_components()
+        if not resolved:
+            raise ValueError("No components resolved from components, indices, or current selection.")
+        faces = cmds.polyListComponentConversion(resolved, toFace=True) or []
+        faces = _unique(faces)
+        if not faces:
+            raise ValueError("Material component assignment requires faces or components convertible to faces.")
+        return faces
+
+    def _surface_materials(shading_group):
+        materials = []
+        for plug in ["surfaceShader", "aiSurfaceShader"]:
+            if cmds.attributeQuery(plug, node=shading_group, exists=True):
+                materials.extend(cmds.listConnections(f"{shading_group}.{plug}", source=True, destination=False) or [])
+        return list(dict.fromkeys(materials))
+
+    def _filtered_members(shading_group):
+        if not include_components:
+            return []
+        members = cmds.sets(shading_group, query=True) or []
+        prefixes = [object_name, shape_name, prefix_name]
+        filtered = []
+        for member in members:
+            flattened = cmds.ls(member, flatten=True) or [member]
+            for item in flattened:
+                clean_item = item.split("|")[-1]
+                if any(clean_item == prefix or clean_item.startswith(f"{prefix}.") for prefix in prefixes if prefix):
+                    filtered.append(clean_item)
+        return list(dict.fromkeys(filtered))
+
+    def _assignment_summary():
+        shading_groups = list(dict.fromkeys(cmds.listConnections(shape_name, type="shadingEngine") or []))
+        assignments = []
+        for shading_group in shading_groups:
+            members = _filtered_members(shading_group)
+            assignments.append({
+                "shading_group": shading_group,
+                "materials": _surface_materials(shading_group),
+                "member_count": len(members),
+                "members_preview": members[:max_preview],
+            })
+        return assignments
+
+    def _set_attr_if_exists(node, attr, value):
+        if not cmds.attributeQuery(attr, node=node, exists=True):
+            return False
+        if isinstance(value, list) and len(value) == 3 and all(_is_number(item) for item in value):
+            attr_type = cmds.getAttr(f"{node}.{attr}", type=True)
+            if attr_type in {"double3", "float3"}:
+                cmds.setAttr(f"{node}.{attr}", float(value[0]), float(value[1]), float(value[2]), type=attr_type)
+            else:
+                cmds.setAttr(f"{node}.{attr}", float(value[0]), float(value[1]), float(value[2]))
+        else:
+            cmds.setAttr(f"{node}.{attr}", value)
+        return True
+
+    def _create_material(shader_name, sg_name=None):
+        shader_type = str(material_type or "lambert").strip()
+        clean_type = shader_type.lower()
+        type_map = {
+            "lambert": "lambert",
+            "phong": "phong",
+            "blinn": "blinn",
+            "surface_shader": "surfaceShader",
+            "surfaceshader": "surfaceShader",
+            "ai_standard_surface": "aiStandardSurface",
+            "aistandardsurface": "aiStandardSurface",
+        }
+        if clean_type not in type_map:
+            raise ValueError("material_type must be lambert, phong, blinn, surface_shader, or ai_standard_surface.")
+        node_type = type_map[clean_type]
+        shader = cmds.shadingNode(node_type, asShader=True, name=shader_name)
+        color = _validate_vector(material_color if material_color is not None else [0.5, 0.5, 0.5], 3, "material_color")
+        if not _set_attr_if_exists(shader, "color", color):
+            _set_attr_if_exists(shader, "baseColor", color)
+        if node_type == "aiStandardSurface":
+            _set_attr_if_exists(shader, "base", 1.0)
+        for attr, value in (material_parameters or {}).items():
+            _set_attr_if_exists(shader, attr, value)
+        shading_group = cmds.sets(name=sg_name or f"{shader}SG", empty=True, renderable=True, noSurfaceShader=True)
+        output_attr = "outColor" if cmds.attributeQuery("outColor", node=shader, exists=True) else "outValue"
+        cmds.connectAttr(f"{shader}.{output_attr}", f"{shading_group}.surfaceShader", force=True)
+        return shader, shading_group, True
+
+    def _material_to_shading_group(shader):
+        groups = cmds.listConnections(shader, type="shadingEngine") or []
+        if groups:
+            return groups[0], False
+        shading_group = cmds.sets(name=f"{shader}SG", empty=True, renderable=True, noSurfaceShader=True)
+        output_attr = "outColor" if cmds.attributeQuery("outColor", node=shader, exists=True) else "outValue"
+        cmds.connectAttr(f"{shader}.{output_attr}", f"{shading_group}.surfaceShader", force=True)
+        return shading_group, True
+
+    def _resolve_shading_group():
+        if shading_group_name:
+            if cmds.objExists(shading_group_name):
+                if cmds.objectType(shading_group_name) != "shadingEngine":
+                    raise ValueError(f"{shading_group_name} is not a shadingEngine.")
+                return None, shading_group_name, False
+            if not create_if_missing:
+                raise ValueError(f"Shading group does not exist: {shading_group_name}")
+            shader_name = material_name or f"{shading_group_name}_mat"
+            return _create_material(shader_name, shading_group_name)
+        if material_name:
+            if cmds.objExists(material_name):
+                shading_group, created_group = _material_to_shading_group(material_name)
+                return material_name, shading_group, created_group
+            if not create_if_missing:
+                raise ValueError(f"Material does not exist: {material_name}")
+            return _create_material(material_name)
+        if not create_if_missing:
+            raise ValueError("material_name or shading_group_name is required when create_if_missing is false.")
+        return _create_material(f"{prefix_name}_mat")
+
+    if not object_name:
+        raise ValueError("object_name is required.")
+    if not operation:
+        raise ValueError("operation is required.")
+    operation = operation.lower().strip()
+    if operation not in {"query", "assign", "select_by_material"}:
+        raise ValueError("operation must be query, assign, or select_by_material.")
+    max_preview = _validate_int(max_preview, "max_preview", 1)
+    material_parameters = material_parameters or {}
+    shape_name = _mesh_shape(object_name)
+    prefix_name = _prefix(shape_name)
+
+    if operation == "query":
+        return {
+            "success": True,
+            "object_name": object_name,
+            "shape_name": shape_name,
+            "operation": operation,
+            "assignments": _assignment_summary(),
+        }
+
+    material, shading_group, created = _resolve_shading_group()
+
+    if operation == "select_by_material":
+        members = _filtered_members(shading_group)
+        if not members:
+            raise RuntimeError(f"No members from {shading_group} found on {object_name}.")
+        cmds.select(members, replace=True)
+        return {
+            "success": True,
+            "object_name": object_name,
+            "shape_name": shape_name,
+            "operation": operation,
+            "material": material,
+            "shading_group": shading_group,
+            "selected_count": len(members),
+            "selected_preview": members[:max_preview],
+        }
+
+    before = _assignment_summary()
+    targets = _resolve_components()
+    cmds.sets(targets, edit=True, forceElement=shading_group)
+    if select_result:
+        cmds.select(targets, replace=True)
+    after = _assignment_summary()
+    return {
+        "success": True,
+        "object_name": object_name,
+        "shape_name": shape_name,
+        "operation": operation,
+        "assign_scope": assign_scope,
+        "material": material,
+        "shading_group": shading_group,
+        "created_material_or_group": bool(created),
+        "assigned_count": len(targets),
+        "assigned_preview": targets[:max_preview],
+        "selected": bool(select_result),
+        "assignments_before": before,
+        "assignments_after": after,
+    }

--- a/src/mayatools/material/edit_material_properties.py
+++ b/src/mayatools/material/edit_material_properties.py
@@ -1,0 +1,264 @@
+from typing import Dict, List, Any, Union
+
+
+def edit_material_properties(
+    operation: str = "query",
+    material_names: Union[str, List[str]] = None,
+    object_names: Union[str, List[str]] = None,
+    attributes: List[str] = None,
+    parameters: Dict[str, Any] = None,
+    disconnect_existing: bool = False,
+    skip_missing: bool = True,
+    include_connections: bool = True,
+    max_preview: int = 100,
+) -> Dict[str, Any]:
+    """Query or set existing Maya material node attributes in batches.
+
+    Materials can be provided directly with material_names or resolved from
+    object_names through their shadingEngine assignments. This is a generic
+    material-editing workflow for inspecting and adjusting shader properties,
+    transparency, PBR controls, texture utility values, and other dependency
+    graph material attributes without recreating the material network.
+    """
+    import maya.cmds as cmds
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return int(value)
+
+    def _as_list(value, arg_name):
+        if value is None:
+            return []
+        if isinstance(value, str):
+            return [value]
+        if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+            raise ValueError(f"{arg_name} must be a string, list of strings, or None.")
+        return value
+
+    def _unique(values):
+        result = []
+        seen = set()
+        for value in values:
+            if value in seen:
+                continue
+            seen.add(value)
+            result.append(value)
+        return result
+
+    def _surface_materials(shading_group):
+        materials = []
+        for plug in ["surfaceShader", "aiSurfaceShader", "volumeShader", "displacementShader"]:
+            if cmds.attributeQuery(plug, node=shading_group, exists=True):
+                materials.extend(cmds.listConnections(f"{shading_group}.{plug}", source=True, destination=False) or [])
+        return materials
+
+    def _renderable_shapes(node):
+        if cmds.objectType(node, isAType="shape"):
+            return [node]
+        return cmds.listRelatives(node, shapes=True, fullPath=False) or []
+
+    def _materials_from_objects(objects):
+        materials = []
+        for obj in objects:
+            if not cmds.objExists(obj):
+                raise ValueError(f"Object does not exist: {obj}")
+            for shape in _renderable_shapes(obj):
+                try:
+                    if cmds.attributeQuery("intermediateObject", node=shape, exists=True) and cmds.getAttr(f"{shape}.intermediateObject"):
+                        continue
+                except Exception:
+                    pass
+                for shading_group in cmds.listConnections(shape, type="shadingEngine") or []:
+                    materials.extend(_surface_materials(shading_group))
+        return materials
+
+    def _resolve_materials():
+        direct = _as_list(material_names, "material_names")
+        objects = _as_list(object_names, "object_names")
+        for material in direct:
+            if not cmds.objExists(material):
+                raise ValueError(f"Material node does not exist: {material}")
+        resolved = direct + _materials_from_objects(objects)
+        resolved = _unique(resolved)
+        if not resolved:
+            raise ValueError("No materials resolved from material_names or object_names.")
+        return resolved
+
+    def _default_attributes(node):
+        common = [
+            "color",
+            "baseColor",
+            "transparency",
+            "opacity",
+            "ambientColor",
+            "incandescence",
+            "diffuse",
+            "specular",
+            "specularColor",
+            "specularRoughness",
+            "roughness",
+            "eccentricity",
+            "reflectivity",
+            "metalness",
+            "transmission",
+            "transmissionColor",
+            "specularIOR",
+            "ior",
+            "coat",
+            "coatRoughness",
+            "thinWalled",
+            "emission",
+            "emissionColor",
+        ]
+        return [attr for attr in common if cmds.attributeQuery(attr, node=node, exists=True)]
+
+    def _connections_for(node, attr):
+        if not include_connections:
+            return []
+        raw = cmds.listConnections(
+            f"{node}.{attr}",
+            source=True,
+            destination=True,
+            plugs=True,
+            connections=True,
+        ) or []
+        pairs = []
+        for index in range(0, len(raw), 2):
+            pairs.append(
+                {
+                    "plug": raw[index],
+                    "connected_plug": raw[index + 1] if index + 1 < len(raw) else None,
+                }
+            )
+        return pairs[:max_preview]
+
+    def _attr_value(node, attr):
+        value = cmds.getAttr(f"{node}.{attr}")
+        if isinstance(value, list) and len(value) == 1:
+            value = value[0]
+        return value
+
+    def _attr_record(node, attr):
+        if not cmds.attributeQuery(attr, node=node, exists=True):
+            return {"attribute": attr, "exists": False}
+        record = {
+            "attribute": attr,
+            "exists": True,
+            "type": cmds.getAttr(f"{node}.{attr}", type=True),
+            "settable": bool(cmds.getAttr(f"{node}.{attr}", settable=True)),
+            "locked": bool(cmds.getAttr(f"{node}.{attr}", lock=True)),
+            "value": None,
+            "connections": _connections_for(node, attr),
+        }
+        try:
+            record["value"] = _attr_value(node, attr)
+        except Exception as exc:
+            record["value_error"] = str(exc)
+        return record
+
+    def _disconnect_inputs(node, attr):
+        plugs = [f"{node}.{attr}"]
+        if cmds.attributeQuery(attr, node=node, exists=True):
+            children = cmds.attributeQuery(attr, node=node, listChildren=True) or []
+            plugs.extend(f"{node}.{child}" for child in children)
+        disconnected = []
+        for plug in plugs:
+            for source in cmds.listConnections(plug, source=True, destination=False, plugs=True) or []:
+                try:
+                    cmds.disconnectAttr(source, plug)
+                    disconnected.append({"source": source, "destination": plug})
+                except Exception:
+                    pass
+        return disconnected
+
+    def _set_attr(node, attr, value):
+        if not cmds.attributeQuery(attr, node=node, exists=True):
+            if skip_missing:
+                return {"attribute": attr, "skipped": True, "reason": "missing"}
+            raise ValueError(f"Attribute {attr} does not exist on {node}.")
+        before = _attr_record(node, attr)
+        attr_type = before.get("type")
+        disconnected = _disconnect_inputs(node, attr) if disconnect_existing else []
+        plug = f"{node}.{attr}"
+        try:
+            if attr_type in {"double3", "float3"}:
+                if not isinstance(value, list) or len(value) != 3 or not all(_is_number(item) for item in value):
+                    raise ValueError(f"{attr} requires a list of three numeric values.")
+                cmds.setAttr(plug, float(value[0]), float(value[1]), float(value[2]), type=attr_type)
+            elif attr_type == "string":
+                cmds.setAttr(plug, str(value), type="string")
+            elif attr_type == "bool":
+                cmds.setAttr(plug, bool(value))
+            elif attr_type == "enum":
+                if isinstance(value, str):
+                    enums = (cmds.attributeQuery(attr, node=node, listEnum=True) or [""])[0].split(":")
+                    if value not in enums:
+                        raise ValueError(f"{attr} enum value must be one of {enums}.")
+                    cmds.setAttr(plug, enums.index(value))
+                else:
+                    cmds.setAttr(plug, int(value))
+            elif _is_number(value):
+                cmds.setAttr(plug, float(value))
+            elif isinstance(value, list) and len(value) == 3 and all(_is_number(item) for item in value):
+                cmds.setAttr(plug, float(value[0]), float(value[1]), float(value[2]))
+            else:
+                cmds.setAttr(plug, value)
+        except Exception as exc:
+            raise RuntimeError(f"Unable to set {plug}: {exc}")
+        after = _attr_record(node, attr)
+        return {
+            "attribute": attr,
+            "skipped": False,
+            "before": before,
+            "after": after,
+            "disconnected_connections": disconnected,
+        }
+
+    clean_operation = (operation or "").lower().strip()
+    if clean_operation not in {"query", "set"}:
+        raise ValueError("operation must be query or set.")
+    max_preview = _validate_int(max_preview, "max_preview", 1)
+    parameters = parameters or {}
+    if attributes is not None and (not isinstance(attributes, list) or not all(isinstance(item, str) for item in attributes)):
+        raise ValueError("attributes must be a list of strings or None.")
+
+    materials = _resolve_materials()
+    material_results = []
+    for material in materials:
+        attrs_to_query = attributes if attributes is not None else _default_attributes(material)
+        if clean_operation == "query":
+            material_results.append(
+                {
+                    "material": material,
+                    "node_type": cmds.objectType(material),
+                    "attributes": [_attr_record(material, attr) for attr in attrs_to_query],
+                }
+            )
+            continue
+        set_results = []
+        for attr, value in parameters.items():
+            set_results.append(_set_attr(material, attr, value))
+        query_after = attributes if attributes is not None else list(dict.fromkeys(list(parameters) + _default_attributes(material)))
+        material_results.append(
+            {
+                "material": material,
+                "node_type": cmds.objectType(material),
+                "set_results": set_results,
+                "attributes_after": [_attr_record(material, attr) for attr in query_after],
+            }
+        )
+
+    return {
+        "success": True,
+        "operation": clean_operation,
+        "materials": materials,
+        "material_count": len(materials),
+        "disconnect_existing": bool(disconnect_existing),
+        "skip_missing": bool(skip_missing),
+        "include_connections": bool(include_connections),
+        "results": material_results,
+    }

--- a/src/mayatools/material/extract_image_detail_mask.py
+++ b/src/mayatools/material/extract_image_detail_mask.py
@@ -1,0 +1,357 @@
+from typing import Dict, List, Any
+
+
+def extract_image_detail_mask(
+    image_path: str,
+    output_path: str = None,
+    bbox_pixels: List[float] = None,
+    bbox_normalized: List[float] = None,
+    padding_pixels: int = 0,
+    output_width: int = 0,
+    output_height: int = 0,
+    stretch_to_output: bool = True,
+    horizontal_remap: str = "none",
+    source_arc_degrees: float = 120.0,
+    remap_center_x: float = 0.5,
+    detail_mode: str = "dark",
+    blur_radius: int = 8,
+    threshold: float = 0.08,
+    threshold_softness: float = 0.08,
+    contrast: float = 4.0,
+    gamma: float = 1.0,
+    invert_output: bool = False,
+    output_alpha: bool = False,
+    overwrite: bool = True,
+) -> Dict[str, Any]:
+    """Extract a grayscale detail mask from a reference image region.
+
+    The tool removes broad lighting gradients with a local blur and keeps local
+    dark details, bright details, absolute contrast, or edge magnitude. It is
+    intended to prepare generic masks for photo-driven relief, emboss/deboss,
+    texture cleanup, decal isolation, grip-dot fields, stamped text, scratches,
+    dents, and other localized details before using them as texture or
+    deformation input.
+    """
+    import math
+    import os
+
+    try:
+        from PySide6.QtCore import Qt
+        from PySide6.QtGui import QImage, QColor
+    except Exception:
+        try:
+            from PySide2.QtCore import Qt
+            from PySide2.QtGui import QImage, QColor
+        except Exception as exc:
+            raise RuntimeError("PySide QImage is required to extract image detail masks in Maya.") from exc
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(v) for v in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(value) for value in values]
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return value
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _clamp(value, lower=0.0, upper=1.0):
+        return max(lower, min(upper, value))
+
+    def _smoothstep(edge0, edge1, value):
+        if abs(edge1 - edge0) <= 1e-9:
+            return 1.0 if value >= edge1 else 0.0
+        t = _clamp((value - edge0) / (edge1 - edge0))
+        return t * t * (3.0 - 2.0 * t)
+
+    def _pixel_rgb_alpha(image, x, y):
+        color = image.pixelColor(int(x), int(y))
+        return [color.redF(), color.greenF(), color.blueF(), color.alphaF()]
+
+    def _luminance(image, x, y):
+        red, green, blue, _ = _pixel_rgb_alpha(image, x, y)
+        return 0.2126 * red + 0.7152 * green + 0.0722 * blue
+
+    def _make_gray(value, alpha_value=1.0):
+        color = QColor()
+        if output_alpha:
+            color.setRgbF(1.0, 1.0, 1.0, _clamp(alpha_value))
+        else:
+            color.setRgbF(_clamp(value), _clamp(value), _clamp(value), 1.0)
+        return color
+
+    def _sample_bilinear(image, x, y):
+        width = image.width()
+        height = image.height()
+        x = max(0.0, min(float(width - 1), x))
+        y = max(0.0, min(float(height - 1), y))
+        x0 = int(math.floor(x))
+        y0 = int(math.floor(y))
+        x1 = min(width - 1, x0 + 1)
+        y1 = min(height - 1, y0 + 1)
+        tx = x - x0
+        ty = y - y0
+        c00 = _pixel_rgb_alpha(image, x0, y0)
+        c10 = _pixel_rgb_alpha(image, x1, y0)
+        c01 = _pixel_rgb_alpha(image, x0, y1)
+        c11 = _pixel_rgb_alpha(image, x1, y1)
+        channels = []
+        for index in range(4):
+            top = c00[index] * (1.0 - tx) + c10[index] * tx
+            bottom = c01[index] * (1.0 - tx) + c11[index] * tx
+            channels.append(top * (1.0 - ty) + bottom * ty)
+        color = QColor()
+        color.setRgbF(_clamp(channels[0]), _clamp(channels[1]), _clamp(channels[2]), _clamp(channels[3]))
+        return color
+
+    def _remap_cylindrical_front(image, target_width, target_height, arc_degrees, center_x):
+        arc_radians = math.radians(arc_degrees)
+        half_arc = arc_radians * 0.5
+        sin_half_arc = math.sin(half_arc)
+        if sin_half_arc <= 1e-9:
+            raise ValueError("source_arc_degrees is too small for cylindrical_front remap.")
+        source_width = image.width()
+        source_height = image.height()
+        projected_center = center_x * float(source_width - 1)
+        left_span = max(1e-9, projected_center)
+        right_span = max(1e-9, float(source_width - 1) - projected_center)
+        remapped = QImage(target_width, target_height, QImage.Format_ARGB32)
+        remapped.fill(QColor(0, 0, 0, 0))
+        for y in range(target_height):
+            v = 0.0 if target_height == 1 else y / float(target_height - 1)
+            source_y = v * float(source_height - 1)
+            for x in range(target_width):
+                u = 0.0 if target_width == 1 else x / float(target_width - 1)
+                theta = (u - 0.5) * arc_radians
+                projected = math.sin(theta) / sin_half_arc
+                if projected < 0.0:
+                    source_x = projected_center + projected * left_span
+                else:
+                    source_x = projected_center + projected * right_span
+                remapped.setPixelColor(x, y, _sample_bilinear(image, source_x, source_y))
+        return remapped
+
+    def _scale_keep_aspect(image, target_width, target_height):
+        scaled = image.scaled(target_width, target_height, Qt.KeepAspectRatio, Qt.SmoothTransformation)
+        canvas = QImage(target_width, target_height, QImage.Format_ARGB32)
+        canvas.fill(QColor(0, 0, 0, 0))
+        try:
+            from PySide6.QtGui import QPainter
+        except Exception:
+            from PySide2.QtGui import QPainter
+        painter = QPainter(canvas)
+        painter.drawImage(int((target_width - scaled.width()) * 0.5), int((target_height - scaled.height()) * 0.5), scaled)
+        painter.end()
+        return canvas
+
+    def _integral_image(values, width, height):
+        integral = [[0.0] * (width + 1) for _ in range(height + 1)]
+        for y in range(height):
+            row_sum = 0.0
+            row = values[y]
+            integral_row = integral[y + 1]
+            previous_integral_row = integral[y]
+            for x in range(width):
+                row_sum += row[x]
+                integral_row[x + 1] = previous_integral_row[x + 1] + row_sum
+        return integral
+
+    def _box_average(integral, x0, y0, x1, y1):
+        width = x1 - x0 + 1
+        height = y1 - y0 + 1
+        total = integral[y1 + 1][x1 + 1] - integral[y0][x1 + 1] - integral[y1 + 1][x0] + integral[y0][x0]
+        return total / float(width * height)
+
+    if not image_path:
+        raise ValueError("image_path is required.")
+    normalized_image_path = os.path.normpath(image_path)
+    if not os.path.isfile(normalized_image_path):
+        raise ValueError(f"Image path does not exist: {image_path}")
+    if bbox_pixels is None and bbox_normalized is None:
+        raise ValueError("bbox_pixels or bbox_normalized is required.")
+    if bbox_pixels is not None and bbox_normalized is not None:
+        raise ValueError("Provide only one of bbox_pixels or bbox_normalized.")
+
+    padding_pixels = _validate_int(padding_pixels, "padding_pixels", 0)
+    output_width = _validate_int(output_width, "output_width", 0)
+    output_height = _validate_int(output_height, "output_height", 0)
+    blur_radius = _validate_int(blur_radius, "blur_radius", 0)
+    threshold = _validate_scalar(threshold, "threshold")
+    threshold_softness = _validate_scalar(threshold_softness, "threshold_softness")
+    contrast = _validate_scalar(contrast, "contrast")
+    gamma = _validate_scalar(gamma, "gamma")
+    if threshold_softness < 0.0:
+        raise ValueError("threshold_softness must be greater than or equal to zero.")
+    if contrast < 0.0:
+        raise ValueError("contrast must be greater than or equal to zero.")
+    if gamma <= 0.0:
+        raise ValueError("gamma must be greater than zero.")
+
+    horizontal_remap = horizontal_remap.lower().strip()
+    if horizontal_remap not in {"none", "cylindrical_front"}:
+        raise ValueError("horizontal_remap must be one of none or cylindrical_front.")
+    source_arc_degrees = _validate_scalar(source_arc_degrees, "source_arc_degrees")
+    if source_arc_degrees <= 0.0 or source_arc_degrees >= 180.0:
+        raise ValueError("source_arc_degrees must be greater than 0 and less than 180.")
+    remap_center_x = _validate_scalar(remap_center_x, "remap_center_x")
+    if remap_center_x <= 0.0 or remap_center_x >= 1.0:
+        raise ValueError("remap_center_x must be greater than 0 and less than 1.")
+    detail_mode = detail_mode.lower().strip()
+    if detail_mode not in {"dark", "bright", "absolute", "edge"}:
+        raise ValueError("detail_mode must be one of dark, bright, absolute, or edge.")
+
+    image = QImage(normalized_image_path)
+    if image.isNull():
+        raise ValueError(f"Unable to load image: {image_path}")
+    source_width = image.width()
+    source_height = image.height()
+    if source_width < 2 or source_height < 2:
+        raise ValueError("image must be at least 2x2 pixels.")
+
+    if bbox_normalized is not None:
+        bbox = _validate_vector(bbox_normalized, 4, "bbox_normalized")
+        if bbox[2] <= bbox[0] or bbox[3] <= bbox[1]:
+            raise ValueError("bbox_normalized must be [min_x, min_y, max_x, max_y].")
+        x_min = int(round(_clamp(bbox[0]) * (source_width - 1)))
+        y_min = int(round(_clamp(bbox[1]) * (source_height - 1)))
+        x_max = int(round(_clamp(bbox[2]) * (source_width - 1)))
+        y_max = int(round(_clamp(bbox[3]) * (source_height - 1)))
+    else:
+        bbox = _validate_vector(bbox_pixels, 4, "bbox_pixels")
+        if bbox[2] <= bbox[0] or bbox[3] <= bbox[1]:
+            raise ValueError("bbox_pixels must be [min_x, min_y, max_x, max_y].")
+        x_min = int(round(bbox[0]))
+        y_min = int(round(bbox[1]))
+        x_max = int(round(bbox[2]))
+        y_max = int(round(bbox[3]))
+
+    x_min = max(0, min(source_width - 1, x_min - padding_pixels))
+    y_min = max(0, min(source_height - 1, y_min - padding_pixels))
+    x_max = max(0, min(source_width - 1, x_max + padding_pixels))
+    y_max = max(0, min(source_height - 1, y_max + padding_pixels))
+    if x_max <= x_min or y_max <= y_min:
+        raise ValueError("Resolved crop bbox is empty.")
+
+    crop_width = x_max - x_min + 1
+    crop_height = y_max - y_min + 1
+    cropped = image.copy(x_min, y_min, crop_width, crop_height).convertToFormat(QImage.Format_ARGB32)
+    final_width = output_width or cropped.width()
+    final_height = output_height or cropped.height()
+    if output_width or output_height:
+        if output_width == 0:
+            final_width = max(1, int(round(cropped.width() * (output_height / float(cropped.height())))))
+        if output_height == 0:
+            final_height = max(1, int(round(cropped.height() * (output_width / float(cropped.width())))))
+        if horizontal_remap == "cylindrical_front":
+            cropped = _remap_cylindrical_front(cropped, final_width, final_height, source_arc_degrees, remap_center_x)
+        elif stretch_to_output:
+            cropped = cropped.scaled(final_width, final_height, Qt.IgnoreAspectRatio, Qt.SmoothTransformation)
+        else:
+            cropped = _scale_keep_aspect(cropped, final_width, final_height)
+    elif horizontal_remap == "cylindrical_front":
+        cropped = _remap_cylindrical_front(cropped, final_width, final_height, source_arc_degrees, remap_center_x)
+
+    width = cropped.width()
+    height = cropped.height()
+    luminance = [[_luminance(cropped, x, y) for x in range(width)] for y in range(height)]
+    integral = _integral_image(luminance, width, height)
+    output = QImage(width, height, QImage.Format_ARGB32)
+    output.fill(QColor(0, 0, 0, 0 if output_alpha else 255))
+
+    raw_min = None
+    raw_max = None
+    mask_min = None
+    mask_max = None
+    mask_total = 0.0
+    active_pixels = 0
+    for y in range(height):
+        for x in range(width):
+            value = luminance[y][x]
+            if detail_mode == "edge":
+                left = luminance[y][max(0, x - 1)]
+                right = luminance[y][min(width - 1, x + 1)]
+                up = luminance[max(0, y - 1)][x]
+                down = luminance[min(height - 1, y + 1)][x]
+                raw = math.sqrt((right - left) * (right - left) + (down - up) * (down - up))
+            else:
+                x0 = max(0, x - blur_radius)
+                y0 = max(0, y - blur_radius)
+                x1 = min(width - 1, x + blur_radius)
+                y1 = min(height - 1, y + blur_radius)
+                local_average = _box_average(integral, x0, y0, x1, y1)
+                if detail_mode == "dark":
+                    raw = local_average - value
+                elif detail_mode == "bright":
+                    raw = value - local_average
+                else:
+                    raw = abs(value - local_average)
+            raw = max(0.0, raw) * contrast
+            raw_min = raw if raw_min is None else min(raw_min, raw)
+            raw_max = raw if raw_max is None else max(raw_max, raw)
+            if threshold_softness <= 0.0:
+                mask_value = 1.0 if raw >= threshold else 0.0
+            else:
+                mask_value = _smoothstep(threshold - threshold_softness * 0.5, threshold + threshold_softness * 0.5, raw)
+            if gamma != 1.0:
+                mask_value = mask_value ** gamma
+            if invert_output:
+                mask_value = 1.0 - mask_value
+            mask_value = _clamp(mask_value)
+            if mask_value > 0.001:
+                active_pixels += 1
+            mask_total += mask_value
+            mask_min = mask_value if mask_min is None else min(mask_min, mask_value)
+            mask_max = mask_value if mask_max is None else max(mask_max, mask_value)
+            output.setPixelColor(x, y, _make_gray(mask_value, mask_value))
+
+    if output_path is None:
+        base_name = os.path.splitext(os.path.basename(normalized_image_path))[0] or "image"
+        output_path = os.path.join(os.path.dirname(normalized_image_path), f"{base_name}_detail_mask.png")
+    normalized_output_path = os.path.normpath(output_path)
+    if not os.path.splitext(normalized_output_path)[1]:
+        normalized_output_path += ".png"
+    output_dir = os.path.dirname(normalized_output_path)
+    if output_dir and not os.path.isdir(output_dir):
+        os.makedirs(output_dir)
+    if os.path.exists(normalized_output_path) and not overwrite:
+        raise ValueError(f"Output path already exists: {output_path}")
+    if not output.save(normalized_output_path):
+        raise RuntimeError(f"Failed to save detail mask: {output_path}")
+
+    return {
+        "success": True,
+        "image_path": normalized_image_path,
+        "output_path": normalized_output_path,
+        "source_image_width": source_width,
+        "source_image_height": source_height,
+        "crop_bbox_pixels": [x_min, y_min, x_max, y_max],
+        "crop_width": crop_width,
+        "crop_height": crop_height,
+        "output_width": width,
+        "output_height": height,
+        "horizontal_remap": horizontal_remap,
+        "source_arc_degrees": source_arc_degrees,
+        "remap_center_x": remap_center_x,
+        "detail_mode": detail_mode,
+        "blur_radius": blur_radius,
+        "threshold": threshold,
+        "threshold_softness": threshold_softness,
+        "contrast": contrast,
+        "gamma": gamma,
+        "invert_output": bool(invert_output),
+        "output_alpha": bool(output_alpha),
+        "raw_min": raw_min if raw_min is not None else 0.0,
+        "raw_max": raw_max if raw_max is not None else 0.0,
+        "mask_min": mask_min if mask_min is not None else 0.0,
+        "mask_max": mask_max if mask_max is not None else 0.0,
+        "mask_mean": mask_total / float(max(1, width * height)),
+        "active_pixels": active_pixels,
+    }

--- a/src/mayatools/material/extract_image_matte_texture.py
+++ b/src/mayatools/material/extract_image_matte_texture.py
@@ -1,0 +1,519 @@
+from typing import Dict, List, Any
+
+
+def extract_image_matte_texture(
+    image_path: str,
+    output_path: str = None,
+    bbox_pixels: List[float] = None,
+    bbox_normalized: List[float] = None,
+    padding_pixels: int = 0,
+    output_width: int = 0,
+    output_height: int = 0,
+    stretch_to_output: bool = True,
+    horizontal_remap: str = "none",
+    source_arc_degrees: float = 120.0,
+    remap_center_x: float = 0.5,
+    match_mode: str = "hue",
+    target_color: List[float] = None,
+    color_tolerance: float = 0.25,
+    hue_tolerance: float = 0.05,
+    saturation_min: float = 0.25,
+    value_min: float = 0.05,
+    alpha_threshold: float = 0.05,
+    background_color: List[float] = None,
+    background_tolerance: float = 0.06,
+    component_selection: str = "largest",
+    seed_pixels: List[float] = None,
+    seed_normalized: List[float] = None,
+    component_connectivity: int = 8,
+    min_component_pixels: int = 25,
+    matte_mode: str = "row_span",
+    matte_expand_pixels: int = 0,
+    overwrite: bool = True,
+) -> Dict[str, Any]:
+    """Extract a cropped texture with alpha matte derived from image regions.
+
+    The crop can be masked by RGB, hue, foreground, or source alpha. A connected
+    component is selected from the mask, then converted into an output matte as
+    exact matched pixels, per-row spans, or a component bbox. Row-span and bbox
+    mattes preserve all original colors inside the selected region, which is
+    useful for generic labels, decals, badges, signs, panels, patches, and
+    product graphics where internal artwork should remain opaque even when it
+    differs from the target color used to find the region.
+    """
+    import math
+    import os
+
+    try:
+        from PySide6.QtCore import Qt
+        from PySide6.QtGui import QImage, QColor, QPainter
+    except Exception:
+        try:
+            from PySide2.QtCore import Qt
+            from PySide2.QtGui import QImage, QColor, QPainter
+        except Exception as exc:
+            raise RuntimeError("PySide QImage is required to extract matte textures in Maya.") from exc
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(v) for v in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(value) for value in values]
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return value
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _clamp(value, lower=0.0, upper=1.0):
+        return max(lower, min(upper, value))
+
+    def _normalize_color(values, arg_name):
+        color = _validate_vector(values, 3, arg_name)
+        if max(color) > 1.0:
+            color = [value / 255.0 for value in color]
+        return [_clamp(value) for value in color]
+
+    def _pixel_rgb_alpha(image, x, y):
+        color = image.pixelColor(int(x), int(y))
+        return color.redF(), color.greenF(), color.blueF(), color.alphaF()
+
+    def _make_color(red, green, blue, alpha):
+        color = QColor()
+        color.setRgbF(_clamp(red), _clamp(green), _clamp(blue), _clamp(alpha))
+        return color
+
+    def _color_distance(a, b):
+        dr = a[0] - b[0]
+        dg = a[1] - b[1]
+        db = a[2] - b[2]
+        return (dr * dr + dg * dg + db * db) ** 0.5
+
+    def _rgb_to_hsv(red, green, blue):
+        max_value = max(red, green, blue)
+        min_value = min(red, green, blue)
+        delta = max_value - min_value
+        if delta == 0.0:
+            hue = 0.0
+        elif max_value == red:
+            hue = ((green - blue) / delta) % 6.0
+        elif max_value == green:
+            hue = ((blue - red) / delta) + 2.0
+        else:
+            hue = ((red - green) / delta) + 4.0
+        hue /= 6.0
+        saturation = 0.0 if max_value == 0.0 else delta / max_value
+        return hue, saturation, max_value
+
+    def _hue_distance(a, b):
+        direct = abs(a - b)
+        return min(direct, 1.0 - direct)
+
+    def _estimate_background(image):
+        width = image.width()
+        height = image.height()
+        sample_points = []
+        radius = max(1, min(width, height, 8))
+        corners = [
+            (0, 0),
+            (width - 1, 0),
+            (0, height - 1),
+            (width - 1, height - 1),
+        ]
+        for corner_x, corner_y in corners:
+            for dy in range(-radius, radius + 1):
+                for dx in range(-radius, radius + 1):
+                    x = max(0, min(width - 1, corner_x + dx))
+                    y = max(0, min(height - 1, corner_y + dy))
+                    sample_points.append(_pixel_rgb_alpha(image, x, y)[:3])
+        channels = []
+        for index in range(3):
+            values = sorted(point[index] for point in sample_points)
+            channels.append(values[len(values) // 2])
+        return channels
+
+    def _sample_bilinear(image, x, y):
+        width = image.width()
+        height = image.height()
+        x = max(0.0, min(float(width - 1), x))
+        y = max(0.0, min(float(height - 1), y))
+        x0 = int(math.floor(x))
+        y0 = int(math.floor(y))
+        x1 = min(width - 1, x0 + 1)
+        y1 = min(height - 1, y0 + 1)
+        tx = x - x0
+        ty = y - y0
+        c00 = _pixel_rgb_alpha(image, x0, y0)
+        c10 = _pixel_rgb_alpha(image, x1, y0)
+        c01 = _pixel_rgb_alpha(image, x0, y1)
+        c11 = _pixel_rgb_alpha(image, x1, y1)
+        channels = []
+        for index in range(4):
+            top = c00[index] * (1.0 - tx) + c10[index] * tx
+            bottom = c01[index] * (1.0 - tx) + c11[index] * tx
+            channels.append(top * (1.0 - ty) + bottom * ty)
+        return _make_color(channels[0], channels[1], channels[2], channels[3])
+
+    def _scale_keep_aspect(image, target_width, target_height):
+        scaled = image.scaled(target_width, target_height, Qt.KeepAspectRatio, Qt.SmoothTransformation)
+        canvas = QImage(target_width, target_height, QImage.Format_ARGB32)
+        canvas.fill(QColor(0, 0, 0, 0))
+        painter = QPainter(canvas)
+        offset_x = int((target_width - scaled.width()) * 0.5)
+        offset_y = int((target_height - scaled.height()) * 0.5)
+        painter.drawImage(offset_x, offset_y, scaled)
+        painter.end()
+        return canvas
+
+    def _remap_cylindrical_front(image, target_width, target_height, arc_degrees, center_x):
+        arc_radians = math.radians(arc_degrees)
+        half_arc = arc_radians * 0.5
+        sin_half_arc = math.sin(half_arc)
+        if sin_half_arc <= 1e-9:
+            raise ValueError("source_arc_degrees is too small for cylindrical_front remap.")
+        source_width = image.width()
+        source_height = image.height()
+        projected_center = center_x * float(source_width - 1)
+        left_span = max(1e-9, projected_center)
+        right_span = max(1e-9, float(source_width - 1) - projected_center)
+        remapped = QImage(target_width, target_height, QImage.Format_ARGB32)
+        remapped.fill(QColor(0, 0, 0, 0))
+        for y in range(target_height):
+            v = 0.0 if target_height == 1 else y / float(target_height - 1)
+            source_y = v * float(source_height - 1)
+            for x in range(target_width):
+                u = 0.0 if target_width == 1 else x / float(target_width - 1)
+                theta = (u - 0.5) * arc_radians
+                projected = math.sin(theta) / sin_half_arc
+                if projected < 0.0:
+                    source_x = projected_center + projected * left_span
+                else:
+                    source_x = projected_center + projected * right_span
+                remapped.setPixelColor(x, y, _sample_bilinear(image, source_x, source_y))
+        return remapped
+
+    def _build_match_mask(image, mode):
+        width = image.width()
+        height = image.height()
+        matched = [bytearray(width) for _ in range(height)]
+        matched_count = 0
+        for y in range(height):
+            row = matched[y]
+            for x in range(width):
+                red, green, blue, alpha = _pixel_rgb_alpha(image, x, y)
+                if alpha < alpha_threshold:
+                    continue
+                rgb = [red, green, blue]
+                is_match = False
+                if mode == "alpha":
+                    is_match = alpha >= alpha_threshold
+                elif mode == "foreground":
+                    is_match = _color_distance(rgb, clean_background_color) > background_tolerance
+                elif mode == "rgb":
+                    is_match = _color_distance(rgb, clean_target_color) <= color_tolerance
+                elif mode == "hue":
+                    hue, saturation, value = _rgb_to_hsv(red, green, blue)
+                    is_match = (
+                        _hue_distance(hue, target_hsv[0]) <= hue_tolerance
+                        and saturation >= saturation_min
+                        and value >= value_min
+                    )
+                if is_match:
+                    row[x] = 1
+                    matched_count += 1
+        return matched, matched_count
+
+    def _find_components(mask, width, height):
+        visited = [bytearray(width) for _ in range(height)]
+        if component_connectivity == 4:
+            neighbors = [(-1, 0), (1, 0), (0, -1), (0, 1)]
+        else:
+            neighbors = [(-1, 0), (1, 0), (0, -1), (0, 1), (-1, -1), (1, -1), (-1, 1), (1, 1)]
+        components = []
+        for y in range(height):
+            for x in range(width):
+                if not mask[y][x] or visited[y][x]:
+                    continue
+                stack = [(x, y)]
+                visited[y][x] = 1
+                pixels = []
+                x_min = x_max = x
+                y_min = y_max = y
+                while stack:
+                    current_x, current_y = stack.pop()
+                    pixels.append((current_x, current_y))
+                    x_min = min(x_min, current_x)
+                    x_max = max(x_max, current_x)
+                    y_min = min(y_min, current_y)
+                    y_max = max(y_max, current_y)
+                    for dx, dy in neighbors:
+                        next_x = current_x + dx
+                        next_y = current_y + dy
+                        if next_x < 0 or next_x >= width or next_y < 0 or next_y >= height:
+                            continue
+                        if visited[next_y][next_x] or not mask[next_y][next_x]:
+                            continue
+                        visited[next_y][next_x] = 1
+                        stack.append((next_x, next_y))
+                if len(pixels) >= min_component_pixels:
+                    components.append({
+                        "pixels": pixels,
+                        "pixel_count": len(pixels),
+                        "bbox_pixels": [x_min, y_min, x_max, y_max],
+                        "width_pixels": x_max - x_min + 1,
+                        "height_pixels": y_max - y_min + 1,
+                    })
+        components.sort(key=lambda item: item["pixel_count"], reverse=True)
+        return components
+
+    def _select_component(components, width, height):
+        if not components:
+            return None
+        if component_selection == "seed":
+            if seed_pixels is None and seed_normalized is None:
+                raise ValueError("seed_pixels or seed_normalized is required when component_selection is seed.")
+            if seed_pixels is not None:
+                seed = _validate_vector(seed_pixels, 2, "seed_pixels")
+                seed_x = int(round(seed[0]))
+                seed_y = int(round(seed[1]))
+            else:
+                seed = _validate_vector(seed_normalized, 2, "seed_normalized")
+                seed_x = int(round(_clamp(seed[0]) * (width - 1)))
+                seed_y = int(round(_clamp(seed[1]) * (height - 1)))
+            for component in components:
+                x_min, y_min, x_max, y_max = component["bbox_pixels"]
+                if x_min <= seed_x <= x_max and y_min <= seed_y <= y_max:
+                    if (seed_x, seed_y) in set(component["pixels"]):
+                        return component
+            raise ValueError("No selected component contains the seed point.")
+        return components[0]
+
+    def _expanded_bbox(bbox, width, height):
+        return [
+            max(0, bbox[0] - matte_expand_pixels),
+            max(0, bbox[1] - matte_expand_pixels),
+            min(width - 1, bbox[2] + matte_expand_pixels),
+            min(height - 1, bbox[3] + matte_expand_pixels),
+        ]
+
+    def _component_to_alpha(component, width, height):
+        alpha = [bytearray(width) for _ in range(height)]
+        if component is None:
+            return alpha
+        if matte_mode == "match":
+            for x, y in component["pixels"]:
+                for yy in range(max(0, y - matte_expand_pixels), min(height - 1, y + matte_expand_pixels) + 1):
+                    for xx in range(max(0, x - matte_expand_pixels), min(width - 1, x + matte_expand_pixels) + 1):
+                        alpha[yy][xx] = 255
+        elif matte_mode == "bbox":
+            x_min, y_min, x_max, y_max = _expanded_bbox(component["bbox_pixels"], width, height)
+            for y in range(y_min, y_max + 1):
+                for x in range(x_min, x_max + 1):
+                    alpha[y][x] = 255
+        else:
+            row_bounds = {}
+            for x, y in component["pixels"]:
+                if y not in row_bounds:
+                    row_bounds[y] = [x, x]
+                else:
+                    row_bounds[y][0] = min(row_bounds[y][0], x)
+                    row_bounds[y][1] = max(row_bounds[y][1], x)
+            for y, bounds in row_bounds.items():
+                x_min = max(0, bounds[0] - matte_expand_pixels)
+                x_max = min(width - 1, bounds[1] + matte_expand_pixels)
+                y_min = max(0, y - matte_expand_pixels)
+                y_max = min(height - 1, y + matte_expand_pixels)
+                for yy in range(y_min, y_max + 1):
+                    for xx in range(x_min, x_max + 1):
+                        alpha[yy][xx] = 255
+        return alpha
+
+    def _apply_alpha(image, alpha):
+        for y in range(image.height()):
+            for x in range(image.width()):
+                color = image.pixelColor(x, y)
+                color.setAlpha(alpha[y][x])
+                image.setPixelColor(x, y, color)
+
+    if not image_path:
+        raise ValueError("image_path is required.")
+    normalized_image_path = os.path.normpath(image_path)
+    if not os.path.isfile(normalized_image_path):
+        raise ValueError(f"Image path does not exist: {image_path}")
+    if bbox_pixels is None and bbox_normalized is None:
+        raise ValueError("bbox_pixels or bbox_normalized is required.")
+    if bbox_pixels is not None and bbox_normalized is not None:
+        raise ValueError("Provide only one of bbox_pixels or bbox_normalized.")
+
+    padding_pixels = _validate_int(padding_pixels, "padding_pixels", 0)
+    output_width = _validate_int(output_width, "output_width", 0)
+    output_height = _validate_int(output_height, "output_height", 0)
+    matte_expand_pixels = _validate_int(matte_expand_pixels, "matte_expand_pixels", 0)
+    min_component_pixels = _validate_int(min_component_pixels, "min_component_pixels", 1)
+    component_connectivity = _validate_int(component_connectivity, "component_connectivity", 4)
+    if component_connectivity not in {4, 8}:
+        raise ValueError("component_connectivity must be 4 or 8.")
+
+    horizontal_remap = horizontal_remap.lower().strip()
+    if horizontal_remap not in {"none", "cylindrical_front"}:
+        raise ValueError("horizontal_remap must be one of none or cylindrical_front.")
+    source_arc_degrees = _validate_scalar(source_arc_degrees, "source_arc_degrees")
+    if source_arc_degrees <= 0.0 or source_arc_degrees >= 180.0:
+        raise ValueError("source_arc_degrees must be greater than 0 and less than 180.")
+    remap_center_x = _validate_scalar(remap_center_x, "remap_center_x")
+    if remap_center_x <= 0.0 or remap_center_x >= 1.0:
+        raise ValueError("remap_center_x must be greater than 0 and less than 1.")
+
+    match_mode = match_mode.lower().strip()
+    if match_mode not in {"rgb", "hue", "foreground", "alpha"}:
+        raise ValueError("match_mode must be one of rgb, hue, foreground, or alpha.")
+    component_selection = component_selection.lower().strip()
+    if component_selection not in {"largest", "seed"}:
+        raise ValueError("component_selection must be one of largest or seed.")
+    matte_mode = matte_mode.lower().strip()
+    if matte_mode not in {"match", "row_span", "bbox"}:
+        raise ValueError("matte_mode must be one of match, row_span, or bbox.")
+
+    color_tolerance = _validate_scalar(color_tolerance, "color_tolerance")
+    if color_tolerance > 1.0:
+        color_tolerance /= 255.0
+    color_tolerance = max(0.0, color_tolerance)
+    hue_tolerance = _validate_scalar(hue_tolerance, "hue_tolerance")
+    if hue_tolerance > 1.0:
+        hue_tolerance /= 360.0
+    if hue_tolerance < 0.0 or hue_tolerance > 0.5:
+        raise ValueError("hue_tolerance must be in 0..0.5 or degrees in 0..180.")
+    saturation_min = _clamp(_validate_scalar(saturation_min, "saturation_min"))
+    value_min = _clamp(_validate_scalar(value_min, "value_min"))
+    alpha_threshold = _clamp(_validate_scalar(alpha_threshold, "alpha_threshold"))
+    background_tolerance = _validate_scalar(background_tolerance, "background_tolerance")
+    if background_tolerance > 1.0:
+        background_tolerance /= 255.0
+    background_tolerance = max(0.0, background_tolerance)
+
+    image = QImage(normalized_image_path)
+    if image.isNull():
+        raise ValueError(f"Unable to load image: {image_path}")
+    image_width = image.width()
+    image_height = image.height()
+    if image_width < 2 or image_height < 2:
+        raise ValueError("image must be at least 2x2 pixels.")
+
+    if bbox_normalized is not None:
+        bbox = _validate_vector(bbox_normalized, 4, "bbox_normalized")
+        if bbox[2] <= bbox[0] or bbox[3] <= bbox[1]:
+            raise ValueError("bbox_normalized must be [min_x, min_y, max_x, max_y].")
+        x_min = int(round(_clamp(bbox[0]) * (image_width - 1)))
+        y_min = int(round(_clamp(bbox[1]) * (image_height - 1)))
+        x_max = int(round(_clamp(bbox[2]) * (image_width - 1)))
+        y_max = int(round(_clamp(bbox[3]) * (image_height - 1)))
+    else:
+        bbox = _validate_vector(bbox_pixels, 4, "bbox_pixels")
+        if bbox[2] <= bbox[0] or bbox[3] <= bbox[1]:
+            raise ValueError("bbox_pixels must be [min_x, min_y, max_x, max_y].")
+        x_min = int(round(bbox[0]))
+        y_min = int(round(bbox[1]))
+        x_max = int(round(bbox[2]))
+        y_max = int(round(bbox[3]))
+
+    x_min = max(0, min(image_width - 1, x_min - padding_pixels))
+    y_min = max(0, min(image_height - 1, y_min - padding_pixels))
+    x_max = max(0, min(image_width - 1, x_max + padding_pixels))
+    y_max = max(0, min(image_height - 1, y_max + padding_pixels))
+    if x_max <= x_min or y_max <= y_min:
+        raise ValueError("Resolved crop bbox is empty.")
+
+    cropped = image.copy(x_min, y_min, x_max - x_min + 1, y_max - y_min + 1).convertToFormat(QImage.Format_ARGB32)
+
+    clean_target_color = None
+    target_hsv = None
+    if match_mode in {"rgb", "hue"}:
+        if target_color is None:
+            raise ValueError("target_color is required for rgb and hue match modes.")
+        clean_target_color = _normalize_color(target_color, "target_color")
+        target_hsv = _rgb_to_hsv(clean_target_color[0], clean_target_color[1], clean_target_color[2])
+
+    if background_color is None:
+        clean_background_color = _estimate_background(cropped)
+    else:
+        clean_background_color = _normalize_color(background_color, "background_color")
+
+    mask, matched_pixels = _build_match_mask(cropped, match_mode)
+    components = _find_components(mask, cropped.width(), cropped.height())
+    selected_component = _select_component(components, cropped.width(), cropped.height())
+    alpha = _component_to_alpha(selected_component, cropped.width(), cropped.height())
+    _apply_alpha(cropped, alpha)
+
+    crop_width = cropped.width()
+    crop_height = cropped.height()
+    final_width = output_width or cropped.width()
+    final_height = output_height or cropped.height()
+    if output_width or output_height:
+        if output_width == 0:
+            final_width = max(1, int(round(cropped.width() * (output_height / float(cropped.height())))))
+        if output_height == 0:
+            final_height = max(1, int(round(cropped.height() * (output_width / float(cropped.width())))))
+        if horizontal_remap == "cylindrical_front":
+            cropped = _remap_cylindrical_front(cropped, final_width, final_height, source_arc_degrees, remap_center_x)
+        elif stretch_to_output:
+            cropped = cropped.scaled(final_width, final_height, Qt.IgnoreAspectRatio, Qt.SmoothTransformation)
+        else:
+            cropped = _scale_keep_aspect(cropped, final_width, final_height)
+    elif horizontal_remap == "cylindrical_front":
+        cropped = _remap_cylindrical_front(cropped, final_width, final_height, source_arc_degrees, remap_center_x)
+
+    if output_path is None:
+        base_name = os.path.splitext(os.path.basename(normalized_image_path))[0] or "image"
+        output_path = os.path.join(os.path.dirname(normalized_image_path), f"{base_name}_matte.png")
+    normalized_output_path = os.path.normpath(output_path)
+    if not os.path.splitext(normalized_output_path)[1]:
+        normalized_output_path += ".png"
+    output_dir = os.path.dirname(normalized_output_path)
+    if output_dir and not os.path.isdir(output_dir):
+        os.makedirs(output_dir)
+    if os.path.exists(normalized_output_path) and not overwrite:
+        raise ValueError(f"Output path already exists: {output_path}")
+    if not cropped.save(normalized_output_path):
+        raise RuntimeError(f"Failed to save matte texture: {output_path}")
+
+    selected_summary = None
+    if selected_component is not None:
+        selected_summary = {
+            "pixel_count": selected_component["pixel_count"],
+            "bbox_pixels": selected_component["bbox_pixels"],
+            "width_pixels": selected_component["width_pixels"],
+            "height_pixels": selected_component["height_pixels"],
+        }
+
+    return {
+        "success": True,
+        "image_path": normalized_image_path,
+        "output_path": normalized_output_path,
+        "source_image_width": image_width,
+        "source_image_height": image_height,
+        "crop_bbox_pixels": [x_min, y_min, x_max, y_max],
+        "crop_width": crop_width,
+        "crop_height": crop_height,
+        "output_width": cropped.width(),
+        "output_height": cropped.height(),
+        "horizontal_remap": horizontal_remap,
+        "source_arc_degrees": source_arc_degrees,
+        "remap_center_x": remap_center_x,
+        "match_mode": match_mode,
+        "target_color": clean_target_color,
+        "background_color": clean_background_color,
+        "matched_pixels": matched_pixels,
+        "component_count": len(components),
+        "selected_component": selected_summary,
+        "component_selection": component_selection,
+        "component_connectivity": component_connectivity,
+        "matte_mode": matte_mode,
+        "matte_expand_pixels": matte_expand_pixels,
+    }

--- a/src/mayatools/material/extract_image_region_texture.py
+++ b/src/mayatools/material/extract_image_region_texture.py
@@ -14,6 +14,7 @@ def extract_image_region_texture(
     source_arc_degrees: float = 120.0,
     remap_center_x: float = 0.5,
     mask_background: bool = False,
+    mask_background_mode: str = "color",
     background_color: List[float] = None,
     background_tolerance: float = 0.06,
     overwrite: bool = True,
@@ -22,9 +23,10 @@ def extract_image_region_texture(
 
     The crop can be defined in pixels or normalized image coordinates, padded,
     optionally resized, optionally remapped from a front cylindrical projection,
-    and optionally written with background-colored pixels made transparent. The
-    output is intended for generic reference-driven texturing workflows such as
-    labels, panels, decals, caps, badges, or trim.
+    and optionally written with background pixels made transparent. Background
+    masking can remove all matching pixels or only flood-fill matching pixels
+    connected to crop edges. The output is intended for generic reference-driven
+    texturing workflows such as labels, panels, decals, caps, badges, or trim.
     """
     import math
     import os
@@ -90,6 +92,51 @@ def extract_image_region_texture(
             values = sorted(point[index] for point in sample_points)
             channels.append(values[len(values) // 2])
         return channels
+
+    def _is_background_pixel(image, x, y, color, tolerance):
+        red, green, blue, alpha = _pixel_rgb_alpha(image, x, y)
+        if alpha <= 0.0:
+            return False
+        return _color_distance([red, green, blue], color) <= tolerance
+
+    def _mask_background_by_color(image, color, tolerance):
+        for y in range(image.height()):
+            for x in range(image.width()):
+                if _is_background_pixel(image, x, y, color, tolerance):
+                    pixel = image.pixelColor(x, y)
+                    pixel.setAlpha(0)
+                    image.setPixelColor(x, y, pixel)
+
+    def _mask_background_by_flood_fill(image, color, tolerance):
+        width = image.width()
+        height = image.height()
+        visited = [bytearray(width) for _ in range(height)]
+        stack = []
+        for x in range(width):
+            stack.append((x, 0))
+            stack.append((x, height - 1))
+        for y in range(1, height - 1):
+            stack.append((0, y))
+            stack.append((width - 1, y))
+
+        while stack:
+            x, y = stack.pop()
+            if visited[y][x]:
+                continue
+            visited[y][x] = 1
+            if not _is_background_pixel(image, x, y, color, tolerance):
+                continue
+            pixel = image.pixelColor(x, y)
+            pixel.setAlpha(0)
+            image.setPixelColor(x, y, pixel)
+            if x > 0:
+                stack.append((x - 1, y))
+            if x < width - 1:
+                stack.append((x + 1, y))
+            if y > 0:
+                stack.append((x, y - 1))
+            if y < height - 1:
+                stack.append((x, y + 1))
 
     def _scale_keep_aspect(image, target_width, target_height):
         scaled = image.scaled(target_width, target_height, Qt.KeepAspectRatio, Qt.SmoothTransformation)
@@ -198,6 +245,9 @@ def extract_image_region_texture(
         background_tolerance /= 255.0
     if background_tolerance < 0.0:
         raise ValueError("background_tolerance must be greater than or equal to zero.")
+    mask_background_mode = mask_background_mode.lower().strip()
+    if mask_background_mode not in {"color", "flood_fill"}:
+        raise ValueError("mask_background_mode must be one of color or flood_fill.")
 
     image = QImage(normalized_image_path)
     if image.isNull():
@@ -238,15 +288,10 @@ def extract_image_region_texture(
     clean_background_color = None
     if mask_background:
         clean_background_color = _validate_color(background_color, "background_color") if background_color else _estimate_background(cropped)
-        for y in range(cropped.height()):
-            for x in range(cropped.width()):
-                red, green, blue, alpha = _pixel_rgb_alpha(cropped, x, y)
-                if alpha <= 0.0:
-                    continue
-                if _color_distance([red, green, blue], clean_background_color) <= background_tolerance:
-                    color = cropped.pixelColor(x, y)
-                    color.setAlpha(0)
-                    cropped.setPixelColor(x, y, color)
+        if mask_background_mode == "flood_fill":
+            _mask_background_by_flood_fill(cropped, clean_background_color, background_tolerance)
+        else:
+            _mask_background_by_color(cropped, clean_background_color, background_tolerance)
 
     final_width = output_width or cropped.width()
     final_height = output_height or cropped.height()
@@ -299,6 +344,7 @@ def extract_image_region_texture(
         "source_arc_degrees": source_arc_degrees,
         "remap_center_x": remap_center_x,
         "mask_background": mask_background,
+        "mask_background_mode": mask_background_mode,
         "background_color": clean_background_color,
         "background_tolerance": background_tolerance,
     }

--- a/src/mayatools/material/extract_image_region_texture.py
+++ b/src/mayatools/material/extract_image_region_texture.py
@@ -10,6 +10,9 @@ def extract_image_region_texture(
     output_width: int = 0,
     output_height: int = 0,
     stretch_to_output: bool = True,
+    auto_bbox_mode: str = "none",
+    alpha_threshold: float = 0.05,
+    min_foreground_pixels: int = 1,
     horizontal_remap: str = "none",
     source_arc_degrees: float = 120.0,
     remap_center_x: float = 0.5,
@@ -21,12 +24,14 @@ def extract_image_region_texture(
 ) -> Dict[str, Any]:
     """Crop an image reference region into a reusable texture file.
 
-    The crop can be defined in pixels or normalized image coordinates, padded,
-    optionally resized, optionally remapped from a front cylindrical projection,
-    and optionally written with background pixels made transparent. Background
-    masking can remove all matching pixels or only flood-fill matching pixels
-    connected to crop edges. The output is intended for generic reference-driven
-    texturing workflows such as labels, panels, decals, caps, badges, or trim.
+    The crop can be defined in pixels, normalized image coordinates, or
+    automatically from foreground pixels against an estimated/provided
+    background color. The crop can be padded, optionally resized, optionally
+    remapped from a front cylindrical projection, and optionally written with
+    background pixels made transparent. Background masking can remove all
+    matching pixels or only flood-fill matching pixels connected to crop edges.
+    The output is intended for generic reference-driven texturing workflows
+    such as labels, panels, decals, caps, badges, silhouettes, or trim.
     """
     import math
     import os
@@ -53,6 +58,11 @@ def extract_image_region_texture(
         if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
             raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
         return value
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
 
     def _validate_color(values, arg_name):
         color = _validate_vector(values, 3, arg_name)
@@ -98,6 +108,28 @@ def extract_image_region_texture(
         if alpha <= 0.0:
             return False
         return _color_distance([red, green, blue], color) <= tolerance
+
+    def _foreground_bbox(image, color, tolerance, minimum_alpha, minimum_pixels):
+        bbox = None
+        count = 0
+        for y in range(image.height()):
+            for x in range(image.width()):
+                red, green, blue, alpha = _pixel_rgb_alpha(image, x, y)
+                if alpha < minimum_alpha:
+                    continue
+                if _color_distance([red, green, blue], color) <= tolerance:
+                    continue
+                count += 1
+                if bbox is None:
+                    bbox = [x, y, x, y]
+                else:
+                    bbox[0] = min(bbox[0], x)
+                    bbox[1] = min(bbox[1], y)
+                    bbox[2] = max(bbox[2], x)
+                    bbox[3] = max(bbox[3], y)
+        if count < minimum_pixels or bbox is None:
+            raise ValueError("No foreground bbox could be found. Adjust background_color, background_tolerance, alpha_threshold, or min_foreground_pixels.")
+        return bbox, count
 
     def _mask_background_by_color(image, color, tolerance):
         for y in range(image.height()):
@@ -217,14 +249,21 @@ def extract_image_region_texture(
     normalized_image_path = os.path.normpath(image_path)
     if not os.path.isfile(normalized_image_path):
         raise ValueError(f"Image path does not exist: {image_path}")
-    if bbox_pixels is None and bbox_normalized is None:
-        raise ValueError("bbox_pixels or bbox_normalized is required.")
     if bbox_pixels is not None and bbox_normalized is not None:
         raise ValueError("Provide only one of bbox_pixels or bbox_normalized.")
 
     padding_pixels = _validate_int(padding_pixels, "padding_pixels", 0)
     output_width = _validate_int(output_width, "output_width", 0)
     output_height = _validate_int(output_height, "output_height", 0)
+    min_foreground_pixels = _validate_int(min_foreground_pixels, "min_foreground_pixels", 1)
+    alpha_threshold = _validate_scalar(alpha_threshold, "alpha_threshold")
+    if alpha_threshold < 0.0 or alpha_threshold > 1.0:
+        raise ValueError("alpha_threshold must be in the 0..1 range.")
+    auto_bbox_mode = auto_bbox_mode.lower().strip()
+    if auto_bbox_mode not in {"none", "foreground"}:
+        raise ValueError("auto_bbox_mode must be one of none or foreground.")
+    if bbox_pixels is None and bbox_normalized is None and auto_bbox_mode == "none":
+        raise ValueError("bbox_pixels or bbox_normalized is required unless auto_bbox_mode is foreground.")
     horizontal_remap = horizontal_remap.lower().strip()
     if horizontal_remap not in {"none", "cylindrical_front"}:
         raise ValueError("horizontal_remap must be one of none or cylindrical_front.")
@@ -257,7 +296,19 @@ def extract_image_region_texture(
     if image_width < 2 or image_height < 2:
         raise ValueError("image must be at least 2x2 pixels.")
 
-    if bbox_normalized is not None:
+    auto_background_color = None
+    auto_foreground_count = 0
+    if bbox_pixels is None and bbox_normalized is None:
+        auto_background_color = _validate_color(background_color, "background_color") if background_color else _estimate_background(image)
+        auto_bbox, auto_foreground_count = _foreground_bbox(
+            image,
+            auto_background_color,
+            background_tolerance,
+            alpha_threshold,
+            min_foreground_pixels,
+        )
+        x_min, y_min, x_max, y_max = auto_bbox
+    elif bbox_normalized is not None:
         bbox = _validate_vector(bbox_normalized, 4, "bbox_normalized")
         if bbox[2] <= bbox[0] or bbox[3] <= bbox[1]:
             raise ValueError("bbox_normalized must be [min_x, min_y, max_x, max_y].")
@@ -287,7 +338,7 @@ def extract_image_region_texture(
 
     clean_background_color = None
     if mask_background:
-        clean_background_color = _validate_color(background_color, "background_color") if background_color else _estimate_background(cropped)
+        clean_background_color = _validate_color(background_color, "background_color") if background_color else auto_background_color or _estimate_background(cropped)
         if mask_background_mode == "flood_fill":
             _mask_background_by_flood_fill(cropped, clean_background_color, background_tolerance)
         else:
@@ -340,11 +391,15 @@ def extract_image_region_texture(
         "crop_height": crop_height,
         "output_width": cropped.width(),
         "output_height": cropped.height(),
+        "auto_bbox_mode": auto_bbox_mode,
+        "auto_foreground_count": auto_foreground_count,
+        "alpha_threshold": alpha_threshold,
+        "min_foreground_pixels": min_foreground_pixels,
         "horizontal_remap": horizontal_remap,
         "source_arc_degrees": source_arc_degrees,
         "remap_center_x": remap_center_x,
         "mask_background": mask_background,
         "mask_background_mode": mask_background_mode,
-        "background_color": clean_background_color,
+        "background_color": clean_background_color or auto_background_color,
         "background_tolerance": background_tolerance,
     }

--- a/src/mayatools/material/extract_image_region_texture.py
+++ b/src/mayatools/material/extract_image_region_texture.py
@@ -10,6 +10,9 @@ def extract_image_region_texture(
     output_width: int = 0,
     output_height: int = 0,
     stretch_to_output: bool = True,
+    horizontal_remap: str = "none",
+    source_arc_degrees: float = 120.0,
+    remap_center_x: float = 0.5,
     mask_background: bool = False,
     background_color: List[float] = None,
     background_tolerance: float = 0.06,
@@ -18,10 +21,12 @@ def extract_image_region_texture(
     """Crop an image reference region into a reusable texture file.
 
     The crop can be defined in pixels or normalized image coordinates, padded,
-    optionally resized, and optionally written with background-colored pixels
-    made transparent. The output is intended for generic reference-driven
-    texturing workflows such as labels, panels, decals, caps, badges, or trim.
+    optionally resized, optionally remapped from a front cylindrical projection,
+    and optionally written with background-colored pixels made transparent. The
+    output is intended for generic reference-driven texturing workflows such as
+    labels, panels, decals, caps, badges, or trim.
     """
+    import math
     import os
 
     try:
@@ -101,6 +106,65 @@ def extract_image_region_texture(
         painter.end()
         return canvas
 
+    def _make_color(red, green, blue, alpha):
+        color = QColor()
+        color.setRgbF(
+            max(0.0, min(1.0, red)),
+            max(0.0, min(1.0, green)),
+            max(0.0, min(1.0, blue)),
+            max(0.0, min(1.0, alpha)),
+        )
+        return color
+
+    def _sample_bilinear(image, x, y):
+        width = image.width()
+        height = image.height()
+        x = max(0.0, min(float(width - 1), x))
+        y = max(0.0, min(float(height - 1), y))
+        x0 = int(math.floor(x))
+        y0 = int(math.floor(y))
+        x1 = min(width - 1, x0 + 1)
+        y1 = min(height - 1, y0 + 1)
+        tx = x - x0
+        ty = y - y0
+        c00 = _pixel_rgb_alpha(image, x0, y0)
+        c10 = _pixel_rgb_alpha(image, x1, y0)
+        c01 = _pixel_rgb_alpha(image, x0, y1)
+        c11 = _pixel_rgb_alpha(image, x1, y1)
+        channels = []
+        for index in range(4):
+            top = c00[index] * (1.0 - tx) + c10[index] * tx
+            bottom = c01[index] * (1.0 - tx) + c11[index] * tx
+            channels.append(top * (1.0 - ty) + bottom * ty)
+        return _make_color(channels[0], channels[1], channels[2], channels[3])
+
+    def _remap_cylindrical_front(image, target_width, target_height, arc_degrees, center_x):
+        arc_radians = math.radians(arc_degrees)
+        half_arc = arc_radians * 0.5
+        sin_half_arc = math.sin(half_arc)
+        if sin_half_arc <= 1e-9:
+            raise ValueError("source_arc_degrees is too small for cylindrical_front remap.")
+        source_width = image.width()
+        source_height = image.height()
+        projected_center = center_x * float(source_width - 1)
+        left_span = max(1e-9, projected_center)
+        right_span = max(1e-9, float(source_width - 1) - projected_center)
+        remapped = QImage(target_width, target_height, QImage.Format_ARGB32)
+        remapped.fill(QColor(0, 0, 0, 0))
+        for y in range(target_height):
+            v = 0.0 if target_height == 1 else y / float(target_height - 1)
+            source_y = v * float(source_height - 1)
+            for x in range(target_width):
+                u = 0.0 if target_width == 1 else x / float(target_width - 1)
+                theta = (u - 0.5) * arc_radians
+                projected = math.sin(theta) / sin_half_arc
+                if projected < 0.0:
+                    source_x = projected_center + projected * left_span
+                else:
+                    source_x = projected_center + projected * right_span
+                remapped.setPixelColor(x, y, _sample_bilinear(image, source_x, source_y))
+        return remapped
+
     if not image_path:
         raise ValueError("image_path is required.")
     normalized_image_path = os.path.normpath(image_path)
@@ -114,6 +178,19 @@ def extract_image_region_texture(
     padding_pixels = _validate_int(padding_pixels, "padding_pixels", 0)
     output_width = _validate_int(output_width, "output_width", 0)
     output_height = _validate_int(output_height, "output_height", 0)
+    horizontal_remap = horizontal_remap.lower().strip()
+    if horizontal_remap not in {"none", "cylindrical_front"}:
+        raise ValueError("horizontal_remap must be one of none or cylindrical_front.")
+    if not _is_number(source_arc_degrees):
+        raise ValueError("source_arc_degrees must be numeric.")
+    source_arc_degrees = float(source_arc_degrees)
+    if source_arc_degrees <= 0.0 or source_arc_degrees >= 180.0:
+        raise ValueError("source_arc_degrees must be greater than 0 and less than 180.")
+    if not _is_number(remap_center_x):
+        raise ValueError("remap_center_x must be numeric.")
+    remap_center_x = float(remap_center_x)
+    if remap_center_x <= 0.0 or remap_center_x >= 1.0:
+        raise ValueError("remap_center_x must be greater than 0 and less than 1.")
     if not _is_number(background_tolerance):
         raise ValueError("background_tolerance must be numeric.")
     background_tolerance = float(background_tolerance)
@@ -178,10 +255,14 @@ def extract_image_region_texture(
             final_width = max(1, int(round(cropped.width() * (output_height / float(cropped.height())))))
         if output_height == 0:
             final_height = max(1, int(round(cropped.height() * (output_width / float(cropped.width())))))
-        if stretch_to_output:
+        if horizontal_remap == "cylindrical_front":
+            cropped = _remap_cylindrical_front(cropped, final_width, final_height, source_arc_degrees, remap_center_x)
+        elif stretch_to_output:
             cropped = cropped.scaled(final_width, final_height, Qt.IgnoreAspectRatio, Qt.SmoothTransformation)
         else:
             cropped = _scale_keep_aspect(cropped, final_width, final_height)
+    elif horizontal_remap == "cylindrical_front":
+        cropped = _remap_cylindrical_front(cropped, final_width, final_height, source_arc_degrees, remap_center_x)
 
     if output_path is None:
         base_name = os.path.splitext(os.path.basename(normalized_image_path))[0] or "image"
@@ -214,6 +295,9 @@ def extract_image_region_texture(
         "crop_height": crop_height,
         "output_width": cropped.width(),
         "output_height": cropped.height(),
+        "horizontal_remap": horizontal_remap,
+        "source_arc_degrees": source_arc_degrees,
+        "remap_center_x": remap_center_x,
         "mask_background": mask_background,
         "background_color": clean_background_color,
         "background_tolerance": background_tolerance,

--- a/src/mayatools/material/extract_image_region_texture.py
+++ b/src/mayatools/material/extract_image_region_texture.py
@@ -1,0 +1,220 @@
+from typing import Dict, List, Any
+
+
+def extract_image_region_texture(
+    image_path: str,
+    output_path: str = None,
+    bbox_pixels: List[float] = None,
+    bbox_normalized: List[float] = None,
+    padding_pixels: int = 0,
+    output_width: int = 0,
+    output_height: int = 0,
+    stretch_to_output: bool = True,
+    mask_background: bool = False,
+    background_color: List[float] = None,
+    background_tolerance: float = 0.06,
+    overwrite: bool = True,
+) -> Dict[str, Any]:
+    """Crop an image reference region into a reusable texture file.
+
+    The crop can be defined in pixels or normalized image coordinates, padded,
+    optionally resized, and optionally written with background-colored pixels
+    made transparent. The output is intended for generic reference-driven
+    texturing workflows such as labels, panels, decals, caps, badges, or trim.
+    """
+    import os
+
+    try:
+        from PySide6.QtCore import Qt
+        from PySide6.QtGui import QImage, QColor
+    except Exception:
+        try:
+            from PySide2.QtCore import Qt
+            from PySide2.QtGui import QImage, QColor
+        except Exception as exc:
+            raise RuntimeError("PySide QImage is required to crop image textures in Maya.") from exc
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(v) for v in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(value) for value in values]
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return value
+
+    def _validate_color(values, arg_name):
+        color = _validate_vector(values, 3, arg_name)
+        if max(color) > 1.0:
+            color = [value / 255.0 for value in color]
+        return [max(0.0, min(1.0, value)) for value in color]
+
+    def _pixel_rgb_alpha(image, x, y):
+        color = image.pixelColor(int(x), int(y))
+        return [color.redF(), color.greenF(), color.blueF(), color.alphaF()]
+
+    def _color_distance(color_a, color_b):
+        dr = color_a[0] - color_b[0]
+        dg = color_a[1] - color_b[1]
+        db = color_a[2] - color_b[2]
+        return (dr * dr + dg * dg + db * db) ** 0.5
+
+    def _estimate_background(image):
+        width = image.width()
+        height = image.height()
+        sample_points = []
+        radius = max(1, min(width, height, 8))
+        corners = [
+            (0, 0),
+            (width - 1, 0),
+            (0, height - 1),
+            (width - 1, height - 1),
+        ]
+        for corner_x, corner_y in corners:
+            for dy in range(-radius, radius + 1):
+                for dx in range(-radius, radius + 1):
+                    x = max(0, min(width - 1, corner_x + dx))
+                    y = max(0, min(height - 1, corner_y + dy))
+                    sample_points.append(_pixel_rgb_alpha(image, x, y)[:3])
+        channels = []
+        for index in range(3):
+            values = sorted(point[index] for point in sample_points)
+            channels.append(values[len(values) // 2])
+        return channels
+
+    def _scale_keep_aspect(image, target_width, target_height):
+        scaled = image.scaled(target_width, target_height, Qt.KeepAspectRatio, Qt.SmoothTransformation)
+        canvas = QImage(target_width, target_height, QImage.Format_ARGB32)
+        canvas.fill(QColor(0, 0, 0, 0))
+        try:
+            from PySide6.QtGui import QPainter
+        except Exception:
+            from PySide2.QtGui import QPainter
+        painter = QPainter(canvas)
+        offset_x = int((target_width - scaled.width()) * 0.5)
+        offset_y = int((target_height - scaled.height()) * 0.5)
+        painter.drawImage(offset_x, offset_y, scaled)
+        painter.end()
+        return canvas
+
+    if not image_path:
+        raise ValueError("image_path is required.")
+    normalized_image_path = os.path.normpath(image_path)
+    if not os.path.isfile(normalized_image_path):
+        raise ValueError(f"Image path does not exist: {image_path}")
+    if bbox_pixels is None and bbox_normalized is None:
+        raise ValueError("bbox_pixels or bbox_normalized is required.")
+    if bbox_pixels is not None and bbox_normalized is not None:
+        raise ValueError("Provide only one of bbox_pixels or bbox_normalized.")
+
+    padding_pixels = _validate_int(padding_pixels, "padding_pixels", 0)
+    output_width = _validate_int(output_width, "output_width", 0)
+    output_height = _validate_int(output_height, "output_height", 0)
+    if not _is_number(background_tolerance):
+        raise ValueError("background_tolerance must be numeric.")
+    background_tolerance = float(background_tolerance)
+    if background_tolerance > 1.0:
+        background_tolerance /= 255.0
+    if background_tolerance < 0.0:
+        raise ValueError("background_tolerance must be greater than or equal to zero.")
+
+    image = QImage(normalized_image_path)
+    if image.isNull():
+        raise ValueError(f"Unable to load image: {image_path}")
+    image_width = image.width()
+    image_height = image.height()
+    if image_width < 2 or image_height < 2:
+        raise ValueError("image must be at least 2x2 pixels.")
+
+    if bbox_normalized is not None:
+        bbox = _validate_vector(bbox_normalized, 4, "bbox_normalized")
+        if bbox[2] <= bbox[0] or bbox[3] <= bbox[1]:
+            raise ValueError("bbox_normalized must be [min_x, min_y, max_x, max_y].")
+        x_min = int(round(max(0.0, min(1.0, bbox[0])) * (image_width - 1)))
+        y_min = int(round(max(0.0, min(1.0, bbox[1])) * (image_height - 1)))
+        x_max = int(round(max(0.0, min(1.0, bbox[2])) * (image_width - 1)))
+        y_max = int(round(max(0.0, min(1.0, bbox[3])) * (image_height - 1)))
+    else:
+        bbox = _validate_vector(bbox_pixels, 4, "bbox_pixels")
+        if bbox[2] <= bbox[0] or bbox[3] <= bbox[1]:
+            raise ValueError("bbox_pixels must be [min_x, min_y, max_x, max_y].")
+        x_min = int(round(bbox[0]))
+        y_min = int(round(bbox[1]))
+        x_max = int(round(bbox[2]))
+        y_max = int(round(bbox[3]))
+
+    x_min = max(0, min(image_width - 1, x_min - padding_pixels))
+    y_min = max(0, min(image_height - 1, y_min - padding_pixels))
+    x_max = max(0, min(image_width - 1, x_max + padding_pixels))
+    y_max = max(0, min(image_height - 1, y_max + padding_pixels))
+    if x_max <= x_min or y_max <= y_min:
+        raise ValueError("Resolved crop bbox is empty.")
+
+    crop_width = x_max - x_min + 1
+    crop_height = y_max - y_min + 1
+    cropped = image.copy(x_min, y_min, crop_width, crop_height).convertToFormat(QImage.Format_ARGB32)
+
+    clean_background_color = None
+    if mask_background:
+        clean_background_color = _validate_color(background_color, "background_color") if background_color else _estimate_background(cropped)
+        for y in range(cropped.height()):
+            for x in range(cropped.width()):
+                red, green, blue, alpha = _pixel_rgb_alpha(cropped, x, y)
+                if alpha <= 0.0:
+                    continue
+                if _color_distance([red, green, blue], clean_background_color) <= background_tolerance:
+                    color = cropped.pixelColor(x, y)
+                    color.setAlpha(0)
+                    cropped.setPixelColor(x, y, color)
+
+    final_width = output_width or cropped.width()
+    final_height = output_height or cropped.height()
+    if output_width or output_height:
+        if output_width == 0:
+            final_width = max(1, int(round(cropped.width() * (output_height / float(cropped.height())))))
+        if output_height == 0:
+            final_height = max(1, int(round(cropped.height() * (output_width / float(cropped.width())))))
+        if stretch_to_output:
+            cropped = cropped.scaled(final_width, final_height, Qt.IgnoreAspectRatio, Qt.SmoothTransformation)
+        else:
+            cropped = _scale_keep_aspect(cropped, final_width, final_height)
+
+    if output_path is None:
+        base_name = os.path.splitext(os.path.basename(normalized_image_path))[0] or "image"
+        output_path = os.path.join(os.path.dirname(normalized_image_path), f"{base_name}_crop.png")
+    normalized_output_path = os.path.normpath(output_path)
+    if not os.path.splitext(normalized_output_path)[1]:
+        normalized_output_path += ".png"
+    output_dir = os.path.dirname(normalized_output_path)
+    if output_dir and not os.path.isdir(output_dir):
+        os.makedirs(output_dir)
+    if os.path.exists(normalized_output_path) and not overwrite:
+        raise ValueError(f"Output path already exists: {output_path}")
+    if not cropped.save(normalized_output_path):
+        raise RuntimeError(f"Failed to save cropped texture: {output_path}")
+
+    return {
+        "success": True,
+        "image_path": normalized_image_path,
+        "output_path": normalized_output_path,
+        "source_image_width": image_width,
+        "source_image_height": image_height,
+        "crop_bbox_pixels": [x_min, y_min, x_max, y_max],
+        "crop_bbox_normalized": [
+            x_min / float(image_width - 1),
+            y_min / float(image_height - 1),
+            x_max / float(image_width - 1),
+            y_max / float(image_height - 1),
+        ],
+        "crop_width": crop_width,
+        "crop_height": crop_height,
+        "output_width": cropped.width(),
+        "output_height": cropped.height(),
+        "mask_background": mask_background,
+        "background_color": clean_background_color,
+        "background_tolerance": background_tolerance,
+    }

--- a/src/mayatools/material/get_material_assignments.py
+++ b/src/mayatools/material/get_material_assignments.py
@@ -1,0 +1,131 @@
+from typing import Dict, List, Any, Union
+
+
+def get_material_assignments(
+    object_names: Union[str, List[str]] = None,
+    include_components: bool = False,
+) -> Dict[str, Any]:
+    """Report material and shading-group assignments for scene geometry.
+
+    This is a generic inspection tool for debugging product assets, imported
+    models, procedural meshes, and textured scenes. It resolves transform or
+    shape inputs to renderable shapes, reports connected shadingEngine nodes,
+    the surface materials driving them, and optionally lists set members so
+    per-face assignments can be diagnosed.
+    """
+    import maya.cmds as cmds
+
+    def _unique(values):
+        result = []
+        seen = set()
+        for value in values or []:
+            if value not in seen:
+                seen.add(value)
+                result.append(value)
+        return result
+
+    def _shape_parent_targets():
+        targets = []
+        seen = set()
+        for shape_type in ["mesh", "nurbsSurface", "subdiv", "nurbsCurve", "bezierCurve"]:
+            for shape in cmds.ls(type=shape_type, long=False) or []:
+                try:
+                    if cmds.attributeQuery("intermediateObject", node=shape, exists=True) and cmds.getAttr(f"{shape}.intermediateObject"):
+                        continue
+                except Exception:
+                    pass
+                parents = cmds.listRelatives(shape, parent=True, fullPath=False) or []
+                target = parents[0] if parents else shape
+                if target not in seen:
+                    seen.add(target)
+                    targets.append(target)
+        return targets
+
+    def _normalize_objects(values):
+        if values is None:
+            return _shape_parent_targets()
+        if isinstance(values, str):
+            values = [values]
+        if not isinstance(values, list) or not all(isinstance(value, str) for value in values):
+            raise ValueError("object_names must be a string, a list of strings, or None.")
+        for value in values:
+            if not cmds.objExists(value):
+                raise ValueError(f"Object does not exist: {value}")
+        return values
+
+    def _renderable_shapes(node):
+        if cmds.objectType(node, isAType="shape"):
+            shapes = [node]
+        else:
+            shapes = cmds.listRelatives(node, shapes=True, fullPath=False) or []
+        result = []
+        for shape in shapes:
+            try:
+                if cmds.attributeQuery("intermediateObject", node=shape, exists=True) and cmds.getAttr(f"{shape}.intermediateObject"):
+                    continue
+            except Exception:
+                pass
+            result.append(shape)
+        return result
+
+    def _surface_materials(shading_group):
+        materials = []
+        for plug in ["surfaceShader", "aiSurfaceShader"]:
+            if cmds.attributeQuery(plug, node=shading_group, exists=True):
+                materials.extend(cmds.listConnections(f"{shading_group}.{plug}", source=True, destination=False) or [])
+        return _unique(materials)
+
+    def _filtered_members(shading_group, object_name, shape_name):
+        if not include_components:
+            return []
+        members = cmds.sets(shading_group, query=True) or []
+        filtered = []
+        prefixes = [object_name, shape_name]
+        parents = cmds.listRelatives(shape_name, parent=True, fullPath=False) or []
+        prefixes.extend(parents)
+        for member in members:
+            clean_member = member.split("|")[-1]
+            if any(clean_member == prefix or clean_member.startswith(f"{prefix}.") for prefix in prefixes if prefix):
+                filtered.append(member)
+        return filtered
+
+    if not isinstance(include_components, bool):
+        raise ValueError("include_components must be a boolean.")
+
+    objects = _normalize_objects(object_names)
+    results = []
+    all_shading_groups = []
+    all_materials = []
+
+    for obj in objects:
+        shape_results = []
+        for shape in _renderable_shapes(obj):
+            shading_groups = _unique(cmds.listConnections(shape, type="shadingEngine") or [])
+            assignments = []
+            for shading_group in shading_groups:
+                materials = _surface_materials(shading_group)
+                all_shading_groups.append(shading_group)
+                all_materials.extend(materials)
+                assignments.append({
+                    "shading_group": shading_group,
+                    "materials": materials,
+                    "members": _filtered_members(shading_group, obj, shape),
+                })
+            shape_results.append({
+                "shape": shape,
+                "shape_type": cmds.objectType(shape),
+                "assignments": assignments,
+            })
+        results.append({
+            "object_name": obj,
+            "shapes": shape_results,
+        })
+
+    return {
+        "success": True,
+        "object_names": objects,
+        "include_components": bool(include_components),
+        "objects": results,
+        "shading_groups": _unique(all_shading_groups),
+        "materials": _unique(all_materials),
+    }

--- a/src/mayatools/material/refresh_file_textures.py
+++ b/src/mayatools/material/refresh_file_textures.py
@@ -1,0 +1,96 @@
+from typing import Dict, List, Any, Union
+
+
+def refresh_file_textures(
+    file_nodes: Union[str, List[str]] = None,
+    validate_paths: bool = True,
+    normalize_paths: bool = True,
+    force_reload: bool = True,
+    reset_viewport: bool = True,
+) -> Dict[str, Any]:
+    """Refresh Maya file texture nodes and viewport texture display.
+
+    This is a generic utility for scenes reopened from disk, imported assets,
+    swapped texture files, or stale VP2 previews. It can re-enable file loading,
+    optionally normalize texture paths, touch fileTextureName to force node
+    dirtiness, and reset/refresh the viewport so textured materials show in
+    playblasts.
+    """
+    import os
+    import maya.cmds as cmds
+
+    def _normalize_nodes(nodes):
+        if nodes is None:
+            return cmds.ls(type="file") or []
+        if isinstance(nodes, str):
+            nodes = [nodes]
+        if not isinstance(nodes, list) or not all(isinstance(node, str) for node in nodes):
+            raise ValueError("file_nodes must be a string, a list of strings, or None.")
+        for node in nodes:
+            if not cmds.objExists(node):
+                raise ValueError(f"File texture node does not exist: {node}")
+            if cmds.objectType(node) != "file":
+                raise ValueError(f"Node is not a Maya file texture node: {node}")
+        return nodes
+
+    nodes = _normalize_nodes(file_nodes)
+    refreshed = []
+    missing = []
+    errors = []
+
+    for node in nodes:
+        try:
+            path = cmds.getAttr(f"{node}.fileTextureName") or ""
+            clean_path = os.path.normpath(path) if path and normalize_paths else path
+            exists = bool(clean_path and os.path.exists(clean_path))
+            if validate_paths and not exists:
+                missing.append({"node": node, "path": clean_path})
+
+            if cmds.attributeQuery("disableFileLoad", node=node, exists=True):
+                cmds.setAttr(f"{node}.disableFileLoad", 0)
+
+            if clean_path:
+                if normalize_paths and clean_path != path:
+                    cmds.setAttr(f"{node}.fileTextureName", clean_path, type="string")
+                if force_reload:
+                    cmds.setAttr(f"{node}.fileTextureName", clean_path, type="string")
+
+            try:
+                cmds.dgdirty(node)
+            except Exception:
+                pass
+
+            refreshed.append({
+                "node": node,
+                "path": clean_path,
+                "exists": exists,
+            })
+        except Exception as exc:
+            errors.append({"node": node, "message": str(exc)})
+
+    if reset_viewport:
+        try:
+            cmds.ogs(reset=True)
+        except Exception:
+            pass
+        try:
+            for panel in cmds.getPanel(type="modelPanel") or []:
+                cmds.modelEditor(panel, edit=True, displayTextures=True, useDefaultMaterial=False)
+        except Exception:
+            pass
+        try:
+            cmds.refresh(force=True)
+        except Exception:
+            pass
+
+    return {
+        "success": len(errors) == 0 and (not validate_paths or len(missing) == 0),
+        "file_nodes": nodes,
+        "refreshed": refreshed,
+        "missing": missing,
+        "errors": errors,
+        "validate_paths": bool(validate_paths),
+        "normalize_paths": bool(normalize_paths),
+        "force_reload": bool(force_reload),
+        "reset_viewport": bool(reset_viewport),
+    }

--- a/src/mayatools/material/refresh_file_textures.py
+++ b/src/mayatools/material/refresh_file_textures.py
@@ -18,6 +18,7 @@ def refresh_file_textures(
     """
     import os
     import maya.cmds as cmds
+    import maya.mel as mel
 
     def _normalize_nodes(nodes):
         if nodes is None:
@@ -38,6 +39,29 @@ def refresh_file_textures(
     missing = []
     errors = []
 
+    def _mel_quote(value):
+        return '"' + str(value).replace("\\", "/").replace('"', '\\"') + '"'
+
+    def _reload_texture_callbacks(node, texture_path):
+        actions = []
+        if not texture_path:
+            return actions
+        try:
+            mel.eval("source AEfileTemplate.mel")
+        except Exception as exc:
+            actions.append({"action": "source_AEfileTemplate", "error": str(exc)})
+        try:
+            mel.eval("AEfileTextureReloadCmd " + _mel_quote(f"{node}.fileTextureName"))
+            actions.append({"action": "AEfileTextureReloadCmd"})
+        except Exception as exc:
+            actions.append({"action": "AEfileTextureReloadCmd", "error": str(exc)})
+            try:
+                mel.eval("callbacks -executeCallbacks -hook textureReload " + _mel_quote(texture_path))
+                actions.append({"action": "textureReload_callback"})
+            except Exception as callback_exc:
+                actions.append({"action": "textureReload_callback", "error": str(callback_exc)})
+        return actions
+
     for node in nodes:
         try:
             path = cmds.getAttr(f"{node}.fileTextureName") or ""
@@ -54,6 +78,11 @@ def refresh_file_textures(
                     cmds.setAttr(f"{node}.fileTextureName", clean_path, type="string")
                 if force_reload:
                     cmds.setAttr(f"{node}.fileTextureName", clean_path, type="string")
+                    reload_actions = _reload_texture_callbacks(node, clean_path)
+                else:
+                    reload_actions = []
+            else:
+                reload_actions = []
 
             try:
                 cmds.dgdirty(node)
@@ -64,6 +93,7 @@ def refresh_file_textures(
                 "node": node,
                 "path": clean_path,
                 "exists": exists,
+                "reload_actions": reload_actions,
             })
         except Exception as exc:
             errors.append({"node": node, "message": str(exc)})

--- a/src/mayatools/material/refresh_file_textures.py
+++ b/src/mayatools/material/refresh_file_textures.py
@@ -34,38 +34,35 @@ def refresh_file_textures(
                 raise ValueError(f"Node is not a Maya file texture node: {node}")
         return nodes
 
+    def _normalize_maya_path(path):
+        return os.path.normpath(path).replace("\\", "/")
+
     nodes = _normalize_nodes(file_nodes)
     refreshed = []
     missing = []
     errors = []
+    viewport_reset = {"panels": []}
 
-    def _mel_quote(value):
-        return '"' + str(value).replace("\\", "/").replace('"', '\\"') + '"'
-
-    def _reload_texture_callbacks(node, texture_path):
+    def _reload_viewport_textures():
         actions = []
-        if not texture_path:
-            return actions
         try:
-            mel.eval("source AEfileTemplate.mel")
+            mel.eval("ogs -reloadTextures;")
+            actions.append({"action": "ogs_reloadTextures"})
         except Exception as exc:
-            actions.append({"action": "source_AEfileTemplate", "error": str(exc)})
-        try:
-            mel.eval("AEfileTextureReloadCmd " + _mel_quote(f"{node}.fileTextureName"))
-            actions.append({"action": "AEfileTextureReloadCmd"})
-        except Exception as exc:
-            actions.append({"action": "AEfileTextureReloadCmd", "error": str(exc)})
-            try:
-                mel.eval("callbacks -executeCallbacks -hook textureReload " + _mel_quote(texture_path))
-                actions.append({"action": "textureReload_callback"})
-            except Exception as callback_exc:
-                actions.append({"action": "textureReload_callback", "error": str(callback_exc)})
+            actions.append({"action": "ogs_reloadTextures", "error": str(exc)})
         return actions
+
+    if reset_viewport:
+        try:
+            mel.eval("ogs -reset;")
+            viewport_reset["actions"] = [{"action": "ogs_reset"}]
+        except Exception as exc:
+            viewport_reset["error"] = str(exc)
 
     for node in nodes:
         try:
             path = cmds.getAttr(f"{node}.fileTextureName") or ""
-            clean_path = os.path.normpath(path) if path and normalize_paths else path
+            clean_path = _normalize_maya_path(path) if path and normalize_paths else path
             exists = bool(clean_path and os.path.exists(clean_path))
             if validate_paths and not exists:
                 missing.append({"node": node, "path": clean_path})
@@ -78,7 +75,7 @@ def refresh_file_textures(
                     cmds.setAttr(f"{node}.fileTextureName", clean_path, type="string")
                 if force_reload:
                     cmds.setAttr(f"{node}.fileTextureName", clean_path, type="string")
-                    reload_actions = _reload_texture_callbacks(node, clean_path)
+                    reload_actions = [{"action": "fileTextureName_touch"}]
                 else:
                     reload_actions = []
             else:
@@ -98,16 +95,11 @@ def refresh_file_textures(
         except Exception as exc:
             errors.append({"node": node, "message": str(exc)})
 
+    viewport_reload_actions = _reload_viewport_textures() if force_reload or reset_viewport else []
+    for item in refreshed:
+        item["viewport_reload_actions"] = viewport_reload_actions
+
     if reset_viewport:
-        try:
-            cmds.ogs(reset=True)
-        except Exception:
-            pass
-        try:
-            for panel in cmds.getPanel(type="modelPanel") or []:
-                cmds.modelEditor(panel, edit=True, displayTextures=True, useDefaultMaterial=False)
-        except Exception:
-            pass
         try:
             cmds.refresh(force=True)
         except Exception:
@@ -123,4 +115,6 @@ def refresh_file_textures(
         "normalize_paths": bool(normalize_paths),
         "force_reload": bool(force_reload),
         "reset_viewport": bool(reset_viewport),
+        "viewport_reset": viewport_reset,
+        "viewport_reload_actions": viewport_reload_actions,
     }

--- a/src/mayatools/material/solidify_image_alpha.py
+++ b/src/mayatools/material/solidify_image_alpha.py
@@ -1,0 +1,232 @@
+from typing import Dict, List, Any
+
+
+def solidify_image_alpha(
+    image_path: str,
+    output_path: str = None,
+    alpha_threshold: float = 0.05,
+    source_mode: str = "alpha",
+    background_color: List[float] = None,
+    background_tolerance: float = 0.08,
+    saturation_min: float = 0.0,
+    value_min: float = 0.0,
+    set_alpha: str = "opaque",
+    overwrite: bool = True,
+) -> Dict[str, Any]:
+    """Fill transparent pixels with nearby opaque color and optionally remove alpha.
+
+    This prepares RGBA textures for workflows where the RGB data will be sampled
+    directly: opaque decal meshes, UV-projected geometry, texture-driven
+    displacement, viewport previews that sort transparency poorly, or export
+    targets that ignore alpha. Transparent pixels are flood-filled from the
+    nearest accepted source pixel in image space, preserving the visible artwork
+    while preventing black or empty RGB pixels from appearing on real geometry.
+    source_mode can filter source pixels by alpha only, foreground against a
+    background color, saturation/value, or foreground plus saturation/value.
+    """
+    import os
+    from collections import deque
+
+    try:
+        from PySide6.QtGui import QImage, QColor
+    except Exception:
+        try:
+            from PySide2.QtGui import QImage, QColor
+        except Exception as exc:
+            raise RuntimeError("PySide QImage is required to process image alpha.") from exc
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _clamp(value, lower=0.0, upper=1.0):
+        return max(lower, min(upper, value))
+
+    def _validate_color(values, arg_name):
+        if not isinstance(values, list) or len(values) != 3 or not all(_is_number(value) for value in values):
+            raise ValueError(f"{arg_name} must be a list of 3 numeric values.")
+        color = [float(values[0]), float(values[1]), float(values[2])]
+        if max(color) > 1.0:
+            color = [value / 255.0 for value in color]
+        return [_clamp(value) for value in color]
+
+    def _color_distance(color_a, color_b):
+        dr = color_a[0] - color_b[0]
+        dg = color_a[1] - color_b[1]
+        db = color_a[2] - color_b[2]
+        return (dr * dr + dg * dg + db * db) ** 0.5
+
+    def _rgb_to_hsv(red, green, blue):
+        red /= 255.0
+        green /= 255.0
+        blue /= 255.0
+        max_value = max(red, green, blue)
+        min_value = min(red, green, blue)
+        delta = max_value - min_value
+        if delta == 0.0:
+            hue = 0.0
+        elif max_value == red:
+            hue = ((green - blue) / delta) % 6.0
+        elif max_value == green:
+            hue = ((blue - red) / delta) + 2.0
+        else:
+            hue = ((red - green) / delta) + 4.0
+        hue /= 6.0
+        saturation = 0.0 if max_value == 0.0 else delta / max_value
+        return hue, saturation, max_value
+
+    def _estimate_background(source_image, alpha_limit_value):
+        width = source_image.width()
+        height = source_image.height()
+        points = []
+        radius = max(1, min(width, height, 8))
+        corners = [
+            (0, 0),
+            (width - 1, 0),
+            (0, height - 1),
+            (width - 1, height - 1),
+        ]
+        for corner_x, corner_y in corners:
+            for dy in range(-radius, radius + 1):
+                for dx in range(-radius, radius + 1):
+                    x = max(0, min(width - 1, corner_x + dx))
+                    y = max(0, min(height - 1, corner_y + dy))
+                    color = source_image.pixelColor(x, y)
+                    if color.alpha() >= alpha_limit_value:
+                        points.append([color.redF(), color.greenF(), color.blueF()])
+        if not points:
+            return [0.0, 0.0, 0.0]
+        channels = []
+        for index in range(3):
+            values = sorted(point[index] for point in points)
+            channels.append(values[len(values) // 2])
+        return channels
+
+    if not image_path:
+        raise ValueError("image_path is required.")
+    normalized_image_path = os.path.normpath(image_path)
+    if not os.path.isfile(normalized_image_path):
+        raise ValueError(f"Image path does not exist: {image_path}")
+    if not _is_number(alpha_threshold):
+        raise ValueError("alpha_threshold must be numeric.")
+    alpha_threshold = _clamp(float(alpha_threshold))
+    if not _is_number(background_tolerance):
+        raise ValueError("background_tolerance must be numeric.")
+    background_tolerance = float(background_tolerance)
+    if background_tolerance > 1.0:
+        background_tolerance /= 255.0
+    background_tolerance = max(0.0, background_tolerance)
+    if not _is_number(saturation_min):
+        raise ValueError("saturation_min must be numeric.")
+    if not _is_number(value_min):
+        raise ValueError("value_min must be numeric.")
+    saturation_min = _clamp(float(saturation_min))
+    value_min = _clamp(float(value_min))
+
+    source_mode = source_mode.lower().strip()
+    if source_mode not in {"alpha", "foreground", "saturation", "foreground_saturation"}:
+        raise ValueError("source_mode must be alpha, foreground, saturation, or foreground_saturation.")
+
+    set_alpha = set_alpha.lower().strip()
+    if set_alpha not in {"opaque", "preserve"}:
+        raise ValueError("set_alpha must be opaque or preserve.")
+
+    image = QImage(normalized_image_path)
+    if image.isNull():
+        raise ValueError(f"Unable to load image: {image_path}")
+    if image.width() < 1 or image.height() < 1:
+        raise ValueError("image must not be empty.")
+
+    image = image.convertToFormat(QImage.Format_ARGB32)
+    width = image.width()
+    height = image.height()
+    alpha_limit = int(round(alpha_threshold * 255.0))
+    clean_background_color = None
+    if source_mode in {"foreground", "foreground_saturation"}:
+        clean_background_color = (
+            _validate_color(background_color, "background_color")
+            if background_color
+            else _estimate_background(image, alpha_limit)
+        )
+
+    def _is_source_color(color):
+        if color.alpha() < alpha_limit:
+            return False
+        if source_mode in {"foreground", "foreground_saturation"}:
+            rgb = [color.redF(), color.greenF(), color.blueF()]
+            if _color_distance(rgb, clean_background_color) <= background_tolerance:
+                return False
+        if source_mode in {"saturation", "foreground_saturation"}:
+            _, saturation, value = _rgb_to_hsv(color.red(), color.green(), color.blue())
+            if saturation < saturation_min or value < value_min:
+                return False
+        return True
+
+    visited = [bytearray(width) for _ in range(height)]
+    queue = deque()
+    opaque_count = 0
+    filled_count = 0
+
+    for y in range(height):
+        for x in range(width):
+            color = image.pixelColor(x, y)
+            if _is_source_color(color):
+                visited[y][x] = 1
+                queue.append((x, y, color.red(), color.green(), color.blue()))
+                opaque_count += 1
+
+    if opaque_count == 0:
+        raise ValueError("No source pixels meet alpha_threshold.")
+
+    neighbors = [(-1, 0), (1, 0), (0, -1), (0, 1)]
+    while queue:
+        x, y, red, green, blue = queue.popleft()
+        for dx, dy in neighbors:
+            nx = x + dx
+            ny = y + dy
+            if nx < 0 or nx >= width or ny < 0 or ny >= height or visited[ny][nx]:
+                continue
+            visited[ny][nx] = 1
+            original = image.pixelColor(nx, ny)
+            alpha = 255 if set_alpha == "opaque" else original.alpha()
+            image.setPixelColor(nx, ny, QColor(red, green, blue, alpha))
+            queue.append((nx, ny, red, green, blue))
+            filled_count += 1
+
+    if set_alpha == "opaque":
+        for y in range(height):
+            for x in range(width):
+                color = image.pixelColor(x, y)
+                if color.alpha() != 255:
+                    color.setAlpha(255)
+                    image.setPixelColor(x, y, color)
+
+    if output_path is None:
+        base_name = os.path.splitext(os.path.basename(normalized_image_path))[0] or "image"
+        output_path = os.path.join(os.path.dirname(normalized_image_path), f"{base_name}_solid.png")
+    normalized_output_path = os.path.normpath(output_path)
+    if not os.path.splitext(normalized_output_path)[1]:
+        normalized_output_path += ".png"
+    output_dir = os.path.dirname(normalized_output_path)
+    if output_dir and not os.path.isdir(output_dir):
+        os.makedirs(output_dir)
+    if os.path.exists(normalized_output_path) and not overwrite:
+        raise ValueError(f"Output path already exists: {output_path}")
+    if not image.save(normalized_output_path):
+        raise RuntimeError(f"Failed to save solidified texture: {output_path}")
+
+    return {
+        "success": True,
+        "image_path": normalized_image_path,
+        "output_path": normalized_output_path,
+        "image_width": width,
+        "image_height": height,
+        "alpha_threshold": alpha_threshold,
+        "source_mode": source_mode,
+        "background_color": clean_background_color,
+        "background_tolerance": background_tolerance,
+        "saturation_min": saturation_min,
+        "value_min": value_min,
+        "set_alpha": set_alpha,
+        "source_pixel_count": opaque_count,
+        "filled_pixel_count": filled_count,
+    }

--- a/src/mayatools/object/assign_uv_rect_to_faces.py
+++ b/src/mayatools/object/assign_uv_rect_to_faces.py
@@ -1,0 +1,349 @@
+from typing import Dict, List, Any, Union
+
+
+def assign_uv_rect_to_faces(
+    object_name: str,
+    face_indices: List[int] = None,
+    components: Union[str, List[str]] = None,
+    uv_set: str = "map1",
+    u_axis: str = "x",
+    v_axis: str = "y",
+    target_box: List[float] = None,
+    source_box: List[float] = None,
+    preserve_aspect: bool = False,
+    padding: float = 0.0,
+    flip_u: bool = False,
+    flip_v: bool = False,
+    separate_uvs: bool = True,
+    space: str = "world",
+    use_selection: bool = True,
+    select_result: bool = True,
+    max_preview: int = 50,
+) -> Dict[str, Any]:
+    """Assign selected mesh faces into a rectangular UV region.
+
+    This is a direct UV-editor style operation for labels, decals, panels, and
+    local face islands. Selected faces are projected from two mesh coordinate
+    axes into target_box [min_u, min_v, max_u, max_v]. By default, selected
+    face-vertices receive separate UV ids so the edited patch does not drag
+    neighboring shells that shared UVs before the assignment.
+    """
+    import re
+    import maya.cmds as cmds
+    import maya.api.OpenMaya as om
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return int(value)
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _validate_box(value, arg_name, default):
+        box = default if value is None else value
+        if not isinstance(box, list) or len(box) != 4 or not all(_is_number(item) for item in box):
+            raise ValueError(f"{arg_name} must be [min_u, min_v, max_u, max_v].")
+        clean = [float(item) for item in box]
+        if clean[2] <= clean[0] or clean[3] <= clean[1]:
+            raise ValueError(f"{arg_name} must have positive width and height.")
+        return clean
+
+    def _axis_index(axis_name, arg_name):
+        clean = (axis_name or "").lower().strip()
+        if clean not in {"x", "y", "z"}:
+            raise ValueError(f"{arg_name} must be x, y, or z.")
+        return {"x": 0, "y": 1, "z": 2}[clean]
+
+    def _mesh_shape(node):
+        if not cmds.objExists(node):
+            raise ValueError(f"Object does not exist: {node}")
+        if cmds.objectType(node) == "mesh":
+            return node
+        shapes = cmds.listRelatives(node, shapes=True, fullPath=True) or []
+        mesh_shapes = []
+        for shape in shapes:
+            if cmds.objectType(shape) != "mesh":
+                continue
+            try:
+                if cmds.attributeQuery("intermediateObject", node=shape, exists=True) and cmds.getAttr(f"{shape}.intermediateObject"):
+                    continue
+            except Exception:
+                pass
+            mesh_shapes.append(shape)
+        if not mesh_shapes:
+            raise ValueError(f"{node} is not a polygon mesh transform or mesh shape.")
+        return mesh_shapes[0]
+
+    def _dag_path(shape):
+        selection = om.MSelectionList()
+        selection.add(shape)
+        return selection.getDagPath(0)
+
+    def _mesh_fn(shape):
+        return om.MFnMesh(_dag_path(shape))
+
+    def _prefix(shape):
+        parents = cmds.listRelatives(shape, parent=True, fullPath=False) or []
+        return parents[0] if parents else object_name
+
+    def _flatten(value):
+        if value is None:
+            return []
+        if isinstance(value, str):
+            value = [value]
+        if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+            raise ValueError("components must be a string, a list of strings, or None.")
+        return cmds.ls(value, flatten=True) or []
+
+    def _selected_components():
+        if not use_selection:
+            return []
+        selected = cmds.ls(selection=True, flatten=True) or []
+        object_tokens = {object_name, prefix_name, shape_name}
+        return [item for item in selected if item.split(".", 1)[0] in object_tokens]
+
+    def _component_ids(items, kind):
+        pattern = re.compile(rf"\.{kind}\[(\d+)\]$")
+        ids = []
+        for item in cmds.ls(items, flatten=True) or []:
+            match = pattern.search(item)
+            if match:
+                ids.append(int(match.group(1)))
+        return list(dict.fromkeys(ids))
+
+    def _resolve_face_ids():
+        if face_indices is not None:
+            if not isinstance(face_indices, list) or not all(isinstance(index, int) and not isinstance(index, bool) for index in face_indices):
+                raise ValueError("face_indices must be a list of integers.")
+            resolved = list(dict.fromkeys(face_indices))
+        else:
+            source = _flatten(components) if components is not None else _selected_components()
+            faces = cmds.polyListComponentConversion(source, toFace=True) or []
+            resolved = _component_ids(faces, "f")
+        if not resolved:
+            raise ValueError("No face components resolved from face_indices, components, or current selection.")
+        for face_id in resolved:
+            if face_id < 0 or face_id >= mesh_fn.numPolygons:
+                raise ValueError(f"Face index {face_id} is out of range 0..{mesh_fn.numPolygons - 1}.")
+        return sorted(set(resolved))
+
+    def _inner_box(box, pad):
+        width = box[2] - box[0]
+        height = box[3] - box[1]
+        clean_pad = max(0.0, min(pad, width * 0.49, height * 0.49))
+        return [box[0] + clean_pad, box[1] + clean_pad, box[2] - clean_pad, box[3] - clean_pad]
+
+    def _face_offsets(face_counts):
+        offsets = []
+        cursor = 0
+        for count in face_counts:
+            offsets.append(cursor)
+            cursor += int(count)
+        return offsets
+
+    def _existing_assignments(face_counts):
+        total_face_vertices = sum(int(count) for count in face_counts)
+        try:
+            assigned_counts, assigned_ids = mesh_fn.getAssignedUVs(uv_set)
+            assigned_counts = [int(item) for item in assigned_counts]
+            assigned_ids = [int(item) for item in assigned_ids]
+            if assigned_counts == [int(item) for item in face_counts] and len(assigned_ids) == total_face_vertices and mesh_fn.numUVs(uv_set) > 0:
+                u_values, v_values = mesh_fn.getUVs(uv_set)
+                return [float(item) for item in u_values], [float(item) for item in v_values], assigned_ids
+        except Exception:
+            pass
+        u_values = [0.0 for _ in range(total_face_vertices)]
+        v_values = [0.0 for _ in range(total_face_vertices)]
+        uv_ids = list(range(total_face_vertices))
+        return u_values, v_values, uv_ids
+
+    def _selected_uv_ids(uv_ids, face_counts, offsets, face_ids):
+        result = []
+        for face_id in face_ids:
+            start = offsets[face_id]
+            for local_index in range(int(face_counts[face_id])):
+                result.append(int(uv_ids[start + local_index]))
+        return result
+
+    def _uv_range(u_values, v_values, uv_ids):
+        clean_ids = [uv_id for uv_id in uv_ids if 0 <= uv_id < len(u_values)]
+        if not clean_ids:
+            return None
+        us = [u_values[uv_id] for uv_id in clean_ids]
+        vs = [v_values[uv_id] for uv_id in clean_ids]
+        return {
+            "min_u": min(us),
+            "max_u": max(us),
+            "min_v": min(vs),
+            "max_v": max(vs),
+        }
+
+    def _project_values(face_ids, face_counts, offsets, vertex_ids, points):
+        values = []
+        for face_id in face_ids:
+            start = offsets[face_id]
+            for local_index in range(int(face_counts[face_id])):
+                vertex_id = int(vertex_ids[start + local_index])
+                point = points[vertex_id]
+                coords = [float(point.x), float(point.y), float(point.z)]
+                values.append((coords[u_axis_index], coords[v_axis_index]))
+        return values
+
+    def _source_box(projected):
+        if source_box is not None:
+            return _validate_box(source_box, "source_box", None)
+        us = [item[0] for item in projected]
+        vs = [item[1] for item in projected]
+        min_u = min(us)
+        max_u = max(us)
+        min_v = min(vs)
+        max_v = max(vs)
+        if abs(max_u - min_u) <= 1.0e-12:
+            min_u -= 0.5
+            max_u += 0.5
+        if abs(max_v - min_v) <= 1.0e-12:
+            min_v -= 0.5
+            max_v += 0.5
+        return [min_u, min_v, max_u, max_v]
+
+    def _map_to_uv(u_value, v_value, src_box, dst_box):
+        if preserve_aspect:
+            src_width = src_box[2] - src_box[0]
+            src_height = src_box[3] - src_box[1]
+            dst_width = dst_box[2] - dst_box[0]
+            dst_height = dst_box[3] - dst_box[1]
+            scale = min(dst_width / src_width, dst_height / src_height)
+            dst_center = [(dst_box[0] + dst_box[2]) * 0.5, (dst_box[1] + dst_box[3]) * 0.5]
+            src_center = [(src_box[0] + src_box[2]) * 0.5, (src_box[1] + src_box[3]) * 0.5]
+            mapped_u = dst_center[0] + (u_value - src_center[0]) * scale
+            mapped_v = dst_center[1] + (v_value - src_center[1]) * scale
+        else:
+            mapped_u = dst_box[0] + ((u_value - src_box[0]) / (src_box[2] - src_box[0])) * (dst_box[2] - dst_box[0])
+            mapped_v = dst_box[1] + ((v_value - src_box[1]) / (src_box[3] - src_box[1])) * (dst_box[3] - dst_box[1])
+        if flip_u:
+            mapped_u = dst_box[0] + dst_box[2] - mapped_u
+        if flip_v:
+            mapped_v = dst_box[1] + dst_box[3] - mapped_v
+        return mapped_u, mapped_v
+
+    if not object_name:
+        raise ValueError("object_name is required.")
+    if not uv_set:
+        raise ValueError("uv_set is required.")
+    max_preview = _validate_int(max_preview, "max_preview", 0)
+    clean_padding = _validate_scalar(padding, "padding")
+    if clean_padding < 0.0:
+        raise ValueError("padding must be greater than or equal to zero.")
+    target = _inner_box(_validate_box(target_box, "target_box", [0.0, 0.0, 1.0, 1.0]), clean_padding)
+    u_axis_index = _axis_index(u_axis, "u_axis")
+    v_axis_index = _axis_index(v_axis, "v_axis")
+    if u_axis_index == v_axis_index:
+        raise ValueError("u_axis and v_axis must be different axes.")
+    space = space.lower().strip()
+    if space not in {"world", "object"}:
+        raise ValueError("space must be world or object.")
+
+    shape_name = _mesh_shape(object_name)
+    prefix_name = _prefix(shape_name)
+    all_uv_sets = cmds.polyUVSet(object_name, query=True, allUVSets=True) or []
+    previous_uv_set = (cmds.polyUVSet(object_name, query=True, currentUVSet=True) or [None])[0]
+    if uv_set not in all_uv_sets:
+        cmds.polyUVSet(object_name, create=True, uvSet=uv_set)
+    cmds.polyUVSet(object_name, currentUVSet=True, uvSet=uv_set)
+
+    mesh_fn = _mesh_fn(shape_name)
+    om_space = om.MSpace.kWorld if space == "world" else om.MSpace.kObject
+
+    try:
+        selected_faces = _resolve_face_ids()
+        face_counts, vertex_ids = mesh_fn.getVertices()
+        face_counts = [int(item) for item in face_counts]
+        vertex_ids = [int(item) for item in vertex_ids]
+        offsets = _face_offsets(face_counts)
+        points = mesh_fn.getPoints(om_space)
+        u_values, v_values, uv_ids = _existing_assignments(face_counts)
+        selected_before_ids = _selected_uv_ids(uv_ids, face_counts, offsets, selected_faces)
+        before_range = _uv_range(u_values, v_values, selected_before_ids)
+
+        projected_values = _project_values(selected_faces, face_counts, offsets, vertex_ids, points)
+        src = _source_box(projected_values)
+        edit_records = []
+        projected_cursor = 0
+        for face_id in selected_faces:
+            start = offsets[face_id]
+            for local_index in range(face_counts[face_id]):
+                projected_u, projected_v = projected_values[projected_cursor]
+                mapped_u, mapped_v = _map_to_uv(projected_u, projected_v, src, target)
+                assignment_index = start + local_index
+                if separate_uvs:
+                    uv_id = len(u_values)
+                    u_values.append(mapped_u)
+                    v_values.append(mapped_v)
+                    uv_ids[assignment_index] = uv_id
+                else:
+                    uv_id = uv_ids[assignment_index]
+                    if uv_id < 0 or uv_id >= len(u_values):
+                        uv_id = len(u_values)
+                        u_values.append(mapped_u)
+                        v_values.append(mapped_v)
+                        uv_ids[assignment_index] = uv_id
+                    else:
+                        u_values[uv_id] = mapped_u
+                        v_values[uv_id] = mapped_v
+                edit_records.append(
+                    {
+                        "face_index": int(face_id),
+                        "local_vertex_index": int(local_index),
+                        "vertex_index": int(vertex_ids[assignment_index]),
+                        "uv_index": int(uv_id),
+                        "uv": [float(mapped_u), float(mapped_v)],
+                    }
+                )
+                projected_cursor += 1
+
+        mesh_fn.setUVs(u_values, v_values, uv_set)
+        mesh_fn.assignUVs(face_counts, uv_ids, uv_set)
+        mesh_fn.updateSurface()
+
+        selected_after_ids = _selected_uv_ids(uv_ids, face_counts, offsets, selected_faces)
+        after_range = _uv_range(u_values, v_values, selected_after_ids)
+        if select_result:
+            cmds.select([f"{prefix_name}.map[{uv_id}]" for uv_id in selected_after_ids], replace=True)
+
+        return {
+            "success": True,
+            "object_name": object_name,
+            "shape_name": shape_name,
+            "uv_set": uv_set,
+            "face_count": len(selected_faces),
+            "face_indices": selected_faces[:max_preview],
+            "truncated_faces": len(selected_faces) > max_preview,
+            "u_axis": u_axis.lower().strip(),
+            "v_axis": v_axis.lower().strip(),
+            "space": space,
+            "target_box": target,
+            "source_box": src,
+            "preserve_aspect": bool(preserve_aspect),
+            "flip_u": bool(flip_u),
+            "flip_v": bool(flip_v),
+            "separate_uvs": bool(separate_uvs),
+            "uv_count_before": len(u_values) - (len(edit_records) if separate_uvs else 0),
+            "uv_count_after": len(u_values),
+            "selected_uv_range_before": before_range,
+            "selected_uv_range_after": after_range,
+            "edited_face_vertex_count": len(edit_records),
+            "edited_preview": edit_records[:max_preview],
+            "selected": bool(select_result),
+        }
+    finally:
+        if previous_uv_set and previous_uv_set in (cmds.polyUVSet(object_name, query=True, allUVSets=True) or []) and cmds.objExists(object_name):
+            try:
+                cmds.polyUVSet(object_name, currentUVSet=True, uvSet=previous_uv_set)
+            except Exception:
+                pass

--- a/src/mayatools/object/create_advanced_model.py
+++ b/src/mayatools/object/create_advanced_model.py
@@ -58,6 +58,15 @@ def create_advanced_model(
     mat_name = f"{name}_material"
     material = cmds.shadingNode('lambert', asShader=True, name=mat_name)
     cmds.setAttr(f"{mat_name}.color", color[0], color[1], color[2], type='double3')
+
+    def _assign_material(objects, shader):
+        if isinstance(objects, str):
+            objects = [objects]
+        sg = f"{shader}SG"
+        if not cmds.objExists(sg):
+            sg = cmds.sets(empty=True, renderable=True, noSurfaceShader=True, name=sg)
+            cmds.connectAttr(f"{shader}.outColor", f"{sg}.surfaceShader", force=True)
+        cmds.sets(objects, edit=True, forceElement=sg)
     
     # Function to apply transformations to the entire model at the end
     def finalize_model():
@@ -190,8 +199,7 @@ def create_advanced_model(
         cmds.parent(headlight_r, model_group)
         
         # Apply materials
-        for comp in components:
-            cmds.sets(comp, forceElement=cmds.sets(name=f"{mat_name}SG", renderable=True, noSurfaceShader=True))
+        _assign_material(components, material)
         
     elif model_type.lower() == "tree":
         # Get tree-specific parameters with defaults
@@ -210,7 +218,7 @@ def create_advanced_model(
         # Create trunk material
         trunk_mat = cmds.shadingNode('lambert', asShader=True, name=f"{name}_trunk_material")
         cmds.setAttr(f"{trunk_mat}.color", 0.3, 0.2, 0.1, type='double3')
-        cmds.sets(trunk, forceElement=cmds.sets(name=f"{trunk_mat}SG", renderable=True, noSurfaceShader=True))
+        _assign_material(trunk, trunk_mat)
         
         # Create foliage based on tree type
         if tree_type.lower() in ('oak', 'maple', 'deciduous'):
@@ -290,7 +298,7 @@ def create_advanced_model(
         # Apply leaf material to all foliage components except trunk
         foliage_components = [c for c in components if 'trunk' not in c]
         if foliage_components:
-            cmds.sets(foliage_components, forceElement=cmds.sets(name=f"{leaf_mat}SG", renderable=True, noSurfaceShader=True))
+            _assign_material(foliage_components, leaf_mat)
         
     elif model_type.lower() == "building":
         # Get building parameters with defaults
@@ -366,7 +374,7 @@ def create_advanced_model(
         # Apply materials
         building_mat = cmds.shadingNode('lambert', asShader=True, name=f"{name}_building_material")
         cmds.setAttr(f"{building_mat}.color", color[0], color[1], color[2], type='double3')
-        cmds.sets([building, roof], forceElement=cmds.sets(name=f"{building_mat}SG", renderable=True, noSurfaceShader=True))
+        _assign_material([building, roof], building_mat)
         
         # Window material
         window_mat = cmds.shadingNode('lambert', asShader=True, name=f"{name}_window_material")
@@ -374,12 +382,12 @@ def create_advanced_model(
         # Get all window objects
         window_objects = [c for c in components if 'window' in c]
         if window_objects:
-            cmds.sets(window_objects, forceElement=cmds.sets(name=f"{window_mat}SG", renderable=True, noSurfaceShader=True))
+            _assign_material(window_objects, window_mat)
         
         # Door material
         door_mat = cmds.shadingNode('lambert', asShader=True, name=f"{name}_door_material")
         cmds.setAttr(f"{door_mat}.color", 0.4, 0.2, 0.1, type='double3')
-        cmds.sets(door, forceElement=cmds.sets(name=f"{door_mat}SG", renderable=True, noSurfaceShader=True))
+        _assign_material(door, door_mat)
     
     elif model_type.lower() == "cup":
         # Get cup parameters
@@ -416,10 +424,10 @@ def create_advanced_model(
             cmds.parent(handle, model_group)
             
             # Create a unified material
-            cmds.sets([cup_final, handle], forceElement=cmds.sets(name=f"{mat_name}SG", renderable=True, noSurfaceShader=True))
+            _assign_material([cup_final, handle], material)
         else:
             # Apply material just to the cup
-            cmds.sets(cup_final, forceElement=cmds.sets(name=f"{mat_name}SG", renderable=True, noSurfaceShader=True))
+            _assign_material(cup_final, material)
     
     elif model_type.lower() == "chair":
         # Get chair parameters
@@ -455,7 +463,7 @@ def create_advanced_model(
             cmds.parent(leg, model_group)
         
         # Apply materials
-        cmds.sets(components, forceElement=cmds.sets(name=f"{mat_name}SG", renderable=True, noSurfaceShader=True))
+        _assign_material(components, material)
         
     else:
         raise ValueError(f"Error: unknown model type {model_type}, use one of these types: car, tree, building, cup, chair")

--- a/src/mayatools/object/create_curved_text.py
+++ b/src/mayatools/object/create_curved_text.py
@@ -1,0 +1,194 @@
+from typing import Dict, List, Any
+
+
+def create_curved_text(
+    text: str,
+    name: str = None,
+    radius: float = 1.0,
+    center: List[float] = [0.0, 0.0, 0.0],
+    axis: str = "y",
+    axis_center: float = 0.0,
+    angle_start: float = -45.0,
+    angle_end: float = 45.0,
+    text_height: float = 0.35,
+    surface_offset: float = 0.02,
+    font: str = "Arial",
+    fit_to_arc: bool = True,
+    create_geometry: bool = True,
+    bevel_radius: float = 0.008,
+    bevel_segments: int = 6,
+    keep_curves: bool = False,
+    material_color: List[float] = None,
+    material_name: str = None,
+) -> Dict[str, Any]:
+    """Create text curves or tube geometry conformed to a cylindrical surface.
+
+    The text is generated as Maya text curves, mapped around a cylindrical
+    surface, and optionally converted into raised/engraved tube geometry. This
+    is useful for generic curved labels, embossing guides, raised outlines, and
+    engraved text on bottles, cups, cans, handles, or other cylindrical forms.
+    """
+    import math
+    import random
+    import maya.cmds as cmds
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(v) for v in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(v) for v in values]
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    if not text:
+        raise ValueError("text is required.")
+    if name is None:
+        name = f"curved_text_{int(random.random() * 1000)}"
+
+    radius = _validate_scalar(radius, "radius")
+    axis_center = _validate_scalar(axis_center, "axis_center")
+    angle_start = _validate_scalar(angle_start, "angle_start")
+    angle_end = _validate_scalar(angle_end, "angle_end")
+    text_height = _validate_scalar(text_height, "text_height")
+    surface_offset = _validate_scalar(surface_offset, "surface_offset")
+    bevel_radius = _validate_scalar(bevel_radius, "bevel_radius")
+    if radius <= 0:
+        raise ValueError("radius must be greater than zero.")
+    if angle_end <= angle_start:
+        raise ValueError("angle_end must be greater than angle_start.")
+    if text_height <= 0:
+        raise ValueError("text_height must be greater than zero.")
+    if bevel_radius < 0:
+        raise ValueError("bevel_radius must be greater than or equal to zero.")
+    if not isinstance(bevel_segments, int) or isinstance(bevel_segments, bool) or bevel_segments < 3:
+        raise ValueError("bevel_segments must be an integer greater than or equal to 3.")
+
+    center = _validate_vector(center, 3, "center")
+    axis = axis.lower()
+    axes = {
+        "x": (0, 1, 2),
+        "y": (1, 0, 2),
+        "z": (2, 0, 1),
+    }
+    if axis not in axes:
+        raise ValueError("axis must be one of x, y, or z.")
+    axis_index, radial_a, radial_b = axes[axis]
+
+    text_result = cmds.textCurves(name=f"{name}_curves", font=font, text=text, constructionHistory=False)
+    if not text_result:
+        raise RuntimeError("Unable to create text curves.")
+    curve_group = text_result[0]
+    if cmds.objExists(curve_group):
+        curve_group = cmds.rename(curve_group, f"{name}_curves")
+
+    bbox = cmds.exactWorldBoundingBox(curve_group)
+    width = max(1e-6, bbox[3] - bbox[0])
+    height = max(1e-6, bbox[4] - bbox[1])
+    text_center_x = (bbox[0] + bbox[3]) * 0.5
+    text_center_y = (bbox[1] + bbox[4]) * 0.5
+    angle_span = math.radians(angle_end - angle_start)
+    arc_width = radius * angle_span
+    if fit_to_arc:
+        scale = min(arc_width / width, text_height / height)
+    else:
+        scale = text_height / height
+
+    theta_start = math.radians(angle_start)
+    theta_end = math.radians(angle_end)
+    mapped_radius = radius + surface_offset
+
+    curve_shapes = cmds.listRelatives(curve_group, allDescendents=True, fullPath=True, type="nurbsCurve") or []
+    curve_transforms = []
+    for shape in curve_shapes:
+        parents = cmds.listRelatives(shape, parent=True, fullPath=True) or []
+        if parents and parents[0] not in curve_transforms:
+            curve_transforms.append(parents[0])
+
+    for shape in curve_shapes:
+        cvs = cmds.ls(f"{shape}.cv[*]", flatten=True) or []
+        for cv in cvs:
+            x, y, _ = cmds.xform(cv, query=True, worldSpace=True, translation=True)
+            local_x = (x - text_center_x) * scale
+            local_y = (y - text_center_y) * scale
+            u = (local_x / arc_width) + 0.5
+            theta = theta_start + (theta_end - theta_start) * u
+            position = [center[0], center[1], center[2]]
+            position[axis_index] = center[axis_index] + axis_center + local_y
+            position[radial_a] = center[radial_a] + mapped_radius * math.sin(theta)
+            position[radial_b] = center[radial_b] + mapped_radius * math.cos(theta)
+            cmds.xform(cv, worldSpace=True, translation=position)
+
+    geometry = []
+    if create_geometry and bevel_radius > 0:
+        for index, path in enumerate(curve_transforms):
+            profile = cmds.circle(
+                name=f"{name}_profile_{index}",
+                radius=bevel_radius,
+                sections=bevel_segments,
+                normal=[0, 1, 0],
+                constructionHistory=False,
+            )[0]
+            try:
+                result = cmds.extrude(
+                    profile,
+                    path,
+                    name=f"{name}_geo_{index}",
+                    fixedPath=True,
+                    useComponentPivot=1,
+                    constructionHistory=False,
+                )
+                if result:
+                    geometry.append(result[0])
+            finally:
+                if cmds.objExists(profile):
+                    cmds.delete(profile)
+
+    material = None
+    shading_group = None
+    assign_targets = geometry if geometry else curve_transforms
+    if material_color is not None:
+        material_color = _validate_vector(material_color, 3, "material_color")
+        material = cmds.shadingNode("lambert", asShader=True, name=material_name or f"{name}_mat")
+        cmds.setAttr(f"{material}.color", material_color[0], material_color[1], material_color[2], type="double3")
+        shading_group = cmds.sets(name=f"{material}SG", empty=True, renderable=True, noSurfaceShader=True)
+        cmds.connectAttr(f"{material}.outColor", f"{shading_group}.surfaceShader", force=True)
+        if assign_targets:
+            cmds.sets(assign_targets, edit=True, forceElement=shading_group)
+
+    output_group = None
+    if geometry:
+        output_group = cmds.group(geometry, name=f"{name}_geometry")
+    if geometry and not keep_curves and cmds.objExists(curve_group):
+        cmds.delete(curve_group)
+        curve_group = None
+    elif curve_group:
+        try:
+            cmds.rename(curve_group, f"{name}_curve_group")
+            curve_group = f"{name}_curve_group"
+        except Exception:
+            pass
+
+    return {
+        "success": True,
+        "name": output_group or curve_group,
+        "text": text,
+        "curve_group": curve_group,
+        "geometry_group": output_group,
+        "geometry": geometry,
+        "curve_count": len(curve_transforms),
+        "radius": radius,
+        "surface_offset": surface_offset,
+        "axis": axis,
+        "axis_center": axis_center,
+        "angle_start": angle_start,
+        "angle_end": angle_end,
+        "text_height": text_height,
+        "font": font,
+        "material": material,
+        "shading_group": shading_group,
+    }

--- a/src/mayatools/object/create_curved_text.py
+++ b/src/mayatools/object/create_curved_text.py
@@ -15,6 +15,7 @@ def create_curved_text(
     font: str = "Arial",
     fit_to_arc: bool = True,
     create_geometry: bool = True,
+    geometry_mode: str = "tube",
     bevel_radius: float = 0.008,
     bevel_segments: int = 6,
     keep_curves: bool = False,
@@ -24,9 +25,10 @@ def create_curved_text(
     """Create text curves or tube geometry conformed to a cylindrical surface.
 
     The text is generated as Maya text curves, mapped around a cylindrical
-    surface, and optionally converted into raised/engraved tube geometry. This
-    is useful for generic curved labels, embossing guides, raised outlines, and
-    engraved text on bottles, cups, cans, handles, or other cylindrical forms.
+    surface, and optionally converted into raised/engraved tube geometry or
+    filled polygon text patches. This is useful for generic curved labels,
+    embossing guides, raised outlines, filled text, and engraved text on
+    bottles, cups, cans, handles, or other cylindrical forms.
     """
     import math
     import random
@@ -68,6 +70,14 @@ def create_curved_text(
     if not isinstance(bevel_segments, int) or isinstance(bevel_segments, bool) or bevel_segments < 3:
         raise ValueError("bevel_segments must be an integer greater than or equal to 3.")
 
+    if not isinstance(geometry_mode, str):
+        raise ValueError("geometry_mode must be one of tube, filled, or curves.")
+    geometry_mode = geometry_mode.lower()
+    if geometry_mode not in {"tube", "filled", "curves"}:
+        raise ValueError("geometry_mode must be one of tube, filled, or curves.")
+    if not create_geometry:
+        geometry_mode = "curves"
+
     center = _validate_vector(center, 3, "center")
     axis = axis.lower()
     axes = {
@@ -102,6 +112,17 @@ def create_curved_text(
     theta_end = math.radians(angle_end)
     mapped_radius = radius + surface_offset
 
+    def _map_flat_position(flat_x, flat_y):
+        local_x = (flat_x - text_center_x) * scale
+        local_y = (flat_y - text_center_y) * scale
+        u = (local_x / arc_width) + 0.5
+        theta = theta_start + (theta_end - theta_start) * u
+        position = [center[0], center[1], center[2]]
+        position[axis_index] = center[axis_index] + axis_center + local_y
+        position[radial_a] = center[radial_a] + mapped_radius * math.sin(theta)
+        position[radial_b] = center[radial_b] + mapped_radius * math.cos(theta)
+        return position
+
     curve_shapes = cmds.listRelatives(curve_group, allDescendents=True, fullPath=True, type="nurbsCurve") or []
     curve_transforms = []
     for shape in curve_shapes:
@@ -109,22 +130,35 @@ def create_curved_text(
         if parents and parents[0] not in curve_transforms:
             curve_transforms.append(parents[0])
 
+    geometry = []
+    if geometry_mode == "filled":
+        for index, curve in enumerate(curve_transforms):
+            try:
+                mesh_result = cmds.planarSrf(
+                    curve,
+                    name=f"{name}_filled_geo_{index}",
+                    constructionHistory=False,
+                    object=True,
+                    polygon=1,
+                )
+                if not mesh_result:
+                    continue
+                mesh = mesh_result[0]
+                vertices = cmds.ls(f"{mesh}.vtx[*]", flatten=True) or []
+                for vertex in vertices:
+                    x, y, _ = cmds.xform(vertex, query=True, worldSpace=True, translation=True)
+                    cmds.xform(vertex, worldSpace=True, translation=_map_flat_position(x, y))
+                geometry.append(mesh)
+            except Exception:
+                continue
+
     for shape in curve_shapes:
         cvs = cmds.ls(f"{shape}.cv[*]", flatten=True) or []
         for cv in cvs:
             x, y, _ = cmds.xform(cv, query=True, worldSpace=True, translation=True)
-            local_x = (x - text_center_x) * scale
-            local_y = (y - text_center_y) * scale
-            u = (local_x / arc_width) + 0.5
-            theta = theta_start + (theta_end - theta_start) * u
-            position = [center[0], center[1], center[2]]
-            position[axis_index] = center[axis_index] + axis_center + local_y
-            position[radial_a] = center[radial_a] + mapped_radius * math.sin(theta)
-            position[radial_b] = center[radial_b] + mapped_radius * math.cos(theta)
-            cmds.xform(cv, worldSpace=True, translation=position)
+            cmds.xform(cv, worldSpace=True, translation=_map_flat_position(x, y))
 
-    geometry = []
-    if create_geometry and bevel_radius > 0:
+    if geometry_mode == "tube" and bevel_radius > 0:
         for index, path in enumerate(curve_transforms):
             profile = cmds.circle(
                 name=f"{name}_profile_{index}",
@@ -177,6 +211,7 @@ def create_curved_text(
         "success": True,
         "name": output_group or curve_group,
         "text": text,
+        "geometry_mode": geometry_mode,
         "curve_group": curve_group,
         "geometry_group": output_group,
         "geometry": geometry,

--- a/src/mayatools/object/create_curved_text.py
+++ b/src/mayatools/object/create_curved_text.py
@@ -11,6 +11,7 @@ def create_curved_text(
     angle_start: float = -45.0,
     angle_end: float = 45.0,
     text_height: float = 0.35,
+    text_rotation_degrees: float = 0.0,
     surface_offset: float = 0.02,
     font: str = "Arial",
     fit_to_arc: bool = True,
@@ -25,7 +26,8 @@ def create_curved_text(
     """Create text curves or tube geometry conformed to a cylindrical surface.
 
     The text is generated as Maya text curves, mapped around a cylindrical
-    surface, and optionally converted into raised/engraved tube geometry or
+    surface, optionally rotated in the flat tangent/axis plane before wrapping,
+    and optionally converted into raised/engraved tube geometry or
     filled polygon text patches. This is useful for generic curved labels,
     embossing guides, raised outlines, filled text, and engraved text on
     bottles, cups, cans, handles, or other cylindrical forms.
@@ -57,6 +59,7 @@ def create_curved_text(
     angle_start = _validate_scalar(angle_start, "angle_start")
     angle_end = _validate_scalar(angle_end, "angle_end")
     text_height = _validate_scalar(text_height, "text_height")
+    text_rotation_degrees = _validate_scalar(text_rotation_degrees, "text_rotation_degrees")
     surface_offset = _validate_scalar(surface_offset, "surface_offset")
     bevel_radius = _validate_scalar(bevel_radius, "bevel_radius")
     if radius <= 0:
@@ -97,24 +100,43 @@ def create_curved_text(
         curve_group = cmds.rename(curve_group, f"{name}_curves")
 
     bbox = cmds.exactWorldBoundingBox(curve_group)
-    width = max(1e-6, bbox[3] - bbox[0])
-    height = max(1e-6, bbox[4] - bbox[1])
     text_center_x = (bbox[0] + bbox[3]) * 0.5
     text_center_y = (bbox[1] + bbox[4]) * 0.5
     angle_span = math.radians(angle_end - angle_start)
     arc_width = radius * angle_span
+    rotation = math.radians(text_rotation_degrees)
+    cos_rotation = math.cos(rotation)
+    sin_rotation = math.sin(rotation)
+
+    rotated_corners = []
+    for corner_x, corner_y in [
+        (bbox[0], bbox[1]),
+        (bbox[0], bbox[4]),
+        (bbox[3], bbox[1]),
+        (bbox[3], bbox[4]),
+    ]:
+        raw_x = corner_x - text_center_x
+        raw_y = corner_y - text_center_y
+        rotated_corners.append((
+            raw_x * cos_rotation - raw_y * sin_rotation,
+            raw_x * sin_rotation + raw_y * cos_rotation,
+        ))
+    rotated_width = max(1e-6, max(point[0] for point in rotated_corners) - min(point[0] for point in rotated_corners))
+    rotated_height = max(1e-6, max(point[1] for point in rotated_corners) - min(point[1] for point in rotated_corners))
     if fit_to_arc:
-        scale = min(arc_width / width, text_height / height)
+        scale = min(arc_width / rotated_width, text_height / rotated_height)
     else:
-        scale = text_height / height
+        scale = text_height / rotated_height
 
     theta_start = math.radians(angle_start)
     theta_end = math.radians(angle_end)
     mapped_radius = radius + surface_offset
 
     def _map_flat_position(flat_x, flat_y):
-        local_x = (flat_x - text_center_x) * scale
-        local_y = (flat_y - text_center_y) * scale
+        raw_x = flat_x - text_center_x
+        raw_y = flat_y - text_center_y
+        local_x = (raw_x * cos_rotation - raw_y * sin_rotation) * scale
+        local_y = (raw_x * sin_rotation + raw_y * cos_rotation) * scale
         u = (local_x / arc_width) + 0.5
         theta = theta_start + (theta_end - theta_start) * u
         position = [center[0], center[1], center[2]]
@@ -223,6 +245,7 @@ def create_curved_text(
         "angle_start": angle_start,
         "angle_end": angle_end,
         "text_height": text_height,
+        "text_rotation_degrees": text_rotation_degrees,
         "font": font,
         "material": material,
         "shading_group": shading_group,

--- a/src/mayatools/object/create_cylindrical_detail_band.py
+++ b/src/mayatools/object/create_cylindrical_detail_band.py
@@ -1,0 +1,164 @@
+from typing import Dict, List, Any
+
+
+def create_cylindrical_detail_band(
+    name: str,
+    radius: float,
+    height: float,
+    center: List[float] = [0.0, 0.0, 0.0],
+    axis: str = "y",
+    radial_segments: int = 96,
+    height_segments: int = 8,
+    circumferential_cycles: int = 0,
+    circumferential_amplitude: float = 0.0,
+    circumferential_sharpness: float = 2.0,
+    circumferential_phase_degrees: float = 0.0,
+    vertical_cycles: int = 0,
+    vertical_amplitude: float = 0.0,
+    vertical_sharpness: float = 2.0,
+    vertical_phase_degrees: float = 0.0,
+    twist_degrees: float = 0.0,
+    waveform: str = "ridge",
+    smooth: bool = True,
+    material_color: List[float] = None,
+    material_name: str = None,
+) -> Dict[str, Any]:
+    """Create a UV-mapped cylindrical detail band with repeated radial features.
+
+    The band can represent generic cap knurling, grip ridges, ring grooves,
+    corrugation, or thread-like helical detail. It creates geometry only and is
+    not tied to any specific product or model.
+    """
+    import math
+    import maya.cmds as cmds
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(v) for v in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(v) for v in values]
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _pattern(angle, sharpness):
+        if waveform == "sin":
+            return math.sin(angle)
+        if waveform == "cosine":
+            return math.cos(angle)
+        value = max(0.0, 0.5 + 0.5 * math.cos(angle))
+        return value ** sharpness
+
+    if not name:
+        raise ValueError("name is required.")
+    radius = _validate_scalar(radius, "radius")
+    height = _validate_scalar(height, "height")
+    if radius <= 0:
+        raise ValueError("radius must be greater than zero.")
+    if height <= 0:
+        raise ValueError("height must be greater than zero.")
+    if not isinstance(radial_segments, int) or isinstance(radial_segments, bool) or radial_segments < 3:
+        raise ValueError("radial_segments must be at least 3.")
+    if not isinstance(height_segments, int) or isinstance(height_segments, bool) or height_segments < 1:
+        raise ValueError("height_segments must be at least 1.")
+    if not isinstance(circumferential_cycles, int) or isinstance(circumferential_cycles, bool):
+        raise ValueError("circumferential_cycles must be an integer greater than or equal to zero.")
+    if not isinstance(vertical_cycles, int) or isinstance(vertical_cycles, bool):
+        raise ValueError("vertical_cycles must be an integer greater than or equal to zero.")
+    if circumferential_cycles < 0 or vertical_cycles < 0:
+        raise ValueError("cycle counts must be greater than or equal to zero.")
+    circumferential_sharpness = _validate_scalar(circumferential_sharpness, "circumferential_sharpness")
+    vertical_sharpness = _validate_scalar(vertical_sharpness, "vertical_sharpness")
+    if circumferential_sharpness <= 0 or vertical_sharpness <= 0:
+        raise ValueError("sharpness values must be greater than zero.")
+
+    center = _validate_vector(center, 3, "center")
+    waveform = waveform.lower()
+    if waveform not in {"ridge", "groove", "sin", "cosine"}:
+        raise ValueError("waveform must be one of ridge, groove, sin, or cosine.")
+
+    axis = axis.lower()
+    axes = {
+        "x": (0, 1, 2),
+        "y": (1, 0, 2),
+        "z": (2, 0, 1),
+    }
+    if axis not in axes:
+        raise ValueError("axis must be one of x, y, or z.")
+    axis_index, radial_a, radial_b = axes[axis]
+
+    circumferential_amplitude = _validate_scalar(circumferential_amplitude, "circumferential_amplitude")
+    vertical_amplitude = _validate_scalar(vertical_amplitude, "vertical_amplitude")
+    circumferential_phase = math.radians(_validate_scalar(circumferential_phase_degrees, "circumferential_phase_degrees"))
+    vertical_phase = math.radians(_validate_scalar(vertical_phase_degrees, "vertical_phase_degrees"))
+    twist = math.radians(_validate_scalar(twist_degrees, "twist_degrees"))
+
+    band = cmds.polyPlane(
+        name=name,
+        width=1.0,
+        height=1.0,
+        subdivisionsX=radial_segments,
+        subdivisionsY=height_segments,
+        axis=[0, 0, 1],
+        constructionHistory=False,
+    )[0]
+
+    vertices = cmds.ls(f"{band}.vtx[*]", flatten=True) or []
+    for vertex in vertices:
+        x, y, _ = cmds.xform(vertex, query=True, objectSpace=True, translation=True)
+        u = max(0.0, min(1.0, x + 0.5))
+        v = max(0.0, min(1.0, y + 0.5))
+        theta = math.tau * u
+        phase_shift = twist * (v - 0.5)
+
+        offset = 0.0
+        if circumferential_cycles:
+            angle = circumferential_cycles * theta + phase_shift + circumferential_phase
+            offset += circumferential_amplitude * _pattern(angle, float(circumferential_sharpness))
+        if vertical_cycles:
+            angle = math.tau * vertical_cycles * v + vertical_phase
+            offset += vertical_amplitude * _pattern(angle, float(vertical_sharpness))
+
+        detail_radius = max(0.0, radius + offset)
+        position = [center[0], center[1], center[2]]
+        position[axis_index] = center[axis_index] + (v - 0.5) * height
+        position[radial_a] = center[radial_a] + detail_radius * math.sin(theta)
+        position[radial_b] = center[radial_b] + detail_radius * math.cos(theta)
+        cmds.xform(vertex, worldSpace=True, translation=position)
+
+    if smooth:
+        cmds.polySoftEdge(band, angle=180, constructionHistory=False)
+
+    material = None
+    shading_group = None
+    if material_color is not None:
+        material_color = _validate_vector(material_color, 3, "material_color")
+        material = cmds.shadingNode("lambert", asShader=True, name=material_name or f"{name}_mat")
+        cmds.setAttr(f"{material}.color", material_color[0], material_color[1], material_color[2], type="double3")
+        shading_group = cmds.sets(name=f"{material}SG", empty=True, renderable=True, noSurfaceShader=True)
+        cmds.connectAttr(f"{material}.outColor", f"{shading_group}.surfaceShader", force=True)
+        cmds.sets(band, edit=True, forceElement=shading_group)
+
+    return {
+        "success": True,
+        "name": band,
+        "radius": radius,
+        "height": height,
+        "center": center,
+        "axis": axis,
+        "radial_segments": radial_segments,
+        "height_segments": height_segments,
+        "circumferential_cycles": circumferential_cycles,
+        "circumferential_amplitude": circumferential_amplitude,
+        "vertical_cycles": vertical_cycles,
+        "vertical_amplitude": vertical_amplitude,
+        "twist_degrees": twist_degrees,
+        "waveform": waveform,
+        "material": material,
+        "shading_group": shading_group,
+        "uv_range": {"min_u": 0.0, "max_u": 1.0, "min_v": 0.0, "max_v": 1.0},
+    }

--- a/src/mayatools/object/create_cylindrical_surface_pattern.py
+++ b/src/mayatools/object/create_cylindrical_surface_pattern.py
@@ -1,0 +1,291 @@
+from typing import Dict, List, Any
+
+
+def create_cylindrical_surface_pattern(
+    name: str,
+    radius: float = 1.0,
+    surface_profile: List[List[float]] = None,
+    center: List[float] = [0.0, 0.0, 0.0],
+    axis: str = "y",
+    axis_range: List[float] = [0.0, 1.0],
+    angle_range_degrees: List[float] = [-45.0, 45.0],
+    axis_count: int = 6,
+    angle_count: int = 8,
+    patch_axis_radius: float = 0.03,
+    patch_angle_radius_degrees: float = 2.0,
+    patch_segments: int = 16,
+    patch_rings: int = 2,
+    surface_offset: float = 0.003,
+    center_offset: float = None,
+    dome_power: float = 2.0,
+    stagger: bool = False,
+    stagger_offset_degrees: float = 0.0,
+    material_type: str = "phong",
+    material_color: List[float] = None,
+    material_parameters: Dict[str, Any] = None,
+    material_name: str = None,
+    smooth: bool = True,
+) -> Dict[str, Any]:
+    """Create repeated conformal patches on a cylindrical or lathed surface.
+
+    The generated mesh contains elliptical surface patches arranged in an axial
+    and angular grid. Patches can sit on a constant radius cylinder or follow a
+    supplied [height, radius] surface profile, and their centers can be raised or
+    recessed relative to their edges. This is useful for generic grip dots,
+    molded dimples, rivets, vents, perforation markers, raised pads, inspection
+    points, and other repeated details on bottles, cans, cups, knobs, handles,
+    and similar near-axisymmetric models.
+    """
+    import math
+    import maya.cmds as cmds
+
+    try:
+        import maya.api.OpenMaya as om
+    except Exception as exc:
+        raise RuntimeError("maya.api.OpenMaya is required to create patch meshes.") from exc
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(value) for value in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(value) for value in values]
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _validate_count(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return value
+
+    def _positive_span(start_degrees, end_degrees):
+        span = (end_degrees - start_degrees) % 360.0
+        return 360.0 if abs(span) < 1e-8 else span
+
+    def _validate_profile(profile):
+        if profile is None:
+            return None
+        if not isinstance(profile, list) or len(profile) < 2:
+            raise ValueError("surface_profile must contain at least two [height, radius] points.")
+        clean = []
+        previous_height = None
+        for point in profile:
+            height, point_radius = _validate_vector(point, 2, "surface_profile point")
+            if point_radius < 0.0:
+                raise ValueError("surface_profile radii must be greater than or equal to zero.")
+            if previous_height is not None and height <= previous_height:
+                raise ValueError("surface_profile heights must be strictly increasing.")
+            clean.append([height, point_radius])
+            previous_height = height
+        return clean
+
+    def _profile_radius_at(profile, height):
+        if profile is None:
+            return radius
+        if height <= profile[0][0]:
+            return profile[0][1]
+        if height >= profile[-1][0]:
+            return profile[-1][1]
+        for index in range(len(profile) - 1):
+            h0, r0 = profile[index]
+            h1, r1 = profile[index + 1]
+            if h0 <= height <= h1:
+                t = (height - h0) / max(1e-9, h1 - h0)
+                return r0 + (r1 - r0) * t
+        return profile[-1][1]
+
+    def _patch_offset(ring_fraction):
+        if center_offset is None:
+            return surface_offset
+        weight = max(0.0, 1.0 - ring_fraction) ** dome_power
+        return surface_offset + (center_offset - surface_offset) * weight
+
+    def _surface_point(axis_value, angle_degrees, offset):
+        local_radius = max(0.0, _profile_radius_at(clean_profile, axis_value) + offset)
+        theta = math.radians(angle_degrees)
+        point = [center[0], center[1], center[2]]
+        point[axis_index] = center[axis_index] + axis_value
+        point[radial_a] = center[radial_a] + local_radius * math.sin(theta)
+        point[radial_b] = center[radial_b] + local_radius * math.cos(theta)
+        return point
+
+    def _make_material(mesh_transform):
+        if material_color is None:
+            return None, None
+        shader_type = str(material_type or "phong").lower().strip()
+        if shader_type not in {"lambert", "phong", "blinn"}:
+            raise ValueError("material_type must be one of lambert, phong, or blinn.")
+        color = _validate_vector(material_color, 3, "material_color")
+        shader = cmds.shadingNode(shader_type, asShader=True, name=material_name or f"{name}_mat")
+        cmds.setAttr(f"{shader}.color", color[0], color[1], color[2], type="double3")
+        for attr, value in (material_parameters or {}).items():
+            if not cmds.attributeQuery(attr, node=shader, exists=True):
+                continue
+            if isinstance(value, list) and len(value) == 3 and all(_is_number(item) for item in value):
+                attr_type = cmds.getAttr(f"{shader}.{attr}", type=True)
+                cmds.setAttr(f"{shader}.{attr}", float(value[0]), float(value[1]), float(value[2]), type=attr_type)
+            else:
+                cmds.setAttr(f"{shader}.{attr}", value)
+        shading_group = cmds.sets(name=f"{shader}SG", empty=True, renderable=True, noSurfaceShader=True)
+        cmds.connectAttr(f"{shader}.outColor", f"{shading_group}.surfaceShader", force=True)
+        cmds.sets(mesh_transform, edit=True, forceElement=shading_group)
+        return shader, shading_group
+
+    if not name:
+        raise ValueError("name is required.")
+    radius = _validate_scalar(radius, "radius")
+    if radius <= 0.0:
+        raise ValueError("radius must be greater than zero.")
+    center = _validate_vector(center, 3, "center")
+    axis_range = _validate_vector(axis_range, 2, "axis_range")
+    if axis_range[0] > axis_range[1]:
+        axis_range = [axis_range[1], axis_range[0]]
+    axis_span = axis_range[1] - axis_range[0]
+    if axis_span <= 0.0:
+        raise ValueError("axis_range must cover a positive span.")
+    angle_range_degrees = _validate_vector(angle_range_degrees, 2, "angle_range_degrees")
+    angle_span = _positive_span(angle_range_degrees[0], angle_range_degrees[1])
+    axis_count = _validate_count(axis_count, "axis_count", 1)
+    angle_count = _validate_count(angle_count, "angle_count", 1)
+    patch_segments = _validate_count(patch_segments, "patch_segments", 3)
+    patch_rings = _validate_count(patch_rings, "patch_rings", 1)
+    patch_axis_radius = _validate_scalar(patch_axis_radius, "patch_axis_radius")
+    patch_angle_radius_degrees = _validate_scalar(patch_angle_radius_degrees, "patch_angle_radius_degrees")
+    surface_offset = _validate_scalar(surface_offset, "surface_offset")
+    if center_offset is not None:
+        center_offset = _validate_scalar(center_offset, "center_offset")
+    dome_power = _validate_scalar(dome_power, "dome_power")
+    stagger_offset_degrees = _validate_scalar(stagger_offset_degrees, "stagger_offset_degrees")
+    if patch_axis_radius <= 0.0:
+        raise ValueError("patch_axis_radius must be greater than zero.")
+    if patch_angle_radius_degrees <= 0.0:
+        raise ValueError("patch_angle_radius_degrees must be greater than zero.")
+    if dome_power <= 0.0:
+        raise ValueError("dome_power must be greater than zero.")
+
+    clean_profile = _validate_profile(surface_profile)
+    if clean_profile is not None:
+        if axis_range[0] < clean_profile[0][0] or axis_range[1] > clean_profile[-1][0]:
+            raise ValueError("axis_range must be within the supplied surface_profile height range.")
+
+    axis = str(axis).lower().strip()
+    axes = {
+        "x": (0, 1, 2),
+        "y": (1, 0, 2),
+        "z": (2, 0, 1),
+    }
+    if axis not in axes:
+        raise ValueError("axis must be one of x, y, or z.")
+    axis_index, radial_a, radial_b = axes[axis]
+
+    angle_spacing = angle_span / float(angle_count)
+    if stagger and abs(stagger_offset_degrees) < 1e-8:
+        stagger_offset_degrees = angle_spacing * 0.5
+
+    feature_centers = []
+    for row_index in range(axis_count):
+        axis_t = (row_index + 0.5) / float(axis_count)
+        axis_value = axis_range[0] + axis_span * axis_t
+        row_offset = stagger_offset_degrees if stagger and row_index % 2 == 1 else 0.0
+        for column_index in range(angle_count):
+            angle_t = (column_index + 0.5) / float(angle_count)
+            angle_value = angle_range_degrees[0] + angle_span * angle_t + row_offset
+            feature_centers.append([axis_value, angle_value])
+
+    vertices = []
+    face_counts = []
+    face_connects = []
+    patch_summaries = []
+    for feature_index, (axis_center, angle_center) in enumerate(feature_centers):
+        center_index = len(vertices)
+        vertices.append(_surface_point(axis_center, angle_center, _patch_offset(0.0)))
+        rings = []
+        for ring_index in range(1, patch_rings + 1):
+            ring_fraction = ring_index / float(patch_rings)
+            ring = []
+            for segment_index in range(patch_segments):
+                phi = math.tau * segment_index / float(patch_segments)
+                point_axis = axis_center + math.cos(phi) * patch_axis_radius * ring_fraction
+                point_angle = angle_center + math.sin(phi) * patch_angle_radius_degrees * ring_fraction
+                ring.append(len(vertices))
+                vertices.append(_surface_point(point_axis, point_angle, _patch_offset(ring_fraction)))
+            rings.append(ring)
+
+        first_ring = rings[0]
+        for segment_index in range(patch_segments):
+            next_segment = (segment_index + 1) % patch_segments
+            face_counts.append(3)
+            face_connects.extend([center_index, first_ring[next_segment], first_ring[segment_index]])
+        for ring_index in range(1, len(rings)):
+            inner = rings[ring_index - 1]
+            outer = rings[ring_index]
+            for segment_index in range(patch_segments):
+                next_segment = (segment_index + 1) % patch_segments
+                face_counts.append(4)
+                face_connects.extend([
+                    inner[segment_index],
+                    inner[next_segment],
+                    outer[next_segment],
+                    outer[segment_index],
+                ])
+        patch_summaries.append({
+            "index": feature_index,
+            "axis_center": axis_center,
+            "angle_center_degrees": angle_center,
+        })
+
+    try:
+        mesh_fn = om.MFnMesh()
+        mesh_fn.create(
+            [om.MPoint(point[0], point[1], point[2]) for point in vertices],
+            face_counts,
+            face_connects,
+        )
+        mesh_shape = mesh_fn.fullPathName()
+        parents = cmds.listRelatives(mesh_shape, parent=True, fullPath=False) or []
+        mesh_transform = parents[0] if parents else mesh_shape
+        mesh_transform = cmds.rename(mesh_transform, name)
+    except Exception as exc:
+        raise RuntimeError(f"Unable to create cylindrical surface pattern mesh: {exc}") from exc
+
+    if smooth:
+        cmds.polySoftEdge(mesh_transform, angle=180, constructionHistory=False)
+
+    material = None
+    shading_group = None
+    if material_color is not None:
+        material, shading_group = _make_material(mesh_transform)
+
+    return {
+        "success": True,
+        "name": mesh_transform,
+        "feature_count": len(feature_centers),
+        "axis": axis,
+        "center": center,
+        "radius": radius,
+        "surface_profile_point_count": len(clean_profile) if clean_profile is not None else 0,
+        "axis_range": axis_range,
+        "angle_range_degrees": angle_range_degrees,
+        "angle_span_degrees": angle_span,
+        "axis_count": axis_count,
+        "angle_count": angle_count,
+        "patch_axis_radius": patch_axis_radius,
+        "patch_angle_radius_degrees": patch_angle_radius_degrees,
+        "patch_segments": patch_segments,
+        "patch_rings": patch_rings,
+        "surface_offset": surface_offset,
+        "center_offset": center_offset,
+        "dome_power": dome_power,
+        "stagger": bool(stagger),
+        "stagger_offset_degrees": stagger_offset_degrees,
+        "vertex_count": len(vertices),
+        "face_count": len(face_counts),
+        "material": material,
+        "shading_group": shading_group,
+        "feature_centers_sample": patch_summaries[:50],
+        "bounding_box": cmds.exactWorldBoundingBox(mesh_transform),
+    }

--- a/src/mayatools/object/create_cylindrical_tube_paths.py
+++ b/src/mayatools/object/create_cylindrical_tube_paths.py
@@ -1,0 +1,346 @@
+from typing import Dict, List, Any
+
+
+def create_cylindrical_tube_paths(
+    name: str,
+    paths: List[List[List[float]]],
+    radius: float = 1.0,
+    surface_profile: List[List[float]] = None,
+    center: List[float] = [0.0, 0.0, 0.0],
+    axis: str = "y",
+    surface_offset: float = 0.02,
+    tube_radius: float = 0.01,
+    radial_segments: int = 8,
+    cap_ends: bool = True,
+    closed: bool = False,
+    min_segment_length: float = 0.0001,
+    material_type: str = "phong",
+    material_color: List[float] = None,
+    material_parameters: Dict[str, Any] = None,
+    material_name: str = None,
+    smooth: bool = True,
+) -> Dict[str, Any]:
+    """Create tube geometry from cylindrical surface path coordinates.
+
+    Each path point is [axis_value, angle_degrees] or
+    [axis_value, angle_degrees, point_surface_offset]. The generated polygon
+    tubes follow either a constant radius cylinder or a supplied
+    [axis_value, radius] profile, making the tool useful for generic molded
+    scripts, raised seams, engraved guide lines, grip outlines, weld beads,
+    routed wires, and other surface-following line details on bottles, cans,
+    handles, knobs, and similar near-axisymmetric forms.
+    """
+    import math
+    import maya.cmds as cmds
+
+    try:
+        import maya.api.OpenMaya as om
+    except Exception as exc:
+        raise RuntimeError("maya.api.OpenMaya is required to create tube meshes.") from exc
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(value) for value in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(value) for value in values]
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return int(value)
+
+    def _validate_profile(profile):
+        if profile is None:
+            return None
+        if not isinstance(profile, list) or len(profile) < 2:
+            raise ValueError("surface_profile must contain at least two [axis_value, radius] points.")
+        clean = []
+        previous_axis_value = None
+        for point in profile:
+            axis_value, point_radius = _validate_vector(point, 2, "surface_profile point")
+            if point_radius < 0.0:
+                raise ValueError("surface_profile radii must be greater than or equal to zero.")
+            if previous_axis_value is not None and axis_value <= previous_axis_value:
+                raise ValueError("surface_profile axis values must be strictly increasing.")
+            clean.append([axis_value, point_radius])
+            previous_axis_value = axis_value
+        return clean
+
+    def _profile_radius_at(profile, axis_value):
+        if profile is None:
+            return radius
+        if axis_value <= profile[0][0]:
+            return profile[0][1]
+        if axis_value >= profile[-1][0]:
+            return profile[-1][1]
+        for index in range(len(profile) - 1):
+            value0, radius0 = profile[index]
+            value1, radius1 = profile[index + 1]
+            if value0 <= axis_value <= value1:
+                t = (axis_value - value0) / max(1e-9, value1 - value0)
+                return radius0 + (radius1 - radius0) * t
+        return profile[-1][1]
+
+    def _surface_point(axis_value, angle_degrees, point_offset):
+        local_radius = max(0.0, _profile_radius_at(clean_profile, axis_value) + surface_offset + point_offset)
+        theta = math.radians(angle_degrees)
+        point = [center[0], center[1], center[2]]
+        point[axis_index] = center[axis_index] + axis_value
+        point[radial_a] = center[radial_a] + local_radius * math.sin(theta)
+        point[radial_b] = center[radial_b] + local_radius * math.cos(theta)
+        return point
+
+    def _sub(a, b):
+        return [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
+
+    def _add(a, b):
+        return [a[0] + b[0], a[1] + b[1], a[2] + b[2]]
+
+    def _mul(a, scalar):
+        return [a[0] * scalar, a[1] * scalar, a[2] * scalar]
+
+    def _dot(a, b):
+        return a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+
+    def _cross(a, b):
+        return [
+            a[1] * b[2] - a[2] * b[1],
+            a[2] * b[0] - a[0] * b[2],
+            a[0] * b[1] - a[1] * b[0],
+        ]
+
+    def _length(a):
+        return math.sqrt(_dot(a, a))
+
+    def _normalize(a):
+        length = _length(a)
+        if length <= 1e-12:
+            return None
+        return [a[0] / length, a[1] / length, a[2] / length]
+
+    def _distance(a, b):
+        return _length(_sub(a, b))
+
+    def _initial_frame(tangent):
+        reference = [0.0, 1.0, 0.0]
+        if abs(_dot(reference, tangent)) > 0.9:
+            reference = [1.0, 0.0, 0.0]
+        normal = _normalize(_cross(reference, tangent))
+        if normal is None:
+            normal = [1.0, 0.0, 0.0]
+        binormal = _normalize(_cross(tangent, normal)) or [0.0, 0.0, 1.0]
+        return normal, binormal
+
+    def _path_tangent(path_points, index, is_closed):
+        count = len(path_points)
+        if is_closed:
+            previous_point = path_points[(index - 1) % count]
+            next_point = path_points[(index + 1) % count]
+            tangent = _normalize(_sub(next_point, previous_point))
+        elif index == 0:
+            tangent = _normalize(_sub(path_points[1], path_points[0]))
+        elif index == count - 1:
+            tangent = _normalize(_sub(path_points[-1], path_points[-2]))
+        else:
+            tangent = _normalize(_sub(path_points[index + 1], path_points[index - 1]))
+        return tangent or [0.0, 1.0, 0.0]
+
+    def _clean_surface_path(surface_path):
+        if not isinstance(surface_path, list) or len(surface_path) < 2:
+            raise ValueError("Each path must contain at least two points.")
+        clean = []
+        for point in surface_path:
+            if not isinstance(point, list) or len(point) not in {2, 3}:
+                raise ValueError("Path points must be [axis_value, angle_degrees] or [axis_value, angle_degrees, offset].")
+            axis_value = _validate_scalar(point[0], "path point axis_value")
+            angle_degrees = _validate_scalar(point[1], "path point angle_degrees")
+            point_offset = _validate_scalar(point[2], "path point offset") if len(point) == 3 else 0.0
+            world_point = _surface_point(axis_value, angle_degrees, point_offset)
+            if clean and _distance(clean[-1], world_point) < min_segment_length:
+                continue
+            clean.append(world_point)
+        path_closed = bool(closed)
+        if len(clean) >= 3 and _distance(clean[0], clean[-1]) < min_segment_length:
+            clean.pop()
+            path_closed = True
+        return clean, path_closed
+
+    def _append_tube(path_points, path_closed, path_index):
+        start_vertex_count = len(vertices)
+        start_face_count = len(face_counts)
+        ring_indices = []
+        previous_normal = None
+        for point_index, point in enumerate(path_points):
+            tangent = _path_tangent(path_points, point_index, path_closed)
+            if previous_normal is None:
+                normal, binormal = _initial_frame(tangent)
+            else:
+                projected = _sub(previous_normal, _mul(tangent, _dot(previous_normal, tangent)))
+                normal = _normalize(projected)
+                if normal is None:
+                    normal, binormal = _initial_frame(tangent)
+                else:
+                    binormal = _normalize(_cross(tangent, normal)) or [0.0, 0.0, 1.0]
+            previous_normal = normal
+
+            ring = []
+            for segment_index in range(radial_segments):
+                angle = math.tau * segment_index / float(radial_segments)
+                offset_vector = _add(
+                    _mul(normal, math.cos(angle) * tube_radius),
+                    _mul(binormal, math.sin(angle) * tube_radius),
+                )
+                vertices.append(_add(point, offset_vector))
+                ring.append(len(vertices) - 1)
+            ring_indices.append(ring)
+
+        segment_count = len(ring_indices) if path_closed else len(ring_indices) - 1
+        for ring_index in range(segment_count):
+            next_ring_index = (ring_index + 1) % len(ring_indices)
+            for segment_index in range(radial_segments):
+                next_segment_index = (segment_index + 1) % radial_segments
+                face_counts.append(4)
+                face_connects.extend([
+                    ring_indices[ring_index][segment_index],
+                    ring_indices[ring_index][next_segment_index],
+                    ring_indices[next_ring_index][next_segment_index],
+                    ring_indices[next_ring_index][segment_index],
+                ])
+
+        if cap_ends and not path_closed:
+            start_center = len(vertices)
+            vertices.append(path_points[0][:])
+            end_center = len(vertices)
+            vertices.append(path_points[-1][:])
+            first_ring = ring_indices[0]
+            last_ring = ring_indices[-1]
+            for segment_index in range(radial_segments):
+                next_segment_index = (segment_index + 1) % radial_segments
+                face_counts.append(3)
+                face_connects.extend([start_center, first_ring[segment_index], first_ring[next_segment_index]])
+                face_counts.append(3)
+                face_connects.extend([end_center, last_ring[next_segment_index], last_ring[segment_index]])
+
+        return {
+            "path_index": path_index,
+            "input_points": len(path_points),
+            "closed": bool(path_closed),
+            "vertices": len(vertices) - start_vertex_count,
+            "faces": len(face_counts) - start_face_count,
+        }
+
+    def _make_material(mesh_transform):
+        if material_color is None:
+            return None, None
+        shader_type = str(material_type or "phong").lower().strip()
+        if shader_type not in {"lambert", "phong", "blinn"}:
+            raise ValueError("material_type must be one of lambert, phong, or blinn.")
+        color = _validate_vector(material_color, 3, "material_color")
+        shader = cmds.shadingNode(shader_type, asShader=True, name=material_name or f"{name}_mat")
+        cmds.setAttr(f"{shader}.color", color[0], color[1], color[2], type="double3")
+        for attr, value in (material_parameters or {}).items():
+            if not cmds.attributeQuery(attr, node=shader, exists=True):
+                continue
+            if isinstance(value, list) and len(value) == 3 and all(_is_number(item) for item in value):
+                attr_type = cmds.getAttr(f"{shader}.{attr}", type=True)
+                cmds.setAttr(f"{shader}.{attr}", float(value[0]), float(value[1]), float(value[2]), type=attr_type)
+            else:
+                cmds.setAttr(f"{shader}.{attr}", value)
+        shading_group = cmds.sets(name=f"{shader}SG", empty=True, renderable=True, noSurfaceShader=True)
+        cmds.connectAttr(f"{shader}.outColor", f"{shading_group}.surfaceShader", force=True)
+        cmds.sets(mesh_transform, edit=True, forceElement=shading_group)
+        return shader, shading_group
+
+    if not name:
+        raise ValueError("name is required.")
+    if not isinstance(paths, list) or not paths:
+        raise ValueError("paths must be a non-empty list of paths.")
+    radius = _validate_scalar(radius, "radius")
+    if radius <= 0.0:
+        raise ValueError("radius must be greater than zero.")
+    center = _validate_vector(center, 3, "center")
+    surface_offset = _validate_scalar(surface_offset, "surface_offset")
+    tube_radius = _validate_scalar(tube_radius, "tube_radius")
+    if tube_radius <= 0.0:
+        raise ValueError("tube_radius must be greater than zero.")
+    radial_segments = _validate_int(radial_segments, "radial_segments", 3)
+    min_segment_length = _validate_scalar(min_segment_length, "min_segment_length")
+    if min_segment_length < 0.0:
+        raise ValueError("min_segment_length must be greater than or equal to zero.")
+
+    clean_profile = _validate_profile(surface_profile)
+    axis = str(axis).lower().strip()
+    axes = {
+        "x": (0, 1, 2),
+        "y": (1, 0, 2),
+        "z": (2, 0, 1),
+    }
+    if axis not in axes:
+        raise ValueError("axis must be one of x, y, or z.")
+    axis_index, radial_a, radial_b = axes[axis]
+
+    vertices = []
+    face_counts = []
+    face_connects = []
+    path_summaries = []
+    skipped_paths = []
+    for path_index, surface_path in enumerate(paths):
+        path_points, path_closed = _clean_surface_path(surface_path)
+        if len(path_points) < 2 or (path_closed and len(path_points) < 3):
+            skipped_paths.append({"path_index": path_index, "reason": "fewer than two usable points"})
+            continue
+        path_summaries.append(_append_tube(path_points, path_closed, path_index))
+
+    if not vertices or not face_counts:
+        raise ValueError("No tube geometry could be created from the provided paths.")
+
+    try:
+        mesh_fn = om.MFnMesh()
+        mesh_fn.create(
+            [om.MPoint(point[0], point[1], point[2]) for point in vertices],
+            face_counts,
+            face_connects,
+        )
+        mesh_shape = mesh_fn.fullPathName()
+        parents = cmds.listRelatives(mesh_shape, parent=True, fullPath=False) or []
+        mesh_transform = parents[0] if parents else mesh_shape
+        mesh_transform = cmds.rename(mesh_transform, name)
+    except Exception as exc:
+        raise RuntimeError(f"Unable to create cylindrical tube path mesh: {exc}") from exc
+
+    if smooth:
+        cmds.polySoftEdge(mesh_transform, angle=180, constructionHistory=False)
+
+    material = None
+    shading_group = None
+    if material_color is not None:
+        material, shading_group = _make_material(mesh_transform)
+
+    return {
+        "success": True,
+        "name": mesh_transform,
+        "path_count": len(path_summaries),
+        "skipped_paths": skipped_paths,
+        "tube_radius": tube_radius,
+        "radial_segments": radial_segments,
+        "cap_ends": bool(cap_ends),
+        "closed": bool(closed),
+        "axis": axis,
+        "center": center,
+        "radius": radius,
+        "surface_profile_point_count": len(clean_profile) if clean_profile is not None else 0,
+        "surface_offset": surface_offset,
+        "vertex_count": len(vertices),
+        "face_count": len(face_counts),
+        "paths": path_summaries,
+        "material": material,
+        "shading_group": shading_group,
+        "bounding_box": cmds.exactWorldBoundingBox(mesh_transform),
+    }

--- a/src/mayatools/object/create_object.py
+++ b/src/mayatools/object/create_object.py
@@ -7,14 +7,55 @@ def create_object(
     object_type:str, 
     translate:List[float]=[0.0, 0.0, 0.0], 
     rotate:List[float]=[0.0, 0.0, 0.0],
+    parameters:Dict[str, Any]=None,
+    material_color:List[float]=None,
+    material_name:str=None,
 ) -> Dict[str, Any]:
     """ Creates an object in the Maya scene. Object types available are
         cube, cone, sphere, cylinder, camera, spotLight, pointLight, directionalLight.
-        Rotate values are in degrees. """
+        Rotate values are in degrees. Optional primitive parameters can set
+        dimensions such as radius, height, width, depth, and subdivisions. """
     import maya.cmds as cmds
 
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
     def _validate_vector3d(vec:List[float]):
-        return isinstance(vec, list) and len(vec) == 3 and all([isinstance(v, float) for v in vec])
+        return isinstance(vec, list) and len(vec) == 3 and all([_is_number(v) for v in vec])
+
+    def _number_param(key, default, minimum=None):
+        value = parameters.get(key, default)
+        if not _is_number(value):
+            raise ValueError(f"parameters.{key} must be numeric.")
+        value = float(value)
+        if minimum is not None and value < minimum:
+            raise ValueError(f"parameters.{key} must be greater than or equal to {minimum}.")
+        return value
+
+    def _int_param(key, default, minimum=None):
+        value = parameters.get(key, default)
+        if not isinstance(value, int) or isinstance(value, bool):
+            raise ValueError(f"parameters.{key} must be an integer.")
+        if minimum is not None and value < minimum:
+            raise ValueError(f"parameters.{key} must be greater than or equal to {minimum}.")
+        return value
+
+    def _assign_material(transform):
+        if material_color is None:
+            return None, None
+        if not _validate_vector3d(material_color):
+            raise ValueError("material_color must be a list of 3 numeric values.")
+        shader = cmds.shadingNode("lambert", asShader=True, name=material_name or f"{name}_mat")
+        cmds.setAttr(f"{shader}.color", float(material_color[0]), float(material_color[1]), float(material_color[2]), type="double3")
+        shading_group = cmds.sets(name=f"{shader}SG", empty=True, renderable=True, noSurfaceShader=True)
+        cmds.connectAttr(f"{shader}.outColor", f"{shading_group}.surfaceShader", force=True)
+        cmds.sets(transform, edit=True, forceElement=shading_group)
+        return shader, shading_group
+
+    if parameters is None:
+        parameters = {}
+    if not isinstance(parameters, dict):
+        raise ValueError("parameters must be a dictionary.")
 
     if not _validate_vector3d(translate):
         raise ValueError("Invalid translate format. Must be a list of 3 float values.")
@@ -22,13 +63,44 @@ def create_object(
         raise ValueError("Invalid rotate format. Must be a list of 3 float values.")
 
     if object_type == "cube":
-        obj = cmds.polyCube(name=name)
+        obj = cmds.polyCube(
+            name=name,
+            width=_number_param("width", 1.0, 0.0),
+            height=_number_param("height", 1.0, 0.0),
+            depth=_number_param("depth", 1.0, 0.0),
+            subdivisionsX=_int_param("subdivisionsX", 1, 1),
+            subdivisionsY=_int_param("subdivisionsY", 1, 1),
+            subdivisionsZ=_int_param("subdivisionsZ", 1, 1),
+            constructionHistory=False,
+        )
     elif object_type == "cone":
-        obj = cmds.polyCone(name=name)
+        obj = cmds.polyCone(
+            name=name,
+            radius=_number_param("radius", 1.0, 0.0),
+            height=_number_param("height", 2.0, 0.0),
+            subdivisionsAxis=_int_param("subdivisionsAxis", 20, 3),
+            subdivisionsHeight=_int_param("subdivisionsHeight", 1, 1),
+            subdivisionsCaps=_int_param("subdivisionsCaps", 0, 0),
+            constructionHistory=False,
+        )
     elif object_type == "sphere":
-        obj = cmds.polySphere(name=name)
+        obj = cmds.polySphere(
+            name=name,
+            radius=_number_param("radius", 1.0, 0.0),
+            subdivisionsX=_int_param("subdivisionsX", 20, 3),
+            subdivisionsY=_int_param("subdivisionsY", 20, 3),
+            constructionHistory=False,
+        )
     elif object_type == "cylinder":
-        obj = cmds.polyCylinder(name=name)
+        obj = cmds.polyCylinder(
+            name=name,
+            radius=_number_param("radius", 1.0, 0.0),
+            height=_number_param("height", 2.0, 0.0),
+            subdivisionsAxis=_int_param("subdivisionsAxis", 20, 3),
+            subdivisionsHeight=_int_param("subdivisionsHeight", 1, 1),
+            subdivisionsCaps=_int_param("subdivisionsCaps", 1, 0),
+            constructionHistory=False,
+        )
     elif object_type == "camera":
         obj = cmds.camera(name=name)
     elif object_type == "spotLight":
@@ -40,16 +112,29 @@ def create_object(
     else:
         raise ValueError(f"Error: unknown {object_type}, use one of these types: cube, cone, sphere, cylinder, camera, spotLight, pointLight, directionalLight")
 
-    cmds.setAttr(obj[0]+".translate", translate[0], translate[1], translate[2], type="double3")
-    cmds.setAttr(obj[0]+".rotate", rotate[0], rotate[1], rotate[2], type="double3")
+    raw_node = obj[0] if isinstance(obj, (list, tuple)) else obj
+    if cmds.objExists(raw_node) and cmds.objectType(raw_node) != "transform":
+        parents = cmds.listRelatives(raw_node, parent=True) or []
+        transform = parents[0] if parents else raw_node
+    else:
+        transform = raw_node
+    shapes = cmds.listRelatives(transform, shapes=True) or []
+    shape = shapes[0] if shapes else (obj[1] if isinstance(obj, (list, tuple)) and len(obj) > 1 else None)
+
+    cmds.setAttr(transform+".translate", translate[0], translate[1], translate[2], type="double3")
+    cmds.setAttr(transform+".rotate", rotate[0], rotate[1], rotate[2], type="double3")
+    material, shading_group = _assign_material(transform)
 
     return {
         "success": True,
-        "name": obj[0],
-        "shape": obj[1],
+        "name": transform,
+        "shape": shape,
         "object_type": object_type,
         "translate": translate,
         "rotate": rotate,
+        "parameters": parameters,
+        "material": material,
+        "shading_group": shading_group,
     }
         
 

--- a/src/mayatools/object/create_revolved_liquid_volume.py
+++ b/src/mayatools/object/create_revolved_liquid_volume.py
@@ -9,6 +9,8 @@ def create_revolved_liquid_volume(
     radius_offset: float = -0.02,
     radial_segments: int = 96,
     height_segments: int = 0,
+    angle_start: float = 0.0,
+    angle_end: float = 360.0,
     profile_interpolation: str = "linear",
     center: List[float] = [0.0, 0.0, 0.0],
     cap_top: bool = True,
@@ -23,6 +25,8 @@ def create_revolved_liquid_volume(
     The container profile is a list of [height, radius] pairs around the Y axis.
     The generated liquid surface can be inset with radius_offset to avoid
     overlapping a container wall, and it can include flat top and bottom caps.
+    angle_start/angle_end can limit the generated volume to an angular sector
+    for cutaway vessels, front-facing product previews, or partial fill views.
     This is useful for generic bottles, glasses, cups, jars, tanks, and other
     transparent or cutaway vessels that need a visible fill volume.
     """
@@ -139,6 +143,14 @@ def create_revolved_liquid_volume(
     radius_offset = _validate_scalar(radius_offset, "radius_offset")
     radial_segments = _validate_segments(radial_segments, "radial_segments", 3)
     height_segments = _validate_segments(height_segments, "height_segments", 0)
+    angle_start = _validate_scalar(angle_start, "angle_start")
+    angle_end = _validate_scalar(angle_end, "angle_end")
+    angle_span_degrees = angle_end - angle_start
+    if angle_span_degrees <= 0.0 or angle_span_degrees > 360.0:
+        raise ValueError("angle_end must be greater than angle_start and span no more than 360 degrees.")
+    full_revolve = abs(angle_span_degrees - 360.0) <= 1e-6
+    theta_start = math.radians(angle_start)
+    theta_span = math.radians(angle_span_degrees)
     cap_thickness = _validate_scalar(cap_thickness, "cap_thickness")
     if cap_thickness <= 0.0:
         raise ValueError("cap_thickness must be greater than zero.")
@@ -181,7 +193,7 @@ def create_revolved_liquid_volume(
         profile_index = int(round((y + 0.5) * max_profile_index))
         profile_index = max(0, min(max_profile_index, profile_index))
         profile_height, radius = sampled_profile[profile_index]
-        theta = math.tau * u
+        theta = theta_start + theta_span * u
         world_x = center[0] + radius * math.sin(theta)
         world_y = center[1] + profile_height
         world_z = center[2] + radius * math.cos(theta)
@@ -189,34 +201,63 @@ def create_revolved_liquid_volume(
 
     parts = [side]
     caps = []
+
+    def _create_sector_cap(cap_name, radius, height, normal_sign):
+        if full_revolve:
+            cap = cmds.polyCylinder(
+                name=cap_name,
+                radius=radius,
+                height=cap_thickness,
+                subdivisionsAxis=radial_segments,
+                subdivisionsHeight=1,
+                constructionHistory=False,
+            )[0]
+            cmds.setAttr(f"{cap}.translate", center[0], center[1] + height, center[2], type="double3")
+            return cap
+
+        triangles = []
+        for index in range(radial_segments):
+            theta0 = theta_start + theta_span * (index / float(radial_segments))
+            theta1 = theta_start + theta_span * ((index + 1) / float(radial_segments))
+            center_point = [center[0], center[1] + height, center[2]]
+            point0 = [center[0] + radius * math.sin(theta0), center[1] + height, center[2] + radius * math.cos(theta0)]
+            point1 = [center[0] + radius * math.sin(theta1), center[1] + height, center[2] + radius * math.cos(theta1)]
+            points = [center_point, point0, point1] if normal_sign >= 0 else [center_point, point1, point0]
+            triangle = cmds.polyCreateFacet(name=f"{cap_name}_tri", point=points, constructionHistory=False)[0]
+            triangles.append(triangle)
+
+        if not triangles:
+            return None
+        cap = triangles[0]
+        if len(triangles) > 1:
+            cap = cmds.polyUnite(triangles, name=cap_name, constructionHistory=False)[0]
+            for triangle in triangles:
+                if triangle != cap and cmds.objExists(triangle):
+                    try:
+                        cmds.delete(triangle)
+                    except Exception:
+                        pass
+        try:
+            cmds.polyMergeVertex(cap, distance=1e-6, constructionHistory=False)
+            cmds.delete(cap, constructionHistory=True)
+        except Exception:
+            pass
+        return cap
+
     if cap_top:
         top_radius = sampled_profile[-1][1]
         if top_radius > 0.0:
-            top = cmds.polyCylinder(
-                name=f"{name}_top_surface",
-                radius=top_radius,
-                height=cap_thickness,
-                subdivisionsAxis=radial_segments,
-                subdivisionsHeight=1,
-                constructionHistory=False,
-            )[0]
-            cmds.setAttr(f"{top}.translate", center[0], center[1] + fill_height, center[2], type="double3")
-            parts.append(top)
-            caps.append(top)
+            top = _create_sector_cap(f"{name}_top_surface", top_radius, fill_height, 1.0)
+            if top:
+                parts.append(top)
+                caps.append(top)
     if cap_bottom:
         bottom_radius = sampled_profile[0][1]
         if bottom_radius > 0.0:
-            bottom = cmds.polyCylinder(
-                name=f"{name}_bottom_surface",
-                radius=bottom_radius,
-                height=cap_thickness,
-                subdivisionsAxis=radial_segments,
-                subdivisionsHeight=1,
-                constructionHistory=False,
-            )[0]
-            cmds.setAttr(f"{bottom}.translate", center[0], center[1] + bottom_height, center[2], type="double3")
-            parts.append(bottom)
-            caps.append(bottom)
+            bottom = _create_sector_cap(f"{name}_bottom_surface", bottom_radius, bottom_height, -1.0)
+            if bottom:
+                parts.append(bottom)
+                caps.append(bottom)
 
     if smooth:
         for part in parts:
@@ -265,6 +306,9 @@ def create_revolved_liquid_volume(
         "radius_offset": radius_offset,
         "radial_segments": radial_segments,
         "height_segments": len(sampled_profile) - 1,
+        "angle_start": angle_start,
+        "angle_end": angle_end,
+        "angle_span": angle_span_degrees,
         "profile_interpolation": profile_interpolation,
         "cap_top": cap_top,
         "cap_bottom": cap_bottom,

--- a/src/mayatools/object/create_revolved_liquid_volume.py
+++ b/src/mayatools/object/create_revolved_liquid_volume.py
@@ -1,0 +1,275 @@
+from typing import Dict, List, Any
+
+
+def create_revolved_liquid_volume(
+    name: str,
+    container_profile: List[List[float]],
+    fill_height: float,
+    bottom_height: float = None,
+    radius_offset: float = -0.02,
+    radial_segments: int = 96,
+    height_segments: int = 0,
+    profile_interpolation: str = "linear",
+    center: List[float] = [0.0, 0.0, 0.0],
+    cap_top: bool = True,
+    cap_bottom: bool = True,
+    cap_thickness: float = 0.001,
+    smooth: bool = True,
+    material_color: List[float] = None,
+    material_name: str = None,
+) -> Dict[str, Any]:
+    """Create an axisymmetric liquid volume inside a lathed container profile.
+
+    The container profile is a list of [height, radius] pairs around the Y axis.
+    The generated liquid surface can be inset with radius_offset to avoid
+    overlapping a container wall, and it can include flat top and bottom caps.
+    This is useful for generic bottles, glasses, cups, jars, tanks, and other
+    transparent or cutaway vessels that need a visible fill volume.
+    """
+    import math
+    import maya.cmds as cmds
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(v) for v in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(v) for v in values]
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _validate_segments(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return value
+
+    def _validate_profile(profile):
+        if not isinstance(profile, list) or len(profile) < 2:
+            raise ValueError("container_profile must contain at least two [height, radius] points.")
+        clean = []
+        previous_height = None
+        for point in profile:
+            height, radius = _validate_vector(point, 2, "container_profile point")
+            if radius < 0:
+                raise ValueError("container_profile radii must be greater than or equal to zero.")
+            if previous_height is not None and height <= previous_height:
+                raise ValueError("container_profile heights must be strictly increasing.")
+            clean.append([height, radius])
+            previous_height = height
+        if not any(radius > 0 for _, radius in clean):
+            raise ValueError("container_profile must contain at least one positive radius.")
+        return clean
+
+    def _profile_radius_at(profile, height, interpolation):
+        if height <= profile[0][0]:
+            return profile[0][1]
+        if height >= profile[-1][0]:
+            return profile[-1][1]
+
+        segment_index = 0
+        for index in range(len(profile) - 1):
+            if profile[index][0] <= height <= profile[index + 1][0]:
+                segment_index = index
+                break
+
+        h0, r0 = profile[segment_index]
+        h1, r1 = profile[segment_index + 1]
+        t = (height - h0) / max(1e-9, h1 - h0)
+        if interpolation == "linear":
+            return r0 + (r1 - r0) * t
+
+        def _slope(point_index):
+            if point_index <= 0:
+                ha, ra = profile[0]
+                hb, rb = profile[1]
+            elif point_index >= len(profile) - 1:
+                ha, ra = profile[-2]
+                hb, rb = profile[-1]
+            else:
+                ha, ra = profile[point_index - 1]
+                hb, rb = profile[point_index + 1]
+            return (rb - ra) / max(1e-9, hb - ha)
+
+        m0 = _slope(segment_index)
+        m1 = _slope(segment_index + 1)
+        t2 = t * t
+        t3 = t2 * t
+        span = h1 - h0
+        radius = (
+            (2.0 * t3 - 3.0 * t2 + 1.0) * r0
+            + (t3 - 2.0 * t2 + t) * span * m0
+            + (-2.0 * t3 + 3.0 * t2) * r1
+            + (t3 - t2) * span * m1
+        )
+        lower = min(r0, r1)
+        upper = max(r0, r1)
+        return max(0.0, min(upper, max(lower, radius)))
+
+    def _liquid_radius_at(profile, height, interpolation):
+        return max(0.0, _profile_radius_at(profile, height, interpolation) + radius_offset)
+
+    def _sample_profile(profile, start_height, end_height, requested_segments, interpolation):
+        if requested_segments > 0:
+            return [
+                [
+                    start_height + (end_height - start_height) * (index / float(requested_segments)),
+                    _liquid_radius_at(profile, start_height + (end_height - start_height) * (index / float(requested_segments)), interpolation),
+                ]
+                for index in range(requested_segments + 1)
+            ]
+
+        sampled = [[start_height, _liquid_radius_at(profile, start_height, interpolation)]]
+        for height, _ in profile:
+            if start_height < height < end_height:
+                sampled.append([height, _liquid_radius_at(profile, height, interpolation)])
+        sampled.append([end_height, _liquid_radius_at(profile, end_height, interpolation)])
+        return sampled
+
+    if not name:
+        raise ValueError("name is required.")
+    clean_profile = _validate_profile(container_profile)
+    fill_height = _validate_scalar(fill_height, "fill_height")
+    if bottom_height is None:
+        bottom_height = clean_profile[0][0]
+    bottom_height = _validate_scalar(bottom_height, "bottom_height")
+    radius_offset = _validate_scalar(radius_offset, "radius_offset")
+    radial_segments = _validate_segments(radial_segments, "radial_segments", 3)
+    height_segments = _validate_segments(height_segments, "height_segments", 0)
+    cap_thickness = _validate_scalar(cap_thickness, "cap_thickness")
+    if cap_thickness <= 0.0:
+        raise ValueError("cap_thickness must be greater than zero.")
+
+    if not isinstance(profile_interpolation, str):
+        raise ValueError("profile_interpolation must be one of linear or smooth.")
+    profile_interpolation = profile_interpolation.lower()
+    if profile_interpolation not in {"linear", "smooth"}:
+        raise ValueError("profile_interpolation must be one of linear or smooth.")
+    center = _validate_vector(center, 3, "center")
+
+    profile_min = clean_profile[0][0]
+    profile_max = clean_profile[-1][0]
+    if bottom_height < profile_min or bottom_height > profile_max:
+        raise ValueError("bottom_height must be within the container_profile height range.")
+    if fill_height < profile_min or fill_height > profile_max:
+        raise ValueError("fill_height must be within the container_profile height range.")
+    if fill_height <= bottom_height:
+        raise ValueError("fill_height must be greater than bottom_height.")
+
+    sampled_profile = _sample_profile(clean_profile, bottom_height, fill_height, height_segments, profile_interpolation)
+    if not any(radius > 0.0 for _, radius in sampled_profile):
+        raise ValueError("Liquid radius is zero throughout the requested fill range.")
+
+    side = cmds.polyPlane(
+        name=f"{name}_side",
+        width=1.0,
+        height=1.0,
+        subdivisionsX=radial_segments,
+        subdivisionsY=len(sampled_profile) - 1,
+        axis=[0, 0, 1],
+        constructionHistory=False,
+    )[0]
+
+    max_profile_index = len(sampled_profile) - 1
+    vertices = cmds.ls(f"{side}.vtx[*]", flatten=True) or []
+    for vertex in vertices:
+        x, y, _ = cmds.xform(vertex, query=True, objectSpace=True, translation=True)
+        u = max(0.0, min(1.0, x + 0.5))
+        profile_index = int(round((y + 0.5) * max_profile_index))
+        profile_index = max(0, min(max_profile_index, profile_index))
+        profile_height, radius = sampled_profile[profile_index]
+        theta = math.tau * u
+        world_x = center[0] + radius * math.sin(theta)
+        world_y = center[1] + profile_height
+        world_z = center[2] + radius * math.cos(theta)
+        cmds.xform(vertex, worldSpace=True, translation=[world_x, world_y, world_z])
+
+    parts = [side]
+    caps = []
+    if cap_top:
+        top_radius = sampled_profile[-1][1]
+        if top_radius > 0.0:
+            top = cmds.polyCylinder(
+                name=f"{name}_top_surface",
+                radius=top_radius,
+                height=cap_thickness,
+                subdivisionsAxis=radial_segments,
+                subdivisionsHeight=1,
+                constructionHistory=False,
+            )[0]
+            cmds.setAttr(f"{top}.translate", center[0], center[1] + fill_height, center[2], type="double3")
+            parts.append(top)
+            caps.append(top)
+    if cap_bottom:
+        bottom_radius = sampled_profile[0][1]
+        if bottom_radius > 0.0:
+            bottom = cmds.polyCylinder(
+                name=f"{name}_bottom_surface",
+                radius=bottom_radius,
+                height=cap_thickness,
+                subdivisionsAxis=radial_segments,
+                subdivisionsHeight=1,
+                constructionHistory=False,
+            )[0]
+            cmds.setAttr(f"{bottom}.translate", center[0], center[1] + bottom_height, center[2], type="double3")
+            parts.append(bottom)
+            caps.append(bottom)
+
+    if smooth:
+        for part in parts:
+            cmds.polySoftEdge(part, angle=180, constructionHistory=False)
+
+    source_part_count = len(parts)
+    cap_count = len(caps)
+    liquid = side
+    if len(parts) > 1:
+        liquid = cmds.polyUnite(parts, name=name, constructionHistory=False)[0]
+        for part in parts:
+            if part != liquid and cmds.objExists(part):
+                try:
+                    cmds.delete(part)
+                except Exception:
+                    pass
+        try:
+            cmds.delete(liquid, constructionHistory=True)
+        except Exception:
+            pass
+        if smooth:
+            cmds.polySoftEdge(liquid, angle=180, constructionHistory=False)
+    else:
+        liquid = cmds.rename(side, name)
+
+    material = None
+    shading_group = None
+    if material_color is not None:
+        material_color = _validate_vector(material_color, 3, "material_color")
+        material = cmds.shadingNode("lambert", asShader=True, name=material_name or f"{name}_mat")
+        cmds.setAttr(f"{material}.color", material_color[0], material_color[1], material_color[2], type="double3")
+        shading_group = cmds.sets(name=f"{material}SG", empty=True, renderable=True, noSurfaceShader=True)
+        cmds.connectAttr(f"{material}.outColor", f"{shading_group}.surfaceShader", force=True)
+        cmds.sets(liquid, edit=True, forceElement=shading_group)
+
+    return {
+        "success": True,
+        "name": liquid,
+        "created": [liquid],
+        "source_part_count": source_part_count,
+        "cap_count": cap_count,
+        "container_profile": clean_profile,
+        "liquid_profile": sampled_profile,
+        "fill_height": fill_height,
+        "bottom_height": bottom_height,
+        "radius_offset": radius_offset,
+        "radial_segments": radial_segments,
+        "height_segments": len(sampled_profile) - 1,
+        "profile_interpolation": profile_interpolation,
+        "cap_top": cap_top,
+        "cap_bottom": cap_bottom,
+        "cap_thickness": cap_thickness,
+        "material": material,
+        "shading_group": shading_group,
+        "uv_range": {"min_u": 0.0, "max_u": 1.0, "min_v": 0.0, "max_v": 1.0},
+    }

--- a/src/mayatools/object/create_revolved_mesh.py
+++ b/src/mayatools/object/create_revolved_mesh.py
@@ -1,0 +1,124 @@
+from typing import Dict, List, Any
+
+
+def create_revolved_mesh(
+    name: str,
+    profile: List[List[float]],
+    radial_segments: int = 64,
+    center: List[float] = [0.0, 0.0, 0.0],
+    smooth: bool = True,
+    cap_ends: bool = False,
+    material_color: List[float] = None,
+    material_name: str = None,
+) -> Dict[str, Any]:
+    """Create a UV-mapped polygon mesh by revolving a radius/height profile.
+
+    Profile points are [height, radius] pairs in bottom-to-top order around the
+    Y axis. The generated side surface preserves a clean 0..1 UV layout, which
+    makes it useful for bottles, cups, vases, lampshades, and similar lathed
+    forms that need texture placement.
+    """
+    import math
+    import maya.cmds as cmds
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_vector(values, length, name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(v) for v in values):
+            raise ValueError(f"{name} must be a list of {length} numeric values.")
+        return [float(v) for v in values]
+
+    if not name:
+        raise ValueError("name is required.")
+    if not isinstance(profile, list) or len(profile) < 2:
+        raise ValueError("profile must contain at least two [height, radius] points.")
+    if radial_segments < 3:
+        raise ValueError("radial_segments must be at least 3.")
+
+    center = _validate_vector(center, 3, "center")
+
+    clean_profile = []
+    previous_height = None
+    for point in profile:
+        height, radius = _validate_vector(point, 2, "profile point")
+        if radius < 0:
+            raise ValueError("profile radii must be greater than or equal to zero.")
+        if previous_height is not None and height <= previous_height:
+            raise ValueError("profile heights must be strictly increasing from bottom to top.")
+        clean_profile.append([height, radius])
+        previous_height = height
+
+    if not any(radius > 0 for _, radius in clean_profile):
+        raise ValueError("profile must contain at least one radius greater than zero.")
+
+    mesh = cmds.polyPlane(
+        name=name,
+        width=1.0,
+        height=1.0,
+        subdivisionsX=radial_segments,
+        subdivisionsY=len(clean_profile) - 1,
+        axis=[0, 0, 1],
+        constructionHistory=False,
+    )[0]
+
+    max_profile_index = len(clean_profile) - 1
+    vertices = cmds.ls(f"{mesh}.vtx[*]", flatten=True) or []
+    for vertex in vertices:
+        x, y, _ = cmds.xform(vertex, query=True, objectSpace=True, translation=True)
+        u = max(0.0, min(1.0, x + 0.5))
+        profile_index = int(round((y + 0.5) * max_profile_index))
+        profile_index = max(0, min(max_profile_index, profile_index))
+        profile_height, radius = clean_profile[profile_index]
+        theta = math.tau * u
+        world_x = center[0] + radius * math.sin(theta)
+        world_y = center[1] + profile_height
+        world_z = center[2] + radius * math.cos(theta)
+        cmds.xform(vertex, worldSpace=True, translation=[world_x, world_y, world_z])
+
+    if smooth:
+        cmds.polySoftEdge(mesh, angle=180, constructionHistory=False)
+
+    created = [mesh]
+    caps = []
+    if cap_ends:
+        for cap_name, profile_index in [("bottom", 0), ("top", -1)]:
+            height, radius = clean_profile[profile_index]
+            if radius <= 0:
+                continue
+            cap = cmds.polyCylinder(
+                name=f"{name}_{cap_name}_cap",
+                radius=radius,
+                height=0.001,
+                subdivisionsAxis=radial_segments,
+                subdivisionsHeight=1,
+                constructionHistory=False,
+            )[0]
+            cmds.setAttr(f"{cap}.translate", center[0], center[1] + height, center[2], type="double3")
+            created.append(cap)
+            caps.append(cap)
+            if smooth:
+                cmds.polySoftEdge(cap, angle=180, constructionHistory=False)
+
+    material = None
+    shading_group = None
+    if material_color is not None:
+        material_color = _validate_vector(material_color, 3, "material_color")
+        material = cmds.shadingNode("lambert", asShader=True, name=material_name or f"{name}_mat")
+        cmds.setAttr(f"{material}.color", material_color[0], material_color[1], material_color[2], type="double3")
+        shading_group = cmds.sets(name=f"{material}SG", empty=True, renderable=True, noSurfaceShader=True)
+        cmds.connectAttr(f"{material}.outColor", f"{shading_group}.surfaceShader", force=True)
+        cmds.sets(created, edit=True, forceElement=shading_group)
+
+    return {
+        "success": True,
+        "name": mesh,
+        "created": created,
+        "caps": caps,
+        "profile": clean_profile,
+        "radial_segments": radial_segments,
+        "center": center,
+        "material": material,
+        "shading_group": shading_group,
+        "uv_range": {"min_u": 0.0, "max_u": 1.0, "min_v": 0.0, "max_v": 1.0},
+    }

--- a/src/mayatools/object/create_revolved_mesh.py
+++ b/src/mayatools/object/create_revolved_mesh.py
@@ -5,6 +5,8 @@ def create_revolved_mesh(
     name: str,
     profile: List[List[float]],
     radial_segments: int = 64,
+    height_segments: int = 0,
+    profile_interpolation: str = "linear",
     center: List[float] = [0.0, 0.0, 0.0],
     smooth: bool = True,
     cap_ends: bool = False,
@@ -14,9 +16,11 @@ def create_revolved_mesh(
     """Create a UV-mapped polygon mesh by revolving a radius/height profile.
 
     Profile points are [height, radius] pairs in bottom-to-top order around the
-    Y axis. The generated side surface preserves a clean 0..1 UV layout, which
-    makes it useful for bottles, cups, vases, lampshades, and similar lathed
-    forms that need texture placement.
+    Y axis. Optional height_segments and profile_interpolation can resample a
+    sparse control profile into a denser linear or smooth lathed contour. The
+    generated side surface preserves a clean 0..1 UV layout, which makes it
+    useful for bottles, cups, vases, lampshades, and similar forms that need
+    texture placement.
     """
     import math
     import maya.cmds as cmds
@@ -29,12 +33,79 @@ def create_revolved_mesh(
             raise ValueError(f"{name} must be a list of {length} numeric values.")
         return [float(v) for v in values]
 
+    def _validate_segments(value, name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{name} must be an integer greater than or equal to {minimum}.")
+        return value
+
+    def _profile_radius_at(clean_profile, height, interpolation):
+        if height <= clean_profile[0][0]:
+            return clean_profile[0][1]
+        if height >= clean_profile[-1][0]:
+            return clean_profile[-1][1]
+
+        segment_index = 0
+        for index in range(len(clean_profile) - 1):
+            if clean_profile[index][0] <= height <= clean_profile[index + 1][0]:
+                segment_index = index
+                break
+
+        h0, r0 = clean_profile[segment_index]
+        h1, r1 = clean_profile[segment_index + 1]
+        t = (height - h0) / max(1e-9, h1 - h0)
+        if interpolation == "linear":
+            return r0 + (r1 - r0) * t
+
+        def _slope(point_index):
+            if point_index <= 0:
+                ha, ra = clean_profile[0]
+                hb, rb = clean_profile[1]
+            elif point_index >= len(clean_profile) - 1:
+                ha, ra = clean_profile[-2]
+                hb, rb = clean_profile[-1]
+            else:
+                ha, ra = clean_profile[point_index - 1]
+                hb, rb = clean_profile[point_index + 1]
+            return (rb - ra) / max(1e-9, hb - ha)
+
+        m0 = _slope(segment_index)
+        m1 = _slope(segment_index + 1)
+        t2 = t * t
+        t3 = t2 * t
+        span = h1 - h0
+        radius = (
+            (2.0 * t3 - 3.0 * t2 + 1.0) * r0
+            + (t3 - 2.0 * t2 + t) * span * m0
+            + (-2.0 * t3 + 3.0 * t2) * r1
+            + (t3 - t2) * span * m1
+        )
+        lower = min(r0, r1)
+        upper = max(r0, r1)
+        return max(0.0, min(upper, max(lower, radius)))
+
+    def _sample_profile(clean_profile, requested_segments, interpolation):
+        if requested_segments == 0:
+            return [point[:] for point in clean_profile]
+        start_height = clean_profile[0][0]
+        end_height = clean_profile[-1][0]
+        sampled = []
+        for index in range(requested_segments + 1):
+            t = index / float(requested_segments)
+            height = start_height + (end_height - start_height) * t
+            sampled.append([height, _profile_radius_at(clean_profile, height, interpolation)])
+        return sampled
+
     if not name:
         raise ValueError("name is required.")
     if not isinstance(profile, list) or len(profile) < 2:
         raise ValueError("profile must contain at least two [height, radius] points.")
-    if radial_segments < 3:
-        raise ValueError("radial_segments must be at least 3.")
+    radial_segments = _validate_segments(radial_segments, "radial_segments", 3)
+    height_segments = _validate_segments(height_segments, "height_segments", 0)
+    if not isinstance(profile_interpolation, str):
+        raise ValueError("profile_interpolation must be one of linear or smooth.")
+    profile_interpolation = profile_interpolation.lower()
+    if profile_interpolation not in {"linear", "smooth"}:
+        raise ValueError("profile_interpolation must be one of linear or smooth.")
 
     center = _validate_vector(center, 3, "center")
 
@@ -51,25 +122,26 @@ def create_revolved_mesh(
 
     if not any(radius > 0 for _, radius in clean_profile):
         raise ValueError("profile must contain at least one radius greater than zero.")
+    sampled_profile = _sample_profile(clean_profile, height_segments, profile_interpolation)
 
     mesh = cmds.polyPlane(
         name=name,
         width=1.0,
         height=1.0,
         subdivisionsX=radial_segments,
-        subdivisionsY=len(clean_profile) - 1,
+        subdivisionsY=len(sampled_profile) - 1,
         axis=[0, 0, 1],
         constructionHistory=False,
     )[0]
 
-    max_profile_index = len(clean_profile) - 1
+    max_profile_index = len(sampled_profile) - 1
     vertices = cmds.ls(f"{mesh}.vtx[*]", flatten=True) or []
     for vertex in vertices:
         x, y, _ = cmds.xform(vertex, query=True, objectSpace=True, translation=True)
         u = max(0.0, min(1.0, x + 0.5))
         profile_index = int(round((y + 0.5) * max_profile_index))
         profile_index = max(0, min(max_profile_index, profile_index))
-        profile_height, radius = clean_profile[profile_index]
+        profile_height, radius = sampled_profile[profile_index]
         theta = math.tau * u
         world_x = center[0] + radius * math.sin(theta)
         world_y = center[1] + profile_height
@@ -83,7 +155,7 @@ def create_revolved_mesh(
     caps = []
     if cap_ends:
         for cap_name, profile_index in [("bottom", 0), ("top", -1)]:
-            height, radius = clean_profile[profile_index]
+            height, radius = sampled_profile[profile_index]
             if radius <= 0:
                 continue
             cap = cmds.polyCylinder(
@@ -115,8 +187,11 @@ def create_revolved_mesh(
         "name": mesh,
         "created": created,
         "caps": caps,
-        "profile": clean_profile,
+        "profile": sampled_profile,
+        "input_profile": clean_profile,
         "radial_segments": radial_segments,
+        "height_segments": len(sampled_profile) - 1,
+        "profile_interpolation": profile_interpolation,
         "center": center,
         "material": material,
         "shading_group": shading_group,

--- a/src/mayatools/object/create_revolved_shell.py
+++ b/src/mayatools/object/create_revolved_shell.py
@@ -1,0 +1,182 @@
+from typing import Dict, List, Any
+
+
+def create_revolved_shell(
+    name: str,
+    outer_profile: List[List[float]],
+    inner_profile: List[List[float]] = None,
+    wall_thickness: float = 0.04,
+    radial_segments: int = 64,
+    center: List[float] = [0.0, 0.0, 0.0],
+    connect_top: bool = True,
+    connect_bottom: bool = True,
+    smooth: bool = True,
+    material_color: List[float] = None,
+    material_name: str = None,
+) -> Dict[str, Any]:
+    """Create a UV-mapped hollow lathed shell from radius/height profiles.
+
+    Outer and inner profile points are [height, radius] pairs around the Y axis.
+    If inner_profile is omitted, it is derived from outer_profile by subtracting
+    wall_thickness from each radius. The result is useful for generic thick-wall
+    bottles, cups, shades, vessels, and similar lathed forms.
+    """
+    import math
+    import maya.cmds as cmds
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(v) for v in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(v) for v in values]
+
+    def _validate_profile(profile, arg_name):
+        if not isinstance(profile, list) or len(profile) < 2:
+            raise ValueError(f"{arg_name} must contain at least two [height, radius] points.")
+        clean = []
+        previous_height = None
+        for point in profile:
+            height, radius = _validate_vector(point, 2, f"{arg_name} point")
+            if radius < 0:
+                raise ValueError(f"{arg_name} radii must be greater than or equal to zero.")
+            if previous_height is not None and height <= previous_height:
+                raise ValueError(f"{arg_name} heights must be strictly increasing.")
+            clean.append([height, radius])
+            previous_height = height
+        if not any(radius > 0 for _, radius in clean):
+            raise ValueError(f"{arg_name} must contain at least one radius greater than zero.")
+        return clean
+
+    if not name:
+        raise ValueError("name is required.")
+    if radial_segments < 3:
+        raise ValueError("radial_segments must be at least 3.")
+    if not _is_number(wall_thickness) or wall_thickness <= 0:
+        raise ValueError("wall_thickness must be a number greater than zero.")
+
+    center = _validate_vector(center, 3, "center")
+    clean_outer = _validate_profile(outer_profile, "outer_profile")
+    if inner_profile is None:
+        clean_inner = [[height, max(0.0, radius - float(wall_thickness))] for height, radius in clean_outer]
+    else:
+        clean_inner = _validate_profile(inner_profile, "inner_profile")
+        if len(clean_inner) != len(clean_outer):
+            raise ValueError("inner_profile must have the same number of points as outer_profile.")
+        for outer, inner in zip(clean_outer, clean_inner):
+            if abs(outer[0] - inner[0]) > 1e-6:
+                raise ValueError("inner_profile heights must match outer_profile heights.")
+            if inner[1] > outer[1]:
+                raise ValueError("inner_profile radii cannot be greater than outer_profile radii.")
+
+    if not any(outer[1] > inner[1] for outer, inner in zip(clean_outer, clean_inner)):
+        raise ValueError("The shell must have positive radial thickness somewhere.")
+
+    def _create_profile_surface(surface_name, profile):
+        surface = cmds.polyPlane(
+            name=surface_name,
+            width=1.0,
+            height=1.0,
+            subdivisionsX=radial_segments,
+            subdivisionsY=len(profile) - 1,
+            axis=[0, 0, 1],
+            constructionHistory=False,
+        )[0]
+        max_profile_index = len(profile) - 1
+        vertices = cmds.ls(f"{surface}.vtx[*]", flatten=True) or []
+        for vertex in vertices:
+            x, y, _ = cmds.xform(vertex, query=True, objectSpace=True, translation=True)
+            u = max(0.0, min(1.0, x + 0.5))
+            profile_index = int(round((y + 0.5) * max_profile_index))
+            profile_index = max(0, min(max_profile_index, profile_index))
+            profile_height, radius = profile[profile_index]
+            theta = math.tau * u
+            world_x = center[0] + radius * math.sin(theta)
+            world_y = center[1] + profile_height
+            world_z = center[2] + radius * math.cos(theta)
+            cmds.xform(vertex, worldSpace=True, translation=[world_x, world_y, world_z])
+        if smooth:
+            cmds.polySoftEdge(surface, angle=180, constructionHistory=False)
+        return surface
+
+    def _create_connector_surface(surface_name, outer_point, inner_point):
+        outer_height, outer_radius = outer_point
+        inner_height, inner_radius = inner_point
+        connector = cmds.polyPlane(
+            name=surface_name,
+            width=1.0,
+            height=1.0,
+            subdivisionsX=radial_segments,
+            subdivisionsY=1,
+            axis=[0, 0, 1],
+            constructionHistory=False,
+        )[0]
+        vertices = cmds.ls(f"{connector}.vtx[*]", flatten=True) or []
+        for vertex in vertices:
+            x, y, _ = cmds.xform(vertex, query=True, objectSpace=True, translation=True)
+            u = max(0.0, min(1.0, x + 0.5))
+            t = max(0.0, min(1.0, y + 0.5))
+            radius = outer_radius + (inner_radius - outer_radius) * t
+            height = outer_height + (inner_height - outer_height) * t
+            theta = math.tau * u
+            world_x = center[0] + radius * math.sin(theta)
+            world_y = center[1] + height
+            world_z = center[2] + radius * math.cos(theta)
+            cmds.xform(vertex, worldSpace=True, translation=[world_x, world_y, world_z])
+        if smooth:
+            cmds.polySoftEdge(connector, angle=180, constructionHistory=False)
+        return connector
+
+    parts = [
+        _create_profile_surface(f"{name}_outer_surface", clean_outer),
+        _create_profile_surface(f"{name}_inner_surface", clean_inner),
+    ]
+    if connect_top:
+        parts.append(_create_connector_surface(f"{name}_top_rim", clean_outer[-1], clean_inner[-1]))
+    if connect_bottom:
+        parts.append(_create_connector_surface(f"{name}_bottom_rim", clean_outer[0], clean_inner[0]))
+
+    shell = parts[0]
+    if len(parts) > 1:
+        shell = cmds.polyUnite(parts, name=name, constructionHistory=False)[0]
+        for part in parts:
+            if part != shell and cmds.objExists(part):
+                try:
+                    cmds.delete(part)
+                except Exception:
+                    pass
+    else:
+        shell = cmds.rename(shell, name)
+
+    try:
+        cmds.delete(shell, constructionHistory=True)
+    except Exception:
+        pass
+    if smooth:
+        cmds.polySoftEdge(shell, angle=180, constructionHistory=False)
+
+    material = None
+    shading_group = None
+    if material_color is not None:
+        material_color = _validate_vector(material_color, 3, "material_color")
+        material = cmds.shadingNode("lambert", asShader=True, name=material_name or f"{name}_mat")
+        cmds.setAttr(f"{material}.color", material_color[0], material_color[1], material_color[2], type="double3")
+        shading_group = cmds.sets(name=f"{material}SG", empty=True, renderable=True, noSurfaceShader=True)
+        cmds.connectAttr(f"{material}.outColor", f"{shading_group}.surfaceShader", force=True)
+        cmds.sets(shell, edit=True, forceElement=shading_group)
+
+    return {
+        "success": True,
+        "name": shell,
+        "outer_profile": clean_outer,
+        "inner_profile": clean_inner,
+        "wall_thickness": float(wall_thickness),
+        "radial_segments": radial_segments,
+        "center": center,
+        "connect_top": connect_top,
+        "connect_bottom": connect_bottom,
+        "material": material,
+        "shading_group": shading_group,
+        "uv_range": {"min_u": 0.0, "max_u": 1.0, "min_v": 0.0, "max_v": 1.0},
+    }

--- a/src/mayatools/object/create_revolved_shell.py
+++ b/src/mayatools/object/create_revolved_shell.py
@@ -7,6 +7,8 @@ def create_revolved_shell(
     inner_profile: List[List[float]] = None,
     wall_thickness: float = 0.04,
     radial_segments: int = 64,
+    height_segments: int = 0,
+    profile_interpolation: str = "linear",
     center: List[float] = [0.0, 0.0, 0.0],
     connect_top: bool = True,
     connect_bottom: bool = True,
@@ -18,8 +20,10 @@ def create_revolved_shell(
 
     Outer and inner profile points are [height, radius] pairs around the Y axis.
     If inner_profile is omitted, it is derived from outer_profile by subtracting
-    wall_thickness from each radius. The result is useful for generic thick-wall
-    bottles, cups, shades, vessels, and similar lathed forms.
+    wall_thickness from each radius. Optional height_segments and
+    profile_interpolation can resample sparse control profiles into denser
+    linear or smooth lathed contours. The result is useful for generic
+    thick-wall bottles, cups, shades, vessels, and similar lathed forms.
     """
     import math
     import maya.cmds as cmds
@@ -49,28 +53,97 @@ def create_revolved_shell(
             raise ValueError(f"{arg_name} must contain at least one radius greater than zero.")
         return clean
 
+    def _validate_segments(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return value
+
+    def _profile_radius_at(profile, height, interpolation):
+        if height <= profile[0][0]:
+            return profile[0][1]
+        if height >= profile[-1][0]:
+            return profile[-1][1]
+
+        segment_index = 0
+        for index in range(len(profile) - 1):
+            if profile[index][0] <= height <= profile[index + 1][0]:
+                segment_index = index
+                break
+
+        h0, r0 = profile[segment_index]
+        h1, r1 = profile[segment_index + 1]
+        t = (height - h0) / max(1e-9, h1 - h0)
+        if interpolation == "linear":
+            return r0 + (r1 - r0) * t
+
+        def _slope(point_index):
+            if point_index <= 0:
+                ha, ra = profile[0]
+                hb, rb = profile[1]
+            elif point_index >= len(profile) - 1:
+                ha, ra = profile[-2]
+                hb, rb = profile[-1]
+            else:
+                ha, ra = profile[point_index - 1]
+                hb, rb = profile[point_index + 1]
+            return (rb - ra) / max(1e-9, hb - ha)
+
+        m0 = _slope(segment_index)
+        m1 = _slope(segment_index + 1)
+        t2 = t * t
+        t3 = t2 * t
+        span = h1 - h0
+        radius = (
+            (2.0 * t3 - 3.0 * t2 + 1.0) * r0
+            + (t3 - 2.0 * t2 + t) * span * m0
+            + (-2.0 * t3 + 3.0 * t2) * r1
+            + (t3 - t2) * span * m1
+        )
+        lower = min(r0, r1)
+        upper = max(r0, r1)
+        return max(0.0, min(upper, max(lower, radius)))
+
+    def _sample_profile(profile, requested_segments, interpolation, heights=None):
+        if heights is None:
+            if requested_segments == 0:
+                return [point[:] for point in profile]
+            start_height = profile[0][0]
+            end_height = profile[-1][0]
+            heights = [
+                start_height + (end_height - start_height) * (index / float(requested_segments))
+                for index in range(requested_segments + 1)
+            ]
+        return [[height, _profile_radius_at(profile, height, interpolation)] for height in heights]
+
     if not name:
         raise ValueError("name is required.")
-    if radial_segments < 3:
-        raise ValueError("radial_segments must be at least 3.")
+    radial_segments = _validate_segments(radial_segments, "radial_segments", 3)
+    height_segments = _validate_segments(height_segments, "height_segments", 0)
+    if not isinstance(profile_interpolation, str):
+        raise ValueError("profile_interpolation must be one of linear or smooth.")
+    profile_interpolation = profile_interpolation.lower()
+    if profile_interpolation not in {"linear", "smooth"}:
+        raise ValueError("profile_interpolation must be one of linear or smooth.")
     if not _is_number(wall_thickness) or wall_thickness <= 0:
         raise ValueError("wall_thickness must be a number greater than zero.")
 
     center = _validate_vector(center, 3, "center")
     clean_outer = _validate_profile(outer_profile, "outer_profile")
+    sampled_outer = _sample_profile(clean_outer, height_segments, profile_interpolation)
+    sample_heights = [height for height, _ in sampled_outer]
     if inner_profile is None:
-        clean_inner = [[height, max(0.0, radius - float(wall_thickness))] for height, radius in clean_outer]
+        clean_inner = None
+        sampled_inner = [[height, max(0.0, radius - float(wall_thickness))] for height, radius in sampled_outer]
     else:
         clean_inner = _validate_profile(inner_profile, "inner_profile")
-        if len(clean_inner) != len(clean_outer):
-            raise ValueError("inner_profile must have the same number of points as outer_profile.")
-        for outer, inner in zip(clean_outer, clean_inner):
-            if abs(outer[0] - inner[0]) > 1e-6:
-                raise ValueError("inner_profile heights must match outer_profile heights.")
+        if abs(clean_inner[0][0] - clean_outer[0][0]) > 1e-6 or abs(clean_inner[-1][0] - clean_outer[-1][0]) > 1e-6:
+            raise ValueError("inner_profile height range must match outer_profile height range.")
+        sampled_inner = _sample_profile(clean_inner, height_segments, profile_interpolation, sample_heights)
+        for outer, inner in zip(sampled_outer, sampled_inner):
             if inner[1] > outer[1]:
                 raise ValueError("inner_profile radii cannot be greater than outer_profile radii.")
 
-    if not any(outer[1] > inner[1] for outer, inner in zip(clean_outer, clean_inner)):
+    if not any(outer[1] > inner[1] for outer, inner in zip(sampled_outer, sampled_inner)):
         raise ValueError("The shell must have positive radial thickness somewhere.")
 
     def _create_profile_surface(surface_name, profile):
@@ -129,13 +202,13 @@ def create_revolved_shell(
         return connector
 
     parts = [
-        _create_profile_surface(f"{name}_outer_surface", clean_outer),
-        _create_profile_surface(f"{name}_inner_surface", clean_inner),
+        _create_profile_surface(f"{name}_outer_surface", sampled_outer),
+        _create_profile_surface(f"{name}_inner_surface", sampled_inner),
     ]
     if connect_top:
-        parts.append(_create_connector_surface(f"{name}_top_rim", clean_outer[-1], clean_inner[-1]))
+        parts.append(_create_connector_surface(f"{name}_top_rim", sampled_outer[-1], sampled_inner[-1]))
     if connect_bottom:
-        parts.append(_create_connector_surface(f"{name}_bottom_rim", clean_outer[0], clean_inner[0]))
+        parts.append(_create_connector_surface(f"{name}_bottom_rim", sampled_outer[0], sampled_inner[0]))
 
     shell = parts[0]
     if len(parts) > 1:
@@ -169,10 +242,14 @@ def create_revolved_shell(
     return {
         "success": True,
         "name": shell,
-        "outer_profile": clean_outer,
-        "inner_profile": clean_inner,
+        "outer_profile": sampled_outer,
+        "inner_profile": sampled_inner,
+        "input_outer_profile": clean_outer,
+        "input_inner_profile": clean_inner,
         "wall_thickness": float(wall_thickness),
         "radial_segments": radial_segments,
+        "height_segments": len(sampled_outer) - 1,
+        "profile_interpolation": profile_interpolation,
         "center": center,
         "connect_top": connect_top,
         "connect_bottom": connect_bottom,

--- a/src/mayatools/object/create_textured_label.py
+++ b/src/mayatools/object/create_textured_label.py
@@ -1,0 +1,146 @@
+from typing import Dict, List, Any
+
+
+def create_textured_label(
+    texture_path: str,
+    name: str = None,
+    target_object: str = None,
+    radius: float = None,
+    center: List[float] = [0.0, 0.0, 0.0],
+    height: float = 1.0,
+    vertical_center: float = 0.0,
+    angle_start: float = -60.0,
+    angle_end: float = 60.0,
+    segments_u: int = 48,
+    segments_v: int = 4,
+    offset: float = 0.02,
+    material_name: str = None,
+) -> Dict[str, Any]:
+    """Create a UV-mapped curved label mesh and apply an image texture to it.
+
+    The label is a curved polygon strip around the Y axis. UVs are preserved from
+    a generated plane, so the image texture is mapped directly to the label UVs
+    instead of being approximated with floating text geometry.
+    """
+    import math
+    import os
+    import maya.cmds as cmds
+
+    if not texture_path:
+        raise ValueError("texture_path is required.")
+    normalized_texture_path = os.path.normpath(texture_path)
+    if not os.path.exists(normalized_texture_path):
+        raise ValueError(f"Texture path does not exist: {texture_path}")
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    if not isinstance(center, list) or len(center) != 3 or not all(_is_number(v) for v in center):
+        raise ValueError("center must be a list of 3 float values.")
+    center = [float(center[0]), float(center[1]), float(center[2])]
+    if height <= 0:
+        raise ValueError("height must be greater than zero.")
+    if segments_u < 3 or segments_v < 1:
+        raise ValueError("segments_u must be >= 3 and segments_v must be >= 1.")
+    if angle_end <= angle_start:
+        raise ValueError("angle_end must be greater than angle_start.")
+
+    if target_object:
+        if not cmds.objExists(target_object):
+            raise ValueError(f"target_object does not exist: {target_object}")
+        if radius is None:
+            bbox = cmds.exactWorldBoundingBox(target_object)
+            radius = max((bbox[3] - bbox[0]) * 0.5, (bbox[5] - bbox[2]) * 0.5)
+            center = [(bbox[0] + bbox[3]) * 0.5, center[1], (bbox[2] + bbox[5]) * 0.5]
+
+    if radius is None:
+        raise ValueError("radius is required when target_object is not specified.")
+    if radius <= 0:
+        raise ValueError("radius must be greater than zero.")
+
+    if name is None:
+        base_name = os.path.splitext(os.path.basename(texture_path))[0] or "textured"
+        name = f"{base_name}_curved_label"
+    if material_name is None:
+        material_name = f"{name}_mat"
+
+    angle_span = math.radians(angle_end - angle_start)
+    arc_width = radius * angle_span
+
+    label = cmds.polyPlane(
+        name=name,
+        width=arc_width,
+        height=height,
+        subdivisionsX=segments_u,
+        subdivisionsY=segments_v,
+        axis=[0, 0, 1],
+        constructionHistory=False,
+    )[0]
+
+    vertices = cmds.ls(f"{label}.vtx[*]", flatten=True) or []
+    theta_start = math.radians(angle_start)
+    theta_end = math.radians(angle_end)
+    label_radius = radius + offset
+
+    for vertex in vertices:
+        x, y, _ = cmds.xform(vertex, query=True, objectSpace=True, translation=True)
+        u = (x / arc_width) + 0.5
+        theta = theta_start + (theta_end - theta_start) * u
+        world_x = center[0] + label_radius * math.sin(theta)
+        world_y = center[1] + vertical_center + y
+        world_z = center[2] + label_radius * math.cos(theta)
+        cmds.xform(vertex, worldSpace=True, translation=[world_x, world_y, world_z])
+
+    try:
+        cmds.polySoftEdge(label, angle=180, constructionHistory=False)
+    except Exception:
+        pass
+
+    shader = cmds.shadingNode("lambert", asShader=True, name=material_name)
+    file_node = cmds.shadingNode("file", asTexture=True, name=f"{material_name}_file")
+    place2d = cmds.shadingNode("place2dTexture", asUtility=True, name=f"{material_name}_place2d")
+
+    for attr in ["outUV", "outUvFilterSize"]:
+        destination = "uvCoord" if attr == "outUV" else "uvFilterSize"
+        cmds.connectAttr(f"{place2d}.{attr}", f"{file_node}.{destination}", force=True)
+    for attr in [
+        "coverage",
+        "translateFrame",
+        "rotateFrame",
+        "mirrorU",
+        "mirrorV",
+        "stagger",
+        "wrapU",
+        "wrapV",
+        "repeatUV",
+        "offset",
+        "rotateUV",
+        "noiseUV",
+        "vertexUvOne",
+        "vertexUvTwo",
+        "vertexUvThree",
+        "vertexCameraOne",
+    ]:
+        if cmds.attributeQuery(attr, node=place2d, exists=True) and cmds.attributeQuery(attr, node=file_node, exists=True):
+            cmds.connectAttr(f"{place2d}.{attr}", f"{file_node}.{attr}", force=True)
+
+    cmds.setAttr(f"{file_node}.fileTextureName", normalized_texture_path, type="string")
+    cmds.connectAttr(f"{file_node}.outColor", f"{shader}.color", force=True)
+    shading_group = cmds.sets(name=f"{material_name}SG", empty=True, renderable=True, noSurfaceShader=True)
+    cmds.connectAttr(f"{shader}.outColor", f"{shading_group}.surfaceShader", force=True)
+    cmds.sets(label, edit=True, forceElement=shading_group)
+
+    return {
+        "success": True,
+        "name": label,
+        "shader": shader,
+        "file_node": file_node,
+        "place2d": place2d,
+        "shading_group": shading_group,
+        "texture_path": normalized_texture_path,
+        "radius": radius,
+        "angle_start": angle_start,
+        "angle_end": angle_end,
+        "segments_u": segments_u,
+        "segments_v": segments_v,
+    }

--- a/src/mayatools/object/create_textured_label.py
+++ b/src/mayatools/object/create_textured_label.py
@@ -18,6 +18,7 @@ def create_textured_label(
     offset: float = 0.02,
     material_name: str = None,
     use_alpha: bool = False,
+    opacity: float = 1.0,
 ) -> Dict[str, Any]:
     """Create a UV-mapped curved label mesh and apply an image texture to it.
 
@@ -26,7 +27,9 @@ def create_textured_label(
     instead of being approximated with floating text geometry. If surface_profile
     is provided as [height, radius] points, the label conforms to that lathed
     profile instead of using a constant cylindrical radius. When use_alpha is
-    true, texture transparency is connected to the label material.
+    true, texture transparency is connected to the label material. Opacity
+    controls the overall material visibility and is multiplied with texture
+    alpha when use_alpha is enabled.
     """
     import math
     import os
@@ -45,6 +48,11 @@ def create_textured_label(
         if not isinstance(values, list) or len(values) != length or not all(_is_number(v) for v in values):
             raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
         return [float(v) for v in values]
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
 
     def _validate_profile(profile, arg_name):
         if profile is None:
@@ -117,6 +125,9 @@ def create_textured_label(
         raise ValueError("height must be greater than zero.")
     if segments_u < 3 or segments_v < 1:
         raise ValueError("segments_u must be >= 3 and segments_v must be >= 1.")
+    opacity = _validate_scalar(opacity, "opacity")
+    if opacity < 0.0 or opacity > 1.0:
+        raise ValueError("opacity must be in the 0..1 range.")
     if angle_end <= angle_start:
         raise ValueError("angle_end must be greater than angle_start.")
     if not isinstance(profile_interpolation, str):
@@ -213,12 +224,19 @@ def create_textured_label(
 
     cmds.setAttr(f"{file_node}.fileTextureName", normalized_texture_path, type="string")
     cmds.connectAttr(f"{file_node}.outColor", f"{shader}.color", force=True)
+    if cmds.attributeQuery("transparency", node=shader, exists=True):
+        cmds.setAttr(f"{shader}.transparency", 1.0 - opacity, 1.0 - opacity, 1.0 - opacity, type="double3")
     alpha_node = None
+    alpha_opacity_node = None
     if use_alpha and cmds.attributeQuery("transparency", node=shader, exists=True):
         if cmds.attributeQuery("outAlpha", node=file_node, exists=True):
+            alpha_opacity_node = cmds.shadingNode("multiplyDivide", asUtility=True, name=f"{material_name}_alpha_opacity")
+            cmds.setAttr(f"{alpha_opacity_node}.input2", opacity, opacity, opacity, type="double3")
+            for channel in ["X", "Y", "Z"]:
+                cmds.connectAttr(f"{file_node}.outAlpha", f"{alpha_opacity_node}.input1{channel}", force=True)
             alpha_node = cmds.shadingNode("reverse", asUtility=True, name=f"{material_name}_alpha_reverse")
             for channel in ["X", "Y", "Z"]:
-                cmds.connectAttr(f"{file_node}.outAlpha", f"{alpha_node}.input{channel}", force=True)
+                cmds.connectAttr(f"{alpha_opacity_node}.output{channel}", f"{alpha_node}.input{channel}", force=True)
             cmds.connectAttr(f"{alpha_node}.output", f"{shader}.transparency", force=True)
         elif cmds.attributeQuery("outTransparency", node=file_node, exists=True):
             cmds.connectAttr(f"{file_node}.outTransparency", f"{shader}.transparency", force=True)
@@ -233,6 +251,7 @@ def create_textured_label(
         "file_node": file_node,
         "place2d": place2d,
         "alpha_node": alpha_node,
+        "alpha_opacity_node": alpha_opacity_node,
         "shading_group": shading_group,
         "texture_path": normalized_texture_path,
         "radius": radius,
@@ -243,4 +262,5 @@ def create_textured_label(
         "segments_u": segments_u,
         "segments_v": segments_v,
         "use_alpha": bool(use_alpha),
+        "opacity": opacity,
     }

--- a/src/mayatools/object/create_textured_label.py
+++ b/src/mayatools/object/create_textured_label.py
@@ -6,6 +6,8 @@ def create_textured_label(
     name: str = None,
     target_object: str = None,
     radius: float = None,
+    surface_profile: List[List[float]] = None,
+    profile_interpolation: str = "linear",
     center: List[float] = [0.0, 0.0, 0.0],
     height: float = 1.0,
     vertical_center: float = 0.0,
@@ -20,7 +22,9 @@ def create_textured_label(
 
     The label is a curved polygon strip around the Y axis. UVs are preserved from
     a generated plane, so the image texture is mapped directly to the label UVs
-    instead of being approximated with floating text geometry.
+    instead of being approximated with floating text geometry. If surface_profile
+    is provided as [height, radius] points, the label conforms to that lathed
+    profile instead of using a constant cylindrical radius.
     """
     import math
     import os
@@ -35,6 +39,75 @@ def create_textured_label(
     def _is_number(value):
         return isinstance(value, (int, float)) and not isinstance(value, bool)
 
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(v) for v in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(v) for v in values]
+
+    def _validate_profile(profile, arg_name):
+        if profile is None:
+            return None
+        if not isinstance(profile, list) or len(profile) < 2:
+            raise ValueError(f"{arg_name} must contain at least two [height, radius] points.")
+        clean = []
+        previous_height = None
+        for point in profile:
+            profile_height, profile_radius = _validate_vector(point, 2, f"{arg_name} point")
+            if profile_radius < 0.0:
+                raise ValueError(f"{arg_name} radii must be greater than or equal to zero.")
+            if previous_height is not None and profile_height <= previous_height:
+                raise ValueError(f"{arg_name} heights must be strictly increasing.")
+            clean.append([profile_height, profile_radius])
+            previous_height = profile_height
+        if not any(profile_radius > 0.0 for _, profile_radius in clean):
+            raise ValueError(f"{arg_name} must contain at least one positive radius.")
+        return clean
+
+    def _profile_radius_at(profile, profile_height, interpolation):
+        if profile_height <= profile[0][0]:
+            return profile[0][1]
+        if profile_height >= profile[-1][0]:
+            return profile[-1][1]
+
+        segment_index = 0
+        for index in range(len(profile) - 1):
+            if profile[index][0] <= profile_height <= profile[index + 1][0]:
+                segment_index = index
+                break
+
+        h0, r0 = profile[segment_index]
+        h1, r1 = profile[segment_index + 1]
+        t = (profile_height - h0) / max(1e-9, h1 - h0)
+        if interpolation == "linear":
+            return r0 + (r1 - r0) * t
+
+        def _slope(point_index):
+            if point_index <= 0:
+                ha, ra = profile[0]
+                hb, rb = profile[1]
+            elif point_index >= len(profile) - 1:
+                ha, ra = profile[-2]
+                hb, rb = profile[-1]
+            else:
+                ha, ra = profile[point_index - 1]
+                hb, rb = profile[point_index + 1]
+            return (rb - ra) / max(1e-9, hb - ha)
+
+        m0 = _slope(segment_index)
+        m1 = _slope(segment_index + 1)
+        t2 = t * t
+        t3 = t2 * t
+        span = h1 - h0
+        interpolated_radius = (
+            (2.0 * t3 - 3.0 * t2 + 1.0) * r0
+            + (t3 - 2.0 * t2 + t) * span * m0
+            + (-2.0 * t3 + 3.0 * t2) * r1
+            + (t3 - t2) * span * m1
+        )
+        lower = min(r0, r1)
+        upper = max(r0, r1)
+        return max(0.0, min(upper, max(lower, interpolated_radius)))
+
     if not isinstance(center, list) or len(center) != 3 or not all(_is_number(v) for v in center):
         raise ValueError("center must be a list of 3 float values.")
     center = [float(center[0]), float(center[1]), float(center[2])]
@@ -44,17 +117,25 @@ def create_textured_label(
         raise ValueError("segments_u must be >= 3 and segments_v must be >= 1.")
     if angle_end <= angle_start:
         raise ValueError("angle_end must be greater than angle_start.")
+    if not isinstance(profile_interpolation, str):
+        raise ValueError("profile_interpolation must be one of linear or smooth.")
+    profile_interpolation = profile_interpolation.lower()
+    if profile_interpolation not in {"linear", "smooth"}:
+        raise ValueError("profile_interpolation must be one of linear or smooth.")
+    clean_surface_profile = _validate_profile(surface_profile, "surface_profile")
 
     if target_object:
         if not cmds.objExists(target_object):
             raise ValueError(f"target_object does not exist: {target_object}")
-        if radius is None:
+        if radius is None and clean_surface_profile is None:
             bbox = cmds.exactWorldBoundingBox(target_object)
             radius = max((bbox[3] - bbox[0]) * 0.5, (bbox[5] - bbox[2]) * 0.5)
             center = [(bbox[0] + bbox[3]) * 0.5, center[1], (bbox[2] + bbox[5]) * 0.5]
 
+    if radius is None and clean_surface_profile is not None:
+        radius = _profile_radius_at(clean_surface_profile, float(vertical_center), profile_interpolation)
     if radius is None:
-        raise ValueError("radius is required when target_object is not specified.")
+        raise ValueError("radius or surface_profile is required when target_object is not specified.")
     if radius <= 0:
         raise ValueError("radius must be greater than zero.")
 
@@ -80,14 +161,18 @@ def create_textured_label(
     vertices = cmds.ls(f"{label}.vtx[*]", flatten=True) or []
     theta_start = math.radians(angle_start)
     theta_end = math.radians(angle_end)
-    label_radius = radius + offset
 
     for vertex in vertices:
         x, y, _ = cmds.xform(vertex, query=True, objectSpace=True, translation=True)
         u = (x / arc_width) + 0.5
         theta = theta_start + (theta_end - theta_start) * u
+        local_height = float(vertical_center) + y
+        if clean_surface_profile is not None:
+            label_radius = _profile_radius_at(clean_surface_profile, local_height, profile_interpolation) + offset
+        else:
+            label_radius = radius + offset
         world_x = center[0] + label_radius * math.sin(theta)
-        world_y = center[1] + vertical_center + y
+        world_y = center[1] + local_height
         world_z = center[2] + label_radius * math.cos(theta)
         cmds.xform(vertex, worldSpace=True, translation=[world_x, world_y, world_z])
 
@@ -139,6 +224,8 @@ def create_textured_label(
         "shading_group": shading_group,
         "texture_path": normalized_texture_path,
         "radius": radius,
+        "surface_profile": clean_surface_profile,
+        "profile_interpolation": profile_interpolation,
         "angle_start": angle_start,
         "angle_end": angle_end,
         "segments_u": segments_u,

--- a/src/mayatools/object/create_textured_label.py
+++ b/src/mayatools/object/create_textured_label.py
@@ -17,6 +17,7 @@ def create_textured_label(
     segments_v: int = 4,
     offset: float = 0.02,
     material_name: str = None,
+    use_alpha: bool = False,
 ) -> Dict[str, Any]:
     """Create a UV-mapped curved label mesh and apply an image texture to it.
 
@@ -24,7 +25,8 @@ def create_textured_label(
     a generated plane, so the image texture is mapped directly to the label UVs
     instead of being approximated with floating text geometry. If surface_profile
     is provided as [height, radius] points, the label conforms to that lathed
-    profile instead of using a constant cylindrical radius.
+    profile instead of using a constant cylindrical radius. When use_alpha is
+    true, texture transparency is connected to the label material.
     """
     import math
     import os
@@ -211,6 +213,15 @@ def create_textured_label(
 
     cmds.setAttr(f"{file_node}.fileTextureName", normalized_texture_path, type="string")
     cmds.connectAttr(f"{file_node}.outColor", f"{shader}.color", force=True)
+    alpha_node = None
+    if use_alpha and cmds.attributeQuery("transparency", node=shader, exists=True):
+        if cmds.attributeQuery("outAlpha", node=file_node, exists=True):
+            alpha_node = cmds.shadingNode("reverse", asUtility=True, name=f"{material_name}_alpha_reverse")
+            for channel in ["X", "Y", "Z"]:
+                cmds.connectAttr(f"{file_node}.outAlpha", f"{alpha_node}.input{channel}", force=True)
+            cmds.connectAttr(f"{alpha_node}.output", f"{shader}.transparency", force=True)
+        elif cmds.attributeQuery("outTransparency", node=file_node, exists=True):
+            cmds.connectAttr(f"{file_node}.outTransparency", f"{shader}.transparency", force=True)
     shading_group = cmds.sets(name=f"{material_name}SG", empty=True, renderable=True, noSurfaceShader=True)
     cmds.connectAttr(f"{shader}.outColor", f"{shading_group}.surfaceShader", force=True)
     cmds.sets(label, edit=True, forceElement=shading_group)
@@ -221,6 +232,7 @@ def create_textured_label(
         "shader": shader,
         "file_node": file_node,
         "place2d": place2d,
+        "alpha_node": alpha_node,
         "shading_group": shading_group,
         "texture_path": normalized_texture_path,
         "radius": radius,
@@ -230,4 +242,5 @@ def create_textured_label(
         "angle_end": angle_end,
         "segments_u": segments_u,
         "segments_v": segments_v,
+        "use_alpha": bool(use_alpha),
     }

--- a/src/mayatools/object/create_tube_mesh_from_curves.py
+++ b/src/mayatools/object/create_tube_mesh_from_curves.py
@@ -1,0 +1,278 @@
+from typing import Dict, List, Any
+
+
+def create_tube_mesh_from_curves(
+    name: str,
+    curve_names: List[str] = None,
+    points: List[List[float]] = None,
+    tube_radius: float = 0.01,
+    radial_segments: int = 8,
+    cap_ends: bool = True,
+    min_segment_length: float = 0.0001,
+    max_points_per_curve: int = 0,
+    material_color: List[float] = None,
+    material_name: str = None,
+    smooth: bool = True,
+) -> Dict[str, Any]:
+    """Create polygon tube geometry along one or more curves or point paths.
+
+    The tool reads world-space CV positions from existing Maya curves and/or a
+    direct point list, then generates a polygon tube mesh following each path.
+    It is useful for turning reference-derived curves into visible geometry:
+    generic raised or recessed outlines, trim wires, seams, engravings, molded
+    marks, veins, routes, annotations, cables, pipes, or decorative strokes.
+    """
+    import math
+    import maya.cmds as cmds
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(v) for v in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(value) for value in values]
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return value
+
+    def _sub(a, b):
+        return [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
+
+    def _add(a, b):
+        return [a[0] + b[0], a[1] + b[1], a[2] + b[2]]
+
+    def _mul(a, scalar):
+        return [a[0] * scalar, a[1] * scalar, a[2] * scalar]
+
+    def _dot(a, b):
+        return a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+
+    def _cross(a, b):
+        return [
+            a[1] * b[2] - a[2] * b[1],
+            a[2] * b[0] - a[0] * b[2],
+            a[0] * b[1] - a[1] * b[0],
+        ]
+
+    def _length(a):
+        return math.sqrt(_dot(a, a))
+
+    def _normalize(a):
+        length = _length(a)
+        if length <= 1e-12:
+            return None
+        return [a[0] / length, a[1] / length, a[2] / length]
+
+    def _distance(a, b):
+        return _length(_sub(a, b))
+
+    def _resample_points(path_points, max_points):
+        if max_points <= 0 or len(path_points) <= max_points:
+            return [point[:] for point in path_points]
+        if max_points < 2:
+            return [path_points[0][:]]
+        return [
+            path_points[int(round(index * (len(path_points) - 1) / float(max_points - 1)))][:]
+            for index in range(max_points)
+        ]
+
+    def _curve_points(curve_name):
+        if not cmds.objExists(curve_name):
+            raise ValueError(f"Curve does not exist: {curve_name}")
+        shapes = cmds.listRelatives(curve_name, shapes=True, fullPath=True) or []
+        if cmds.objectType(curve_name) == "nurbsCurve":
+            shapes = [curve_name]
+        if not any(cmds.objectType(shape) == "nurbsCurve" for shape in shapes):
+            raise ValueError(f"{curve_name} is not a NURBS curve transform or shape.")
+        cvs = cmds.ls(f"{curve_name}.cv[*]", flatten=True) or []
+        if not cvs and shapes:
+            cvs = cmds.ls(f"{shapes[0]}.cv[*]", flatten=True) or []
+        return [cmds.pointPosition(cv, world=True) for cv in cvs]
+
+    def _clean_path(path_points):
+        clean = []
+        for point in path_points:
+            clean_point = _validate_vector(point, 3, "path point")
+            if clean and _distance(clean[-1], clean_point) < min_segment_length:
+                continue
+            clean.append(clean_point)
+        if len(clean) >= 3 and _distance(clean[0], clean[-1]) < min_segment_length:
+            clean.pop()
+            return clean, True
+        return clean, False
+
+    def _initial_frame(tangent):
+        reference = [0.0, 1.0, 0.0]
+        if abs(_dot(reference, tangent)) > 0.9:
+            reference = [1.0, 0.0, 0.0]
+        normal = _normalize(_cross(reference, tangent))
+        if normal is None:
+            normal = [1.0, 0.0, 0.0]
+        binormal = _normalize(_cross(tangent, normal)) or [0.0, 0.0, 1.0]
+        return normal, binormal
+
+    def _path_tangent(path_points, index, closed):
+        count = len(path_points)
+        if closed:
+            previous_point = path_points[(index - 1) % count]
+            next_point = path_points[(index + 1) % count]
+            tangent = _normalize(_sub(next_point, previous_point))
+        elif index == 0:
+            tangent = _normalize(_sub(path_points[1], path_points[0]))
+        elif index == count - 1:
+            tangent = _normalize(_sub(path_points[-1], path_points[-2]))
+        else:
+            tangent = _normalize(_sub(path_points[index + 1], path_points[index - 1]))
+        return tangent or [0.0, 1.0, 0.0]
+
+    def _append_tube(path_points, closed, source_name):
+        start_vertex_count = len(vertices)
+        start_face_count = len(face_counts)
+        ring_indices = []
+        previous_normal = None
+        for point_index, point in enumerate(path_points):
+            tangent = _path_tangent(path_points, point_index, closed)
+            if previous_normal is None:
+                normal, binormal = _initial_frame(tangent)
+            else:
+                projected = _sub(previous_normal, _mul(tangent, _dot(previous_normal, tangent)))
+                normal = _normalize(projected)
+                if normal is None:
+                    normal, binormal = _initial_frame(tangent)
+                else:
+                    binormal = _normalize(_cross(tangent, normal)) or [0.0, 0.0, 1.0]
+            previous_normal = normal
+            ring = []
+            for segment_index in range(radial_segments):
+                angle = math.tau * segment_index / float(radial_segments)
+                offset_vector = _add(
+                    _mul(normal, math.cos(angle) * tube_radius),
+                    _mul(binormal, math.sin(angle) * tube_radius),
+                )
+                vertices.append(_add(point, offset_vector))
+                ring.append(len(vertices) - 1)
+            ring_indices.append(ring)
+
+        segment_count = len(ring_indices) if closed else len(ring_indices) - 1
+        for ring_index in range(segment_count):
+            next_ring_index = (ring_index + 1) % len(ring_indices)
+            for segment_index in range(radial_segments):
+                next_segment_index = (segment_index + 1) % radial_segments
+                face_counts.append(4)
+                face_connects.extend([
+                    ring_indices[ring_index][segment_index],
+                    ring_indices[ring_index][next_segment_index],
+                    ring_indices[next_ring_index][next_segment_index],
+                    ring_indices[next_ring_index][segment_index],
+                ])
+
+        if cap_ends and not closed:
+            start_center = len(vertices)
+            vertices.append(path_points[0][:])
+            end_center = len(vertices)
+            vertices.append(path_points[-1][:])
+            first_ring = ring_indices[0]
+            last_ring = ring_indices[-1]
+            for segment_index in range(radial_segments):
+                next_segment_index = (segment_index + 1) % radial_segments
+                face_counts.append(3)
+                face_connects.extend([start_center, first_ring[segment_index], first_ring[next_segment_index]])
+                face_counts.append(3)
+                face_connects.extend([end_center, last_ring[next_segment_index], last_ring[segment_index]])
+
+        return {
+            "source": source_name,
+            "input_points": len(path_points),
+            "closed": bool(closed),
+            "vertices": len(vertices) - start_vertex_count,
+            "faces": len(face_counts) - start_face_count,
+        }
+
+    if not name:
+        raise ValueError("name is required.")
+    tube_radius = _validate_scalar(tube_radius, "tube_radius")
+    if tube_radius <= 0.0:
+        raise ValueError("tube_radius must be greater than zero.")
+    radial_segments = _validate_int(radial_segments, "radial_segments", 3)
+    max_points_per_curve = _validate_int(max_points_per_curve, "max_points_per_curve", 0)
+    min_segment_length = _validate_scalar(min_segment_length, "min_segment_length")
+    if min_segment_length < 0.0:
+        raise ValueError("min_segment_length must be greater than or equal to zero.")
+
+    sources = []
+    if curve_names is not None:
+        if not isinstance(curve_names, list) or not all(isinstance(item, str) for item in curve_names):
+            raise ValueError("curve_names must be a list of curve names.")
+        for curve_name in curve_names:
+            sources.append((curve_name, _curve_points(curve_name)))
+    if points is not None:
+        if not isinstance(points, list) or len(points) < 2:
+            raise ValueError("points must contain at least two [x, y, z] points.")
+        sources.append(("points", points))
+    if not sources:
+        raise ValueError("Provide curve_names and/or points.")
+
+    vertices = []
+    face_counts = []
+    face_connects = []
+    source_summaries = []
+    skipped_sources = []
+    for source_name, source_points in sources:
+        resampled_points = _resample_points(source_points, max_points_per_curve)
+        path_points, closed = _clean_path(resampled_points)
+        if len(path_points) < 2:
+            skipped_sources.append({"source": source_name, "reason": "fewer than two usable points"})
+            continue
+        source_summaries.append(_append_tube(path_points, closed, source_name))
+
+    if not vertices or not face_counts:
+        raise ValueError("No tube geometry could be created from the provided paths.")
+
+    try:
+        import maya.api.OpenMaya as om
+        mesh_fn = om.MFnMesh()
+        mesh_fn.create([om.MPoint(point[0], point[1], point[2]) for point in vertices], face_counts, face_connects)
+        mesh_shape = mesh_fn.fullPathName()
+        parents = cmds.listRelatives(mesh_shape, parent=True, fullPath=False) or []
+        mesh_transform = parents[0] if parents else mesh_shape
+        mesh_transform = cmds.rename(mesh_transform, name)
+    except Exception as exc:
+        raise RuntimeError(f"Unable to create tube mesh: {exc}") from exc
+
+    if smooth:
+        cmds.polySoftEdge(mesh_transform, angle=180, constructionHistory=False)
+
+    material = None
+    shading_group = None
+    if material_color is not None:
+        material_color = _validate_vector(material_color, 3, "material_color")
+        material = cmds.shadingNode("lambert", asShader=True, name=material_name or f"{name}_mat")
+        cmds.setAttr(f"{material}.color", material_color[0], material_color[1], material_color[2], type="double3")
+        shading_group = cmds.sets(name=f"{material}SG", empty=True, renderable=True, noSurfaceShader=True)
+        cmds.connectAttr(f"{material}.outColor", f"{shading_group}.surfaceShader", force=True)
+        cmds.sets(mesh_transform, edit=True, forceElement=shading_group)
+
+    return {
+        "success": True,
+        "name": mesh_transform,
+        "curve_names": curve_names or [],
+        "used_source_count": len(source_summaries),
+        "skipped_sources": skipped_sources,
+        "tube_radius": tube_radius,
+        "radial_segments": radial_segments,
+        "cap_ends": bool(cap_ends),
+        "vertex_count": len(vertices),
+        "face_count": len(face_counts),
+        "sources": source_summaries,
+        "material": material,
+        "shading_group": shading_group,
+        "bounding_box": cmds.exactWorldBoundingBox(mesh_transform),
+    }

--- a/src/mayatools/object/curve_modeling.py
+++ b/src/mayatools/object/curve_modeling.py
@@ -142,7 +142,6 @@ def curve_modeling(
             axis=axis_vector,
             degree=3,
             sections=sections,
-            sweepType=1,  # 0=linear, 1=circular, 2=square
             useTolerance=True,
             startSweep=0,
             endSweep=angle

--- a/src/mayatools/object/cylindrical_component_deform.py
+++ b/src/mayatools/object/cylindrical_component_deform.py
@@ -1,0 +1,441 @@
+from typing import Dict, List, Any
+
+
+def cylindrical_component_deform(
+    object_name: str,
+    image_path: str,
+    center: List[float] = [0.0, 0.0, 0.0],
+    axis: str = "y",
+    axis_range: List[float] = [0.0, 1.0],
+    angle_range_degrees: List[float] = [-60.0, 60.0],
+    amplitude: float = -0.02,
+    displacement_direction: str = "radial",
+    sample_channel: str = "luminance",
+    invert: bool = False,
+    black_point: float = 0.0,
+    white_point: float = 1.0,
+    threshold: float = 0.5,
+    component_connectivity: int = 8,
+    min_component_pixels: int = 12,
+    max_component_pixels: int = 0,
+    min_component_width: int = 2,
+    min_component_height: int = 2,
+    max_component_width: int = 0,
+    max_component_height: int = 0,
+    max_components: int = 200,
+    feature_axis_scale: float = 0.7,
+    feature_angle_scale: float = 0.7,
+    min_feature_axis_radius: float = 0.01,
+    min_feature_angle_radius_degrees: float = 0.75,
+    max_feature_axis_radius: float = 0.25,
+    max_feature_angle_radius_degrees: float = 15.0,
+    falloff: str = "smooth",
+    blend_mode: str = "max",
+    flip_u: bool = False,
+    flip_v: bool = False,
+    smooth: bool = True,
+) -> Dict[str, Any]:
+    """Apply fitted image-mask components as local relief on a cylindrical mesh.
+
+    The input image is thresholded into connected components. Each component is
+    fitted to an axis/angle-space ellipse, then used as a localized radial or
+    axis-direction deformation feature. This is useful for generic grip
+    dimples, raised dots, molded emboss/deboss marks, perforation-like dents,
+    droplets, rivets, vents, or other component-shaped details on bottles,
+    cans, cups, knobs, handles, and other lathed forms. UVs are not edited.
+    """
+    import math
+    import os
+    import maya.cmds as cmds
+
+    try:
+        from PySide6.QtGui import QImage
+    except Exception:
+        try:
+            from PySide2.QtGui import QImage
+        except Exception as exc:
+            raise RuntimeError("PySide QImage is required to read image pixels in Maya.") from exc
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(v) for v in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(value) for value in values]
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return value
+
+    def _clamp(value, lower=0.0, upper=1.0):
+        return max(lower, min(upper, value))
+
+    def _positive_span(start_degrees, end_degrees):
+        span = (end_degrees - start_degrees) % 360.0
+        return 360.0 if abs(span) < 1e-8 else span
+
+    def _angle_delta_degrees(a, b):
+        return (a - b + 180.0) % 360.0 - 180.0
+
+    def _angle_range_t(angle, start_degrees, span_degrees):
+        delta = (angle - start_degrees) % 360.0
+        if delta < -1e-8 or delta > span_degrees + 1e-8:
+            return None
+        return _clamp(delta / span_degrees)
+
+    def _pixel_rgb_alpha(image, x, y):
+        color = image.pixelColor(int(x), int(y))
+        return color.redF(), color.greenF(), color.blueF(), color.alphaF()
+
+    def _rgb_to_hsv(red, green, blue):
+        max_value = max(red, green, blue)
+        min_value = min(red, green, blue)
+        delta = max_value - min_value
+        if delta == 0.0:
+            hue = 0.0
+        elif max_value == red:
+            hue = ((green - blue) / delta) % 6.0
+        elif max_value == green:
+            hue = ((blue - red) / delta) + 2.0
+        else:
+            hue = ((red - green) / delta) + 4.0
+        hue /= 6.0
+        saturation = 0.0 if max_value == 0.0 else delta / max_value
+        return hue, saturation, max_value
+
+    def _sample_value(image, x, y):
+        red, green, blue, alpha = _pixel_rgb_alpha(image, x, y)
+        if sample_channel == "red":
+            value = red
+        elif sample_channel == "green":
+            value = green
+        elif sample_channel == "blue":
+            value = blue
+        elif sample_channel == "alpha":
+            value = alpha
+        elif sample_channel == "value":
+            value = max(red, green, blue)
+        elif sample_channel == "saturation":
+            value = _rgb_to_hsv(red, green, blue)[1]
+        else:
+            value = 0.2126 * red + 0.7152 * green + 0.0722 * blue
+
+        value = _clamp((value - black_point) / max(1e-9, white_point - black_point))
+        return 1.0 - value if invert else value
+
+    def _is_valid_component(component):
+        if component["pixel_count"] < min_component_pixels:
+            return False
+        if max_component_pixels > 0 and component["pixel_count"] > max_component_pixels:
+            return False
+        if component["width_pixels"] < min_component_width or component["height_pixels"] < min_component_height:
+            return False
+        if max_component_width > 0 and component["width_pixels"] > max_component_width:
+            return False
+        if max_component_height > 0 and component["height_pixels"] > max_component_height:
+            return False
+        return True
+
+    def _feature_weight(distance):
+        if distance > 1.0:
+            return 0.0
+        if falloff == "hard":
+            return 1.0
+        if falloff == "linear":
+            return 1.0 - distance
+        if falloff == "gaussian":
+            return math.exp(-4.0 * distance * distance)
+        t = _clamp(distance)
+        return 1.0 - (t * t * (3.0 - 2.0 * t))
+
+    if not cmds.objExists(object_name):
+        raise ValueError(f"Object does not exist: {object_name}")
+    if not image_path:
+        raise ValueError("image_path is required.")
+    normalized_image_path = os.path.normpath(image_path)
+    if not os.path.isfile(normalized_image_path):
+        raise ValueError(f"Image path does not exist: {image_path}")
+
+    center = _validate_vector(center, 3, "center")
+    axis_range = _validate_vector(axis_range, 2, "axis_range")
+    angle_range_degrees = _validate_vector(angle_range_degrees, 2, "angle_range_degrees")
+    amplitude = _validate_scalar(amplitude, "amplitude")
+    black_point = _validate_scalar(black_point, "black_point")
+    white_point = _validate_scalar(white_point, "white_point")
+    if abs(white_point - black_point) <= 1e-9:
+        raise ValueError("white_point must differ from black_point.")
+    threshold = _clamp(_validate_scalar(threshold, "threshold"))
+    component_connectivity = _validate_int(component_connectivity, "component_connectivity", 4)
+    if component_connectivity not in {4, 8}:
+        raise ValueError("component_connectivity must be 4 or 8.")
+    min_component_pixels = _validate_int(min_component_pixels, "min_component_pixels", 1)
+    max_component_pixels = _validate_int(max_component_pixels, "max_component_pixels", 0)
+    min_component_width = _validate_int(min_component_width, "min_component_width", 1)
+    min_component_height = _validate_int(min_component_height, "min_component_height", 1)
+    max_component_width = _validate_int(max_component_width, "max_component_width", 0)
+    max_component_height = _validate_int(max_component_height, "max_component_height", 0)
+    max_components = _validate_int(max_components, "max_components", 1)
+    feature_axis_scale = _validate_scalar(feature_axis_scale, "feature_axis_scale")
+    feature_angle_scale = _validate_scalar(feature_angle_scale, "feature_angle_scale")
+    min_feature_axis_radius = _validate_scalar(min_feature_axis_radius, "min_feature_axis_radius")
+    min_feature_angle_radius_degrees = _validate_scalar(min_feature_angle_radius_degrees, "min_feature_angle_radius_degrees")
+    max_feature_axis_radius = _validate_scalar(max_feature_axis_radius, "max_feature_axis_radius")
+    max_feature_angle_radius_degrees = _validate_scalar(max_feature_angle_radius_degrees, "max_feature_angle_radius_degrees")
+    if feature_axis_scale <= 0.0 or feature_angle_scale <= 0.0:
+        raise ValueError("feature scale values must be greater than zero.")
+    if min_feature_axis_radius <= 0.0 or min_feature_angle_radius_degrees <= 0.0:
+        raise ValueError("minimum feature radii must be greater than zero.")
+    if max_feature_axis_radius < min_feature_axis_radius:
+        raise ValueError("max_feature_axis_radius must be greater than or equal to min_feature_axis_radius.")
+    if max_feature_angle_radius_degrees < min_feature_angle_radius_degrees:
+        raise ValueError("max_feature_angle_radius_degrees must be greater than or equal to min_feature_angle_radius_degrees.")
+
+    displacement_direction = displacement_direction.lower().strip()
+    if displacement_direction not in {"radial", "axis"}:
+        raise ValueError("displacement_direction must be one of radial or axis.")
+    sample_channel = sample_channel.lower().strip()
+    if sample_channel not in {"luminance", "red", "green", "blue", "alpha", "value", "saturation"}:
+        raise ValueError("sample_channel must be one of luminance, red, green, blue, alpha, value, or saturation.")
+    falloff = falloff.lower().strip()
+    if falloff not in {"smooth", "linear", "gaussian", "hard"}:
+        raise ValueError("falloff must be one of smooth, linear, gaussian, or hard.")
+    blend_mode = blend_mode.lower().strip()
+    if blend_mode not in {"max", "add"}:
+        raise ValueError("blend_mode must be one of max or add.")
+
+    axis = axis.lower().strip()
+    axes = {
+        "x": (0, 1, 2),
+        "y": (1, 0, 2),
+        "z": (2, 0, 1),
+    }
+    if axis not in axes:
+        raise ValueError("axis must be one of x, y, or z.")
+    axis_index, radial_a, radial_b = axes[axis]
+
+    axis_start, axis_end = axis_range
+    if axis_start > axis_end:
+        axis_start, axis_end = axis_end, axis_start
+    axis_span = axis_end - axis_start
+    if axis_span <= 0.0:
+        raise ValueError("axis_range must cover a positive span.")
+
+    angle_start, angle_end = angle_range_degrees
+    angle_span = _positive_span(angle_start, angle_end)
+
+    image = QImage(normalized_image_path)
+    if image.isNull():
+        raise ValueError(f"Unable to load image: {image_path}")
+    image_width = image.width()
+    image_height = image.height()
+    if image_width < 2 or image_height < 2:
+        raise ValueError("image must be at least 2x2 pixels.")
+
+    mask = [bytearray(image_width) for _ in range(image_height)]
+    value_sum = 0.0
+    active_pixels = 0
+    min_value = None
+    max_value = None
+    for y in range(image_height):
+        row = mask[y]
+        for x in range(image_width):
+            value = _sample_value(image, x, y)
+            min_value = value if min_value is None else min(min_value, value)
+            max_value = value if max_value is None else max(max_value, value)
+            value_sum += value
+            if value >= threshold:
+                row[x] = 1
+                active_pixels += 1
+
+    visited = [bytearray(image_width) for _ in range(image_height)]
+    if component_connectivity == 4:
+        neighbors = [(-1, 0), (1, 0), (0, -1), (0, 1)]
+    else:
+        neighbors = [(-1, 0), (1, 0), (0, -1), (0, 1), (-1, -1), (1, -1), (-1, 1), (1, 1)]
+
+    components = []
+    for y in range(image_height):
+        for x in range(image_width):
+            if not mask[y][x] or visited[y][x]:
+                continue
+            stack = [(x, y)]
+            visited[y][x] = 1
+            pixel_count = 0
+            x_sum = 0.0
+            y_sum = 0.0
+            x_min = x_max = x
+            y_min = y_max = y
+
+            while stack:
+                current_x, current_y = stack.pop()
+                pixel_count += 1
+                x_sum += current_x
+                y_sum += current_y
+                x_min = min(x_min, current_x)
+                x_max = max(x_max, current_x)
+                y_min = min(y_min, current_y)
+                y_max = max(y_max, current_y)
+
+                for dx, dy in neighbors:
+                    next_x = current_x + dx
+                    next_y = current_y + dy
+                    if next_x < 0 or next_x >= image_width or next_y < 0 or next_y >= image_height:
+                        continue
+                    if visited[next_y][next_x] or not mask[next_y][next_x]:
+                        continue
+                    visited[next_y][next_x] = 1
+                    stack.append((next_x, next_y))
+
+            width_pixels = x_max - x_min + 1
+            height_pixels = y_max - y_min + 1
+            component = {
+                "pixel_count": pixel_count,
+                "bbox_pixels": [x_min, y_min, x_max, y_max],
+                "width_pixels": width_pixels,
+                "height_pixels": height_pixels,
+                "center_pixels": [x_sum / float(pixel_count), y_sum / float(pixel_count)],
+            }
+            if _is_valid_component(component):
+                components.append(component)
+
+    components.sort(key=lambda item: item["pixel_count"], reverse=True)
+    retained_components = components[:max_components]
+
+    features = []
+    for component in retained_components:
+        center_x, center_y = component["center_pixels"]
+        image_u = center_x / float(image_width - 1)
+        image_v = center_y / float(image_height - 1)
+        angle_t = 1.0 - image_u if flip_u else image_u
+        axis_t = 1.0 - image_v if flip_v else image_v
+        component_angle = angle_start + angle_span * angle_t
+        component_axis = axis_start + axis_span * axis_t
+
+        axis_radius = (component["height_pixels"] / float(image_height)) * axis_span * 0.5 * feature_axis_scale
+        angle_radius = (component["width_pixels"] / float(image_width)) * angle_span * 0.5 * feature_angle_scale
+        axis_radius = max(min_feature_axis_radius, min(max_feature_axis_radius, axis_radius))
+        angle_radius = max(min_feature_angle_radius_degrees, min(max_feature_angle_radius_degrees, angle_radius))
+
+        features.append({
+            "axis": component_axis,
+            "angle_degrees": component_angle,
+            "feature_axis_radius": axis_radius,
+            "feature_angle_radius_degrees": angle_radius,
+            "pixel_count": component["pixel_count"],
+            "bbox_pixels": component["bbox_pixels"],
+            "center_pixels": component["center_pixels"],
+        })
+
+    shapes = cmds.listRelatives(object_name, shapes=True, fullPath=True) or []
+    if cmds.objectType(object_name) == "mesh":
+        shapes = [object_name]
+    if not any(cmds.objectType(shape) == "mesh" for shape in shapes):
+        raise ValueError(f"{object_name} is not a polygon mesh transform or mesh shape.")
+
+    vertices = cmds.ls(f"{object_name}.vtx[*]", flatten=True) or []
+    if not vertices:
+        raise ValueError(f"No vertices found on {object_name}.")
+
+    deformed_vertices = 0
+    displacement_values = []
+    for vertex in vertices:
+        position = cmds.xform(vertex, query=True, worldSpace=True, translation=True)
+        local_axis = position[axis_index] - center[axis_index]
+        if local_axis < axis_start or local_axis > axis_end:
+            continue
+
+        delta_a = position[radial_a] - center[radial_a]
+        delta_b = position[radial_b] - center[radial_b]
+        radius = math.sqrt(delta_a * delta_a + delta_b * delta_b)
+        if radius <= 1e-8:
+            continue
+
+        angle = math.degrees(math.atan2(delta_a, delta_b))
+        if _angle_range_t(angle, angle_start, angle_span) is None:
+            continue
+
+        feature_weight = 0.0
+        for feature in features:
+            axis_distance = abs(local_axis - feature["axis"]) / feature["feature_axis_radius"]
+            if axis_distance > 1.0:
+                continue
+            angle_distance = abs(_angle_delta_degrees(angle, feature["angle_degrees"])) / feature["feature_angle_radius_degrees"]
+            if angle_distance > 1.0:
+                continue
+            distance = math.sqrt(axis_distance * axis_distance + angle_distance * angle_distance)
+            weight = _feature_weight(distance)
+            if blend_mode == "add":
+                feature_weight += weight
+            else:
+                feature_weight = max(feature_weight, weight)
+
+        if feature_weight <= 0.0:
+            continue
+        feature_weight = min(1.0, feature_weight)
+        displacement = amplitude * feature_weight
+        if abs(displacement) <= 1e-12:
+            continue
+
+        if displacement_direction == "radial":
+            new_radius = max(0.0, radius + displacement)
+            scale = new_radius / radius
+            position[radial_a] = center[radial_a] + delta_a * scale
+            position[radial_b] = center[radial_b] + delta_b * scale
+        else:
+            position[axis_index] = position[axis_index] + displacement
+
+        cmds.xform(vertex, worldSpace=True, translation=position)
+        deformed_vertices += 1
+        displacement_values.append(displacement)
+
+    if smooth:
+        cmds.polySoftEdge(object_name, angle=180, constructionHistory=False)
+
+    return {
+        "success": True,
+        "object_name": object_name,
+        "image_path": normalized_image_path,
+        "image_width": image_width,
+        "image_height": image_height,
+        "active_pixels": active_pixels,
+        "active_pixel_ratio": active_pixels / float(image_width * image_height),
+        "image_value_min": min_value if min_value is not None else 0.0,
+        "image_value_max": max_value if max_value is not None else 0.0,
+        "image_value_mean": value_sum / float(image_width * image_height),
+        "detected_components": len(components),
+        "retained_components": len(retained_components),
+        "deformed_vertices": deformed_vertices,
+        "axis": axis,
+        "axis_range": [axis_start, axis_end],
+        "angle_range_degrees": angle_range_degrees,
+        "amplitude": amplitude,
+        "displacement_direction": displacement_direction,
+        "threshold": threshold,
+        "component_connectivity": component_connectivity,
+        "component_filters": {
+            "min_component_pixels": min_component_pixels,
+            "max_component_pixels": max_component_pixels,
+            "min_component_width": min_component_width,
+            "min_component_height": min_component_height,
+            "max_component_width": max_component_width,
+            "max_component_height": max_component_height,
+            "max_components": max_components,
+        },
+        "feature_axis_scale": feature_axis_scale,
+        "feature_angle_scale": feature_angle_scale,
+        "falloff": falloff,
+        "blend_mode": blend_mode,
+        "flip_u": bool(flip_u),
+        "flip_v": bool(flip_v),
+        "min_displacement": min(displacement_values) if displacement_values else 0.0,
+        "max_displacement": max(displacement_values) if displacement_values else 0.0,
+        "features": features,
+        "bounding_box": cmds.exactWorldBoundingBox(object_name),
+    }

--- a/src/mayatools/object/cylindrical_image_deform.py
+++ b/src/mayatools/object/cylindrical_image_deform.py
@@ -1,0 +1,326 @@
+from typing import Dict, List, Any
+
+
+def cylindrical_image_deform(
+    object_name: str,
+    image_path: str,
+    center: List[float] = [0.0, 0.0, 0.0],
+    axis: str = "y",
+    axis_range: List[float] = [0.0, 1.0],
+    angle_range_degrees: List[float] = [-60.0, 60.0],
+    amplitude: float = 0.02,
+    displacement_direction: str = "radial",
+    sample_channel: str = "luminance",
+    invert: bool = False,
+    black_point: float = 0.0,
+    white_point: float = 1.0,
+    threshold: float = None,
+    threshold_softness: float = 0.0,
+    neutral_value: float = 0.0,
+    gamma: float = 1.0,
+    flip_u: bool = False,
+    flip_v: bool = False,
+    axis_falloff: float = 0.0,
+    angle_falloff_degrees: float = 0.0,
+    smooth: bool = True,
+) -> Dict[str, Any]:
+    """Deform a cylindrical or lathed mesh from an image sampled in angle/height space.
+
+    The image's horizontal axis maps to an angular range around the selected
+    axis, and the image's vertical axis maps to an axis-height range. Sampled
+    pixel values can drive radial or axis-direction displacement, making this
+    useful for generic photo-driven relief, emboss/deboss patterns, grips,
+    dents, labels, panels, and localized texture-to-geometry transfer on
+    bottles, cans, cups, knobs, and other lathed objects.
+    """
+    import math
+    import os
+    import maya.cmds as cmds
+
+    try:
+        from PySide6.QtGui import QImage
+    except Exception:
+        try:
+            from PySide2.QtGui import QImage
+        except Exception as exc:
+            raise RuntimeError("PySide QImage is required to sample image pixels in Maya.") from exc
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(v) for v in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(value) for value in values]
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _clamp(value, lower=0.0, upper=1.0):
+        return max(lower, min(upper, value))
+
+    def _positive_span(start_degrees, end_degrees):
+        span = (end_degrees - start_degrees) % 360.0
+        return 360.0 if abs(span) < 1e-8 else span
+
+    def _angle_range_t(angle, start_degrees, span_degrees):
+        delta = (angle - start_degrees) % 360.0
+        if delta < -1e-8 or delta > span_degrees + 1e-8:
+            return None
+        return _clamp(delta / span_degrees)
+
+    def _edge_weight(value, start, end, falloff):
+        if value < start or value > end:
+            return 0.0
+        if falloff <= 0.0:
+            return 1.0
+        weight = 1.0
+        if value < start + falloff:
+            t = _clamp((value - start) / max(1e-9, falloff))
+            weight *= t * t * (3.0 - 2.0 * t)
+        if value > end - falloff:
+            t = _clamp((end - value) / max(1e-9, falloff))
+            weight *= t * t * (3.0 - 2.0 * t)
+        return weight
+
+    def _angle_edge_weight(angle_t, span_degrees, falloff_degrees):
+        if falloff_degrees <= 0.0:
+            return 1.0
+        falloff_t = _clamp(falloff_degrees / max(1e-9, span_degrees))
+        if falloff_t <= 0.0:
+            return 1.0
+        weight = 1.0
+        if angle_t < falloff_t:
+            t = _clamp(angle_t / falloff_t)
+            weight *= t * t * (3.0 - 2.0 * t)
+        if angle_t > 1.0 - falloff_t:
+            t = _clamp((1.0 - angle_t) / falloff_t)
+            weight *= t * t * (3.0 - 2.0 * t)
+        return weight
+
+    def _pixel_rgb_alpha(image, x, y):
+        color = image.pixelColor(int(x), int(y))
+        return [color.redF(), color.greenF(), color.blueF(), color.alphaF()]
+
+    def _sample_bilinear(image, u, v):
+        width = image.width()
+        height = image.height()
+        x = _clamp(u) * float(width - 1)
+        y = _clamp(v) * float(height - 1)
+        x0 = int(math.floor(x))
+        y0 = int(math.floor(y))
+        x1 = min(width - 1, x0 + 1)
+        y1 = min(height - 1, y0 + 1)
+        tx = x - x0
+        ty = y - y0
+        c00 = _pixel_rgb_alpha(image, x0, y0)
+        c10 = _pixel_rgb_alpha(image, x1, y0)
+        c01 = _pixel_rgb_alpha(image, x0, y1)
+        c11 = _pixel_rgb_alpha(image, x1, y1)
+        channels = []
+        for index in range(4):
+            top = c00[index] * (1.0 - tx) + c10[index] * tx
+            bottom = c01[index] * (1.0 - tx) + c11[index] * tx
+            channels.append(top * (1.0 - ty) + bottom * ty)
+        return channels
+
+    def _rgb_to_hsv(red, green, blue):
+        max_value = max(red, green, blue)
+        min_value = min(red, green, blue)
+        delta = max_value - min_value
+        if delta == 0.0:
+            hue = 0.0
+        elif max_value == red:
+            hue = ((green - blue) / delta) % 6.0
+        elif max_value == green:
+            hue = ((blue - red) / delta) + 2.0
+        else:
+            hue = ((red - green) / delta) + 4.0
+        hue /= 6.0
+        saturation = 0.0 if max_value == 0.0 else delta / max_value
+        return hue, saturation, max_value
+
+    def _sample_value(image, u, v):
+        red, green, blue, alpha = _sample_bilinear(image, u, v)
+        if sample_channel == "red":
+            value = red
+        elif sample_channel == "green":
+            value = green
+        elif sample_channel == "blue":
+            value = blue
+        elif sample_channel == "alpha":
+            value = alpha
+        elif sample_channel == "value":
+            value = max(red, green, blue)
+        elif sample_channel == "saturation":
+            value = _rgb_to_hsv(red, green, blue)[1]
+        else:
+            value = 0.2126 * red + 0.7152 * green + 0.0722 * blue
+
+        value = _clamp((value - black_point) / max(1e-9, white_point - black_point))
+        if invert:
+            value = 1.0 - value
+        if threshold is not None:
+            if threshold_softness <= 0.0:
+                value = 1.0 if value >= threshold else 0.0
+            else:
+                lower = threshold - threshold_softness * 0.5
+                upper = threshold + threshold_softness * 0.5
+                value = _clamp((value - lower) / max(1e-9, upper - lower))
+                value = value * value * (3.0 - 2.0 * value)
+        if gamma != 1.0:
+            value = value ** gamma
+        return value
+
+    if not cmds.objExists(object_name):
+        raise ValueError(f"Object does not exist: {object_name}")
+    if not image_path:
+        raise ValueError("image_path is required.")
+    normalized_image_path = os.path.normpath(image_path)
+    if not os.path.isfile(normalized_image_path):
+        raise ValueError(f"Image path does not exist: {image_path}")
+
+    center = _validate_vector(center, 3, "center")
+    axis_range = _validate_vector(axis_range, 2, "axis_range")
+    angle_range_degrees = _validate_vector(angle_range_degrees, 2, "angle_range_degrees")
+    amplitude = _validate_scalar(amplitude, "amplitude")
+    black_point = _validate_scalar(black_point, "black_point")
+    white_point = _validate_scalar(white_point, "white_point")
+    if abs(white_point - black_point) <= 1e-9:
+        raise ValueError("white_point must differ from black_point.")
+    if threshold is not None:
+        threshold = _validate_scalar(threshold, "threshold")
+    threshold_softness = _validate_scalar(threshold_softness, "threshold_softness")
+    if threshold_softness < 0.0:
+        raise ValueError("threshold_softness must be greater than or equal to zero.")
+    neutral_value = _validate_scalar(neutral_value, "neutral_value")
+    gamma = _validate_scalar(gamma, "gamma")
+    if gamma <= 0.0:
+        raise ValueError("gamma must be greater than zero.")
+    axis_falloff = _validate_scalar(axis_falloff, "axis_falloff")
+    angle_falloff_degrees = _validate_scalar(angle_falloff_degrees, "angle_falloff_degrees")
+    if axis_falloff < 0.0 or angle_falloff_degrees < 0.0:
+        raise ValueError("falloff values must be greater than or equal to zero.")
+
+    displacement_direction = displacement_direction.lower().strip()
+    if displacement_direction not in {"radial", "axis"}:
+        raise ValueError("displacement_direction must be one of radial or axis.")
+    sample_channel = sample_channel.lower().strip()
+    if sample_channel not in {"luminance", "red", "green", "blue", "alpha", "value", "saturation"}:
+        raise ValueError("sample_channel must be one of luminance, red, green, blue, alpha, value, or saturation.")
+
+    axis = axis.lower()
+    axes = {
+        "x": (0, 1, 2),
+        "y": (1, 0, 2),
+        "z": (2, 0, 1),
+    }
+    if axis not in axes:
+        raise ValueError("axis must be one of x, y, or z.")
+    axis_index, radial_a, radial_b = axes[axis]
+
+    axis_start, axis_end = axis_range
+    if axis_start > axis_end:
+        axis_start, axis_end = axis_end, axis_start
+    axis_span = axis_end - axis_start
+    if axis_span <= 0.0:
+        raise ValueError("axis_range must cover a positive span.")
+
+    angle_start, angle_end = angle_range_degrees
+    angle_span = _positive_span(angle_start, angle_end)
+
+    image = QImage(normalized_image_path)
+    if image.isNull():
+        raise ValueError(f"Unable to load image: {image_path}")
+    if image.width() < 2 or image.height() < 2:
+        raise ValueError("image must be at least 2x2 pixels.")
+
+    shapes = cmds.listRelatives(object_name, shapes=True, fullPath=True) or []
+    if cmds.objectType(object_name) == "mesh":
+        shapes = [object_name]
+    if not any(cmds.objectType(shape) == "mesh" for shape in shapes):
+        raise ValueError(f"{object_name} is not a polygon mesh transform or mesh shape.")
+
+    vertices = cmds.ls(f"{object_name}.vtx[*]", flatten=True) or []
+    if not vertices:
+        raise ValueError(f"No vertices found on {object_name}.")
+
+    deformed_vertices = 0
+    sample_values = []
+    displacement_values = []
+    for vertex in vertices:
+        position = cmds.xform(vertex, query=True, worldSpace=True, translation=True)
+        local_axis = position[axis_index] - center[axis_index]
+        axis_weight = _edge_weight(local_axis, axis_start, axis_end, axis_falloff)
+        if axis_weight <= 0.0:
+            continue
+
+        delta_a = position[radial_a] - center[radial_a]
+        delta_b = position[radial_b] - center[radial_b]
+        radius = math.sqrt(delta_a * delta_a + delta_b * delta_b)
+        if radius <= 1e-8:
+            continue
+
+        angle_degrees = math.degrees(math.atan2(delta_a, delta_b))
+        angle_t = _angle_range_t(angle_degrees, angle_start, angle_span)
+        if angle_t is None:
+            continue
+        angle_weight = _angle_edge_weight(angle_t, angle_span, angle_falloff_degrees)
+        if angle_weight <= 0.0:
+            continue
+
+        u = 1.0 - angle_t if flip_u else angle_t
+        v = (local_axis - axis_start) / axis_span
+        v = 1.0 - v if flip_v else v
+        sampled = _sample_value(image, u, v)
+        displacement = amplitude * (sampled - neutral_value) * axis_weight * angle_weight
+        if abs(displacement) <= 1e-12:
+            continue
+
+        if displacement_direction == "radial":
+            new_radius = max(0.0, radius + displacement)
+            scale = new_radius / radius
+            position[radial_a] = center[radial_a] + delta_a * scale
+            position[radial_b] = center[radial_b] + delta_b * scale
+        else:
+            position[axis_index] = position[axis_index] + displacement
+        cmds.xform(vertex, worldSpace=True, translation=position)
+        deformed_vertices += 1
+        sample_values.append(sampled)
+        displacement_values.append(displacement)
+
+    if smooth:
+        cmds.polySoftEdge(object_name, angle=180, constructionHistory=False)
+
+    return {
+        "success": True,
+        "object_name": object_name,
+        "image_path": normalized_image_path,
+        "image_width": image.width(),
+        "image_height": image.height(),
+        "deformed_vertices": deformed_vertices,
+        "axis": axis,
+        "axis_range": [axis_start, axis_end],
+        "angle_range_degrees": angle_range_degrees,
+        "amplitude": amplitude,
+        "displacement_direction": displacement_direction,
+        "sample_channel": sample_channel,
+        "invert": bool(invert),
+        "black_point": black_point,
+        "white_point": white_point,
+        "threshold": threshold,
+        "threshold_softness": threshold_softness,
+        "neutral_value": neutral_value,
+        "gamma": gamma,
+        "flip_u": bool(flip_u),
+        "flip_v": bool(flip_v),
+        "axis_falloff": axis_falloff,
+        "angle_falloff_degrees": angle_falloff_degrees,
+        "min_sample_value": min(sample_values) if sample_values else 0.0,
+        "max_sample_value": max(sample_values) if sample_values else 0.0,
+        "min_displacement": min(displacement_values) if displacement_values else 0.0,
+        "max_displacement": max(displacement_values) if displacement_values else 0.0,
+        "bounding_box": cmds.exactWorldBoundingBox(object_name),
+    }

--- a/src/mayatools/object/cylindrical_uv_projection.py
+++ b/src/mayatools/object/cylindrical_uv_projection.py
@@ -1,0 +1,202 @@
+from typing import Dict, List, Any
+
+
+def cylindrical_uv_projection(
+    object_name: str,
+    uv_set: str = "map1",
+    center: List[float] = [0.0, 0.0, 0.0],
+    axis: str = "y",
+    axis_range: List[float] = None,
+    angle_range_degrees: List[float] = [0.0, 360.0],
+    flip_u: bool = False,
+    flip_v: bool = False,
+    outside_angle_mode: str = "wrap",
+    set_current: bool = True,
+) -> Dict[str, Any]:
+    """Create or replace UVs from world-space cylindrical coordinates.
+
+    The selected mesh is sampled in world space around the chosen axis. U is
+    derived from angular position and V from height along the axis. UVs are
+    assigned per face-vertex instead of per shared vertex, so seams and partial
+    angular ranges remain stable. This is useful for generic bottles, cans,
+    cups, tubes, columns, and other lathed objects that need deterministic
+    texture placement before material assignment, trimming, or texture-driven
+    deformation.
+    """
+    import math
+    import maya.cmds as cmds
+
+    try:
+        import maya.api.OpenMaya as om
+    except Exception as exc:
+        raise RuntimeError("maya.api.OpenMaya is required to edit mesh UVs.") from exc
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(value) for value in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(value) for value in values]
+
+    def _clamp(value, lower=0.0, upper=1.0):
+        return max(lower, min(upper, value))
+
+    def _positive_span(start_degrees, end_degrees):
+        span = (end_degrees - start_degrees) % 360.0
+        return 360.0 if abs(span) < 1e-8 else span
+
+    def _angle_delta(angle_degrees, start_degrees):
+        return (angle_degrees - start_degrees) % 360.0
+
+    def _angle_u(angle_degrees, start_degrees, span_degrees):
+        delta = _angle_delta(angle_degrees, start_degrees)
+        if span_degrees >= 360.0 - 1e-8:
+            return delta / 360.0
+
+        if delta <= span_degrees:
+            return delta / span_degrees
+
+        if outside_angle_mode == "wrap":
+            return (delta / span_degrees) % 1.0
+        if outside_angle_mode == "clamp":
+            distance_to_start = min(delta, 360.0 - delta)
+            distance_to_end = abs(delta - span_degrees)
+            return 0.0 if distance_to_start < distance_to_end else 1.0
+        return delta / span_degrees
+
+    def _shape_dag_path(node_name):
+        selection = om.MSelectionList()
+        selection.add(node_name)
+        dag_path = selection.getDagPath(0)
+        if dag_path.node().hasFn(om.MFn.kTransform):
+            dag_path.extendToShape()
+        if not dag_path.node().hasFn(om.MFn.kMesh):
+            raise ValueError(f"{object_name} is not a polygon mesh transform or mesh shape.")
+        return dag_path
+
+    if not object_name:
+        raise ValueError("object_name is required.")
+    if not cmds.objExists(object_name):
+        raise ValueError(f"Object does not exist: {object_name}")
+    if not uv_set:
+        raise ValueError("uv_set is required.")
+
+    center = _validate_vector(center, 3, "center")
+    if axis_range is not None:
+        axis_range = _validate_vector(axis_range, 2, "axis_range")
+    angle_range_degrees = _validate_vector(angle_range_degrees, 2, "angle_range_degrees")
+
+    axis = axis.lower().strip()
+    axes = {
+        "x": (0, 1, 2),
+        "y": (1, 0, 2),
+        "z": (2, 0, 1),
+    }
+    if axis not in axes:
+        raise ValueError("axis must be one of x, y, or z.")
+    axis_index, radial_a, radial_b = axes[axis]
+
+    outside_angle_mode = outside_angle_mode.lower().strip()
+    if outside_angle_mode not in {"wrap", "clamp", "extend"}:
+        raise ValueError("outside_angle_mode must be wrap, clamp, or extend.")
+
+    angle_start, angle_end = angle_range_degrees
+    angle_span = _positive_span(angle_start, angle_end)
+
+    dag_path = _shape_dag_path(object_name)
+    mesh_fn = om.MFnMesh(dag_path)
+    uv_sets = list(mesh_fn.getUVSetNames())
+    if uv_set not in uv_sets:
+        mesh_fn.createUVSet(uv_set)
+    if set_current:
+        try:
+            mesh_fn.setCurrentUVSetName(uv_set)
+        except Exception:
+            cmds.polyUVSet(object_name, currentUVSet=True, uvSet=uv_set)
+
+    points = mesh_fn.getPoints(om.MSpace.kWorld)
+    face_counts, vertex_ids = mesh_fn.getVertices()
+    if not face_counts:
+        raise ValueError(f"No polygon faces found on {object_name}.")
+
+    if axis_range is None:
+        axis_values = [point[axis_index] - center[axis_index] for point in points]
+        axis_start = min(axis_values)
+        axis_end = max(axis_values)
+    else:
+        axis_start, axis_end = axis_range
+        if axis_start > axis_end:
+            axis_start, axis_end = axis_end, axis_start
+    axis_span = axis_end - axis_start
+    if axis_span <= 1e-12:
+        raise ValueError("axis_range must cover a positive span.")
+
+    u_values = []
+    v_values = []
+    uv_ids = []
+    cursor = 0
+    min_u = None
+    max_u = None
+    min_v = None
+    max_v = None
+
+    for count in face_counts:
+        for _ in range(count):
+            vertex_id = vertex_ids[cursor]
+            point = points[vertex_id]
+            delta_a = point[radial_a] - center[radial_a]
+            delta_b = point[radial_b] - center[radial_b]
+            angle_degrees = math.degrees(math.atan2(delta_a, delta_b))
+
+            u = _angle_u(angle_degrees, angle_start, angle_span)
+            v = (point[axis_index] - center[axis_index] - axis_start) / axis_span
+            if flip_u:
+                u = 1.0 - u
+            if flip_v:
+                v = 1.0 - v
+
+            uv_ids.append(len(u_values))
+            u_values.append(float(u))
+            v_values.append(float(v))
+            min_u = u if min_u is None else min(min_u, u)
+            max_u = u if max_u is None else max(max_u, u)
+            min_v = v if min_v is None else min(min_v, v)
+            max_v = v if max_v is None else max(max_v, v)
+            cursor += 1
+
+    try:
+        mesh_fn.clearUVs(uv_set)
+    except Exception:
+        pass
+    mesh_fn.setUVs(u_values, v_values, uv_set)
+    mesh_fn.assignUVs(face_counts, uv_ids, uv_set)
+    mesh_fn.updateSurface()
+
+    if set_current:
+        try:
+            cmds.polyUVSet(object_name, currentUVSet=True, uvSet=uv_set)
+        except Exception:
+            pass
+
+    return {
+        "success": True,
+        "object_name": object_name,
+        "uv_set": uv_set,
+        "center": center,
+        "axis": axis,
+        "axis_range": [axis_start, axis_end],
+        "angle_range_degrees": angle_range_degrees,
+        "angle_span_degrees": angle_span,
+        "flip_u": bool(flip_u),
+        "flip_v": bool(flip_v),
+        "outside_angle_mode": outside_angle_mode,
+        "face_count": len(face_counts),
+        "uv_count": len(u_values),
+        "uv_range": {
+            "min_u": _clamp(min_u) if outside_angle_mode != "extend" else min_u,
+            "max_u": _clamp(max_u) if outside_angle_mode != "extend" else max_u,
+            "min_v": min_v,
+            "max_v": max_v,
+        },
+    }

--- a/src/mayatools/object/edit_mesh_boundary.py
+++ b/src/mayatools/object/edit_mesh_boundary.py
@@ -1,0 +1,280 @@
+from typing import Dict, List, Any, Union
+
+
+def edit_mesh_boundary(
+    object_name: str,
+    operation: str,
+    component_type: str = None,
+    indices: List[int] = None,
+    components: Union[str, List[str]] = None,
+    parameters: Dict[str, Any] = None,
+    use_selection: bool = True,
+    max_preview: int = 50,
+) -> Dict[str, Any]:
+    """Open, clean, and repair polygon mesh boundaries.
+
+    Operations:
+    - delete_faces: remove selected faces, leaving border edges around the hole
+    - delete_edges: delete selected edges, optionally cleaning unused vertices
+    - fill_holes: close selected border loops, or all current border loops when
+      no components are provided
+
+    This is a Maya-style component repair tool for local mesh work: make an
+    opening, remove support edges, then close border loops while reporting
+    before/after topology counts and border edge changes.
+    """
+    import re
+    import maya.cmds as cmds
+    import maya.api.OpenMaya as om
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return int(value)
+
+    def _mesh_shape(node):
+        if not cmds.objExists(node):
+            raise ValueError(f"Object does not exist: {node}")
+        if cmds.objectType(node) == "mesh":
+            return node
+        shapes = cmds.listRelatives(node, shapes=True, fullPath=True) or []
+        mesh_shapes = []
+        for shape in shapes:
+            if cmds.objectType(shape) != "mesh":
+                continue
+            try:
+                if cmds.attributeQuery("intermediateObject", node=shape, exists=True) and cmds.getAttr(f"{shape}.intermediateObject"):
+                    continue
+            except Exception:
+                pass
+            mesh_shapes.append(shape)
+        if not mesh_shapes:
+            raise ValueError(f"{node} is not a polygon mesh transform or mesh shape.")
+        return mesh_shapes[0]
+
+    def _mesh_dag(shape):
+        selection = om.MSelectionList()
+        selection.add(shape)
+        return selection.getDagPath(0)
+
+    def _prefix(shape):
+        parents = cmds.listRelatives(shape, parent=True, fullPath=False) or []
+        return parents[0] if parents else object_name
+
+    def _flatten(value):
+        if value is None:
+            return []
+        if isinstance(value, str):
+            value = [value]
+        if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+            raise ValueError("components must be a string, a list of strings, or None.")
+        return cmds.ls(value, flatten=True) or []
+
+    def _selected_components():
+        if not use_selection:
+            return []
+        selected = cmds.ls(selection=True, flatten=True) or []
+        object_tokens = {object_name, prefix_name, shape_name}
+        return [item for item in selected if item.split(".", 1)[0] in object_tokens]
+
+    def _components_from_indices(kind):
+        if indices is None:
+            return []
+        if not isinstance(indices, list) or not all(isinstance(index, int) and not isinstance(index, bool) for index in indices):
+            raise ValueError("indices must be a list of integers.")
+        return [f"{prefix_name}.{kind}[{index}]" for index in indices]
+
+    def _resolve_components(default_type=None, allow_empty=False):
+        clean_type = (component_type or default_type or "").lower().strip()
+        kind_map = {"vertex": "vtx", "edge": "e", "face": "f", "uv": "map", "vertex_face": "vtxFace"}
+        if components is not None:
+            resolved = _flatten(components)
+        elif clean_type in kind_map and indices is not None:
+            resolved = _components_from_indices(kind_map[clean_type])
+        else:
+            resolved = _selected_components()
+        if not resolved and not allow_empty:
+            raise ValueError("No components resolved from components, indices, or current selection.")
+        return resolved
+
+    def _convert(items, target):
+        flags = {
+            "vertex": {"toVertex": True},
+            "edge": {"toEdge": True},
+            "face": {"toFace": True},
+        }[target]
+        return cmds.ls(cmds.polyListComponentConversion(items, **flags) or [], flatten=True) or []
+
+    def _component_ids(items, kind):
+        pattern = re.compile(rf"\.{kind}\[(\d+)\]$")
+        ids = []
+        for item in cmds.ls(items, flatten=True) or []:
+            match = pattern.search(item)
+            if match:
+                ids.append(int(match.group(1)))
+        return list(dict.fromkeys(ids))
+
+    def _counts():
+        return {
+            "vertices": int(cmds.polyEvaluate(object_name, vertex=True)),
+            "edges": int(cmds.polyEvaluate(object_name, edge=True)),
+            "faces": int(cmds.polyEvaluate(object_name, face=True)),
+        }
+
+    def _boundary_edge_data():
+        dag_path = _mesh_dag(shape_name)
+        edge_it = om.MItMeshEdge(dag_path)
+        data = {}
+        while not edge_it.isDone():
+            try:
+                is_boundary = bool(edge_it.onBoundary())
+            except Exception:
+                is_boundary = len(edge_it.getConnectedFaces()) < 2
+            if is_boundary:
+                edge_id = int(edge_it.index())
+                data[edge_id] = (int(edge_it.vertexId(0)), int(edge_it.vertexId(1)))
+            edge_it.next()
+        return data
+
+    def _component(kind, index):
+        return f"{prefix_name}.{kind}[{index}]"
+
+    def _edge_groups(edge_ids, boundary_data):
+        seed_edges = set(edge_ids)
+        adjacency = {edge_id: set() for edge_id in boundary_data}
+        edges_by_vertex = {}
+        for edge_id in boundary_data:
+            for vertex_id in boundary_data[edge_id]:
+                edges_by_vertex.setdefault(vertex_id, []).append(edge_id)
+        for connected_edges in edges_by_vertex.values():
+            for edge_id in connected_edges:
+                adjacency[edge_id].update(other for other in connected_edges if other != edge_id)
+
+        groups = []
+        visited = set()
+        for edge_id in sorted(boundary_data):
+            if edge_id in visited:
+                continue
+            stack = [edge_id]
+            group = []
+            visited.add(edge_id)
+            while stack:
+                current = stack.pop()
+                group.append(current)
+                for neighbor in sorted(adjacency[current]):
+                    if neighbor in visited:
+                        continue
+                    visited.add(neighbor)
+                    stack.append(neighbor)
+            if seed_edges.intersection(group):
+                groups.append(sorted(group))
+        return groups
+
+    def _changed(before, after, border_before, border_after):
+        if any(before[key] != after[key] for key in before):
+            return True
+        return len(border_before) != len(border_after)
+
+    def _result(node_result, resolved, before_counts, before_border, extra=None):
+        after_counts = _counts()
+        after_border = sorted(_boundary_edge_data())
+        if not _changed(before_counts, after_counts, before_border, after_border):
+            raise RuntimeError(f"{operation} did not change mesh topology or boundary state.")
+        current_selection = cmds.ls(selection=True, flatten=True) or []
+        payload = {
+            "success": True,
+            "object_name": object_name,
+            "operation": operation,
+            "node": node_result,
+            "input_component_count": len(resolved),
+            "input_components_preview": resolved[:max_preview],
+            "selected_after_count": len(current_selection),
+            "selected_after_preview": current_selection[:max_preview],
+            "counts_before": before_counts,
+            "counts_after": after_counts,
+            "border_edges_before_count": len(before_border),
+            "border_edges_after_count": len(after_border),
+            "border_edges_before_preview": [_component("e", edge_id) for edge_id in before_border[:max_preview]],
+            "border_edges_after_preview": [_component("e", edge_id) for edge_id in after_border[:max_preview]],
+        }
+        if extra:
+            payload.update(extra)
+        return payload
+
+    if not object_name:
+        raise ValueError("object_name is required.")
+    if not operation:
+        raise ValueError("operation is required.")
+    operation = operation.lower().strip()
+    allowed = {"delete_faces", "delete_edges", "fill_holes"}
+    if operation not in allowed:
+        raise ValueError(f"operation must be one of: {', '.join(sorted(allowed))}.")
+
+    parameters = parameters or {}
+    max_preview = _validate_int(max_preview, "max_preview", 1)
+    shape_name = _mesh_shape(object_name)
+    prefix_name = _prefix(shape_name)
+    before_counts = _counts()
+    before_border = sorted(_boundary_edge_data())
+    construction_history = bool(parameters.get("construction_history", False))
+
+    if operation == "delete_faces":
+        faces = _convert(_resolve_components("face"), "face")
+        if not faces:
+            raise ValueError("delete_faces requires face components.")
+        node = cmds.polyDelFacet(faces, constructionHistory=construction_history)
+        return _result(node, faces, before_counts, before_border)
+
+    if operation == "delete_edges":
+        edges = _convert(_resolve_components("edge"), "edge")
+        if not edges:
+            raise ValueError("delete_edges requires edge components.")
+        clean_vertices = bool(parameters.get("clean_vertices", False))
+        node = cmds.polyDelEdge(
+            edges,
+            cleanVertices=clean_vertices,
+            constructionHistory=construction_history,
+        )
+        return _result(node, edges, before_counts, before_border, {"clean_vertices": clean_vertices})
+
+    if operation == "fill_holes":
+        resolved = _resolve_components("edge", allow_empty=True)
+        boundary_data = _boundary_edge_data()
+        if not boundary_data:
+            raise ValueError(f"{object_name} has no border edges to fill.")
+        if resolved:
+            edge_ids = _component_ids(_convert(resolved, "edge"), "e")
+            border_edge_ids = [edge_id for edge_id in edge_ids if edge_id in boundary_data]
+            if not border_edge_ids:
+                raise ValueError("fill_holes requires selected or indexed border edges.")
+        else:
+            fill_all = bool(parameters.get("fill_all_border_edges", True))
+            if not fill_all:
+                raise ValueError("No components resolved; set parameters.fill_all_border_edges true to fill all holes.")
+            border_edge_ids = sorted(boundary_data)
+            resolved = [_component("e", edge_id) for edge_id in border_edge_ids]
+
+        groups = _edge_groups(border_edge_ids, boundary_data)
+        target_edge_ids = []
+        for group in groups:
+            target_edge_ids.extend(group)
+        target_edge_ids = sorted(dict.fromkeys(target_edge_ids))
+        nodes = []
+        for group in groups:
+            loop_edges = [_component("e", edge_id) for edge_id in group]
+            nodes.append(cmds.polyCloseBorder(loop_edges, constructionHistory=construction_history))
+        return _result(
+            nodes,
+            resolved,
+            before_counts,
+            before_border,
+            {
+                "filled_loop_count": len(groups),
+                "seed_edge_count": len(border_edge_ids),
+                "seed_edges_preview": [_component("e", edge_id) for edge_id in border_edge_ids[:max_preview]],
+                "filled_edge_count": len(target_edge_ids),
+                "filled_edges_preview": [_component("e", edge_id) for edge_id in target_edge_ids[:max_preview]],
+            },
+        )
+
+    raise ValueError(f"Unsupported operation: {operation}")

--- a/src/mayatools/object/edit_mesh_creases.py
+++ b/src/mayatools/object/edit_mesh_creases.py
@@ -1,0 +1,283 @@
+from typing import Dict, List, Any, Union
+
+
+def edit_mesh_creases(
+    object_name: str,
+    operation: str = "query",
+    component_type: str = None,
+    indices: List[int] = None,
+    components: Union[str, List[str]] = None,
+    value: float = 2.0,
+    include_zero: bool = False,
+    use_selection: bool = True,
+    max_preview: int = 100,
+) -> Dict[str, Any]:
+    """Query and edit polygon subdivision crease weights.
+
+    Operations:
+    - query: report crease values for selected, indexed, or nonzero mesh creases
+    - set_edge_creases: set selected/resolved edge crease values
+    - set_vertex_creases: set selected/resolved vertex crease values
+    - clear_creases: set selected/resolved edge and vertex crease values to zero
+
+    Creases control subdivision sharpness and are separate from soft/hard
+    normals. Use this for Maya-style local hard-surface control when extra
+    support geometry is unnecessary or too heavy.
+    """
+    import re
+    import maya.cmds as cmds
+
+    def _is_number(item):
+        return isinstance(item, (int, float)) and not isinstance(item, bool)
+
+    def _validate_scalar(item, arg_name):
+        if not _is_number(item):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(item)
+
+    def _validate_int(item, arg_name, minimum):
+        if not isinstance(item, int) or isinstance(item, bool) or item < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return int(item)
+
+    def _mesh_shape(node):
+        if not cmds.objExists(node):
+            raise ValueError(f"Object does not exist: {node}")
+        if cmds.objectType(node) == "mesh":
+            return node
+        shapes = cmds.listRelatives(node, shapes=True, fullPath=True) or []
+        mesh_shapes = []
+        for shape in shapes:
+            if cmds.objectType(shape) != "mesh":
+                continue
+            try:
+                if cmds.attributeQuery("intermediateObject", node=shape, exists=True) and cmds.getAttr(f"{shape}.intermediateObject"):
+                    continue
+            except Exception:
+                pass
+            mesh_shapes.append(shape)
+        if not mesh_shapes:
+            raise ValueError(f"{node} is not a polygon mesh transform or mesh shape.")
+        return mesh_shapes[0]
+
+    def _prefix(shape):
+        parents = cmds.listRelatives(shape, parent=True, fullPath=False) or []
+        return parents[0] if parents else object_name
+
+    def _flatten(item):
+        if item is None:
+            return []
+        if isinstance(item, str):
+            item = [item]
+        if not isinstance(item, list) or not all(isinstance(entry, str) for entry in item):
+            raise ValueError("components must be a string, a list of strings, or None.")
+        return cmds.ls(item, flatten=True) or []
+
+    def _selected_components():
+        if not use_selection:
+            return []
+        selected = cmds.ls(selection=True, flatten=True) or []
+        object_tokens = {object_name, prefix_name, shape_name}
+        return [item for item in selected if item.split(".", 1)[0] in object_tokens]
+
+    def _components_from_indices(kind):
+        if indices is None:
+            return []
+        if not isinstance(indices, list) or not all(isinstance(index, int) and not isinstance(index, bool) for index in indices):
+            raise ValueError("indices must be a list of integers.")
+        return [f"{prefix_name}.{kind}[{index}]" for index in indices]
+
+    def _resolve_components(default_type=None, allow_empty=False):
+        clean_type = (component_type or default_type or "").lower().strip()
+        kind_map = {"vertex": "vtx", "edge": "e", "face": "f", "uv": "map", "vertex_face": "vtxFace"}
+        if components is not None:
+            resolved = _flatten(components)
+        elif clean_type in kind_map and indices is not None:
+            resolved = _components_from_indices(kind_map[clean_type])
+        else:
+            resolved = _selected_components()
+        if not resolved and not allow_empty:
+            raise ValueError("No components resolved from components, indices, or current selection.")
+        return resolved
+
+    def _unique(items):
+        seen = set()
+        result = []
+        for item in cmds.ls(items, flatten=True) or []:
+            if item in seen:
+                continue
+            seen.add(item)
+            result.append(item)
+        return result
+
+    def _convert(items, target):
+        flags = {
+            "edge": {"toEdge": True},
+            "vertex": {"toVertex": True},
+        }[target]
+        return _unique(cmds.polyListComponentConversion(items, **flags) or [])
+
+    def _component_ids(items, kind):
+        pattern = re.compile(rf"\.{kind}\[(\d+)\]$")
+        ids = []
+        for item in cmds.ls(items, flatten=True) or []:
+            match = pattern.search(item)
+            if match:
+                ids.append(int(match.group(1)))
+        return list(dict.fromkeys(ids))
+
+    def _all_components(kind):
+        count_flag = "edge" if kind == "e" else "vertex"
+        total = int(cmds.polyEvaluate(object_name, **{count_flag: True}))
+        return [f"{prefix_name}.{kind}[{index}]" for index in range(total)]
+
+    def _query_edges(edge_items):
+        records = []
+        for component in _unique(edge_items):
+            values = cmds.polyCrease(component, query=True, value=True) or []
+            crease_value = float(values[0]) if values else 0.0
+            if crease_value < 0.0:
+                crease_value = 0.0
+            if include_zero or abs(crease_value) > 1.0e-9:
+                edge_id = _component_ids([component], "e")
+                records.append({"component": component, "index": edge_id[0] if edge_id else None, "value": crease_value})
+        return records
+
+    def _query_vertices(vertex_items):
+        records = []
+        for component in _unique(vertex_items):
+            values = cmds.polyCrease(component, query=True, vertexValue=True) or []
+            crease_value = float(values[0]) if values else 0.0
+            if crease_value < 0.0:
+                crease_value = 0.0
+            if include_zero or abs(crease_value) > 1.0e-9:
+                vertex_id = _component_ids([component], "vtx")
+                records.append({"component": component, "index": vertex_id[0] if vertex_id else None, "value": crease_value})
+        return records
+
+    def _query_payload(edge_items, vertex_items):
+        edge_records = _query_edges(edge_items)
+        vertex_records = _query_vertices(vertex_items)
+        return {
+            "edge_count": len(edge_records),
+            "vertex_count": len(vertex_records),
+            "edges": edge_records[:max_preview],
+            "vertices": vertex_records[:max_preview],
+            "truncated_edges": len(edge_records) > max_preview,
+            "truncated_vertices": len(vertex_records) > max_preview,
+        }
+
+    def _resolved_edges_and_vertices(allow_empty=False):
+        resolved = _resolve_components(allow_empty=allow_empty)
+        if not resolved:
+            return [], [], resolved
+        clean_type = (component_type or "").lower().strip()
+        if clean_type == "vertex":
+            return [], _convert(resolved, "vertex"), resolved
+        if clean_type == "edge":
+            return _convert(resolved, "edge"), [], resolved
+        if clean_type == "face":
+            return _convert(resolved, "edge"), _convert(resolved, "vertex"), resolved
+        edges = _convert(resolved, "edge")
+        vertices = _convert(resolved, "vertex")
+        return edges, vertices, resolved
+
+    def _counts():
+        return {
+            "vertices": int(cmds.polyEvaluate(object_name, vertex=True)),
+            "edges": int(cmds.polyEvaluate(object_name, edge=True)),
+            "faces": int(cmds.polyEvaluate(object_name, face=True)),
+        }
+
+    if not object_name:
+        raise ValueError("object_name is required.")
+    operation = operation.lower().strip()
+    allowed = {"query", "set_edge_creases", "set_vertex_creases", "clear_creases"}
+    if operation not in allowed:
+        raise ValueError(f"operation must be one of: {', '.join(sorted(allowed))}.")
+
+    clean_value = _validate_scalar(value, "value")
+    if clean_value < 0.0:
+        raise ValueError("value must be greater than or equal to zero.")
+    max_preview = _validate_int(max_preview, "max_preview", 0)
+    shape_name = _mesh_shape(object_name)
+    prefix_name = _prefix(shape_name)
+    counts = _counts()
+
+    if operation == "query":
+        edge_targets, vertex_targets, resolved = _resolved_edges_and_vertices(allow_empty=True)
+        if not resolved:
+            edge_targets = _all_components("e")
+            vertex_targets = _all_components("vtx")
+        return {
+            "success": True,
+            "object_name": object_name,
+            "operation": operation,
+            "component_count": len(resolved),
+            "components_preview": resolved[:max_preview],
+            "include_zero": bool(include_zero),
+            "counts": counts,
+            "query": _query_payload(edge_targets, vertex_targets),
+        }
+
+    if operation == "set_edge_creases":
+        resolved = _resolve_components("edge")
+        edge_targets = _convert(resolved, "edge")
+        if not edge_targets:
+            raise ValueError("set_edge_creases requires edge components.")
+        before = _query_payload(edge_targets, [])
+        cmds.polyCrease(edge_targets, value=clean_value)
+        return {
+            "success": True,
+            "object_name": object_name,
+            "operation": operation,
+            "value": clean_value,
+            "component_count": len(edge_targets),
+            "components_preview": edge_targets[:max_preview],
+            "counts": counts,
+            "query_before": before,
+            "query_after": _query_payload(edge_targets, []),
+        }
+
+    if operation == "set_vertex_creases":
+        resolved = _resolve_components("vertex")
+        vertex_targets = _convert(resolved, "vertex")
+        if not vertex_targets:
+            raise ValueError("set_vertex_creases requires vertex components.")
+        before = _query_payload([], vertex_targets)
+        cmds.polyCrease(vertex_targets, vertexValue=clean_value)
+        return {
+            "success": True,
+            "object_name": object_name,
+            "operation": operation,
+            "value": clean_value,
+            "component_count": len(vertex_targets),
+            "components_preview": vertex_targets[:max_preview],
+            "counts": counts,
+            "query_before": before,
+            "query_after": _query_payload([], vertex_targets),
+        }
+
+    if operation == "clear_creases":
+        edge_targets, vertex_targets, resolved = _resolved_edges_and_vertices()
+        if not edge_targets and not vertex_targets:
+            raise ValueError("clear_creases requires edge, vertex, face, or mixed components.")
+        before = _query_payload(edge_targets, vertex_targets)
+        if edge_targets:
+            cmds.polyCrease(edge_targets, value=0.0)
+        if vertex_targets:
+            cmds.polyCrease(vertex_targets, vertexValue=0.0)
+        return {
+            "success": True,
+            "object_name": object_name,
+            "operation": operation,
+            "component_count": len(resolved),
+            "components_preview": resolved[:max_preview],
+            "cleared_edge_count": len(edge_targets),
+            "cleared_vertex_count": len(vertex_targets),
+            "counts": counts,
+            "query_before": before,
+            "query_after": _query_payload(edge_targets, vertex_targets),
+        }
+
+    raise ValueError(f"Unsupported operation: {operation}")

--- a/src/mayatools/object/edit_mesh_normals.py
+++ b/src/mayatools/object/edit_mesh_normals.py
@@ -9,6 +9,9 @@ def edit_mesh_normals(
     components: Union[str, List[str]] = None,
     normal: List[float] = None,
     angle: float = 30.0,
+    min_angle: float = None,
+    max_angle: float = None,
+    include_boundary_edges: bool = False,
     distance: float = 0.0,
     normalize_vector: bool = True,
     construction_history: bool = False,
@@ -29,6 +32,10 @@ def edit_mesh_normals(
     - lock_normals: freeze selected vertex normals
     - unlock_normals: unfreeze selected vertex normals
     - average_normals: average selected vertex normals within distance
+    - query_edge_angles: report dihedral angles for selected or all mesh edges
+    - select_edges_by_angle: select edges whose adjacent face angle matches
+    - harden_edges_by_angle: harden matching edges
+    - soften_edges_by_angle: soften matching edges
 
     This provides Maya-style normal control for localized shading and highlight
     cleanup without relying on object-wide smoothing shortcuts.
@@ -141,6 +148,18 @@ def edit_mesh_normals(
                 ids.append(int(match.group(1)))
         return sorted(set(ids))
 
+    def _all_edge_components():
+        return [f"{prefix_name}.e[{edge_id}]" for edge_id in range(int(mesh_fn.numEdges))]
+
+    def _edge_scope_components():
+        resolved = _resolve_components("edge", allow_object=True)
+        if resolved == [object_name]:
+            return _all_edge_components()
+        edge_targets = _to_edges(resolved)
+        if not edge_targets:
+            raise ValueError(f"{operation} requires edge components or object scope.")
+        return edge_targets
+
     def _to_vertices(items):
         converted = cmds.polyListComponentConversion(items, toVertex=True) or []
         return cmds.ls(converted, flatten=True) or []
@@ -159,6 +178,61 @@ def edit_mesh_normals(
             if index + 2 < len(values):
                 triplets.append([float(values[index]), float(values[index + 1]), float(values[index + 2])])
         return triplets
+
+    def _edge_angle_records(edge_items):
+        edge_ids = _component_ids(edge_items, "e")
+        records = []
+        for edge_id in edge_ids:
+            component = f"{prefix_name}.e[{edge_id}]"
+            edge_it = om.MItMeshEdge(_dag_path)
+            edge_it.setIndex(edge_id)
+            connected_faces = [int(face_id) for face_id in edge_it.getConnectedFaces()]
+            angle_value = None
+            if len(connected_faces) == 2:
+                normal_a = mesh_fn.getPolygonNormal(connected_faces[0], om.MSpace.kWorld)
+                normal_b = mesh_fn.getPolygonNormal(connected_faces[1], om.MSpace.kWorld)
+                vector_a = om.MVector(normal_a.x, normal_a.y, normal_a.z)
+                vector_b = om.MVector(normal_b.x, normal_b.y, normal_b.z)
+                if vector_a.length() > 1.0e-12 and vector_b.length() > 1.0e-12:
+                    vector_a.normalize()
+                    vector_b.normalize()
+                    dot = max(-1.0, min(1.0, vector_a * vector_b))
+                    angle_value = float(math.degrees(math.acos(dot)))
+            records.append(
+                {
+                    "component": component,
+                    "index": edge_id,
+                    "connected_faces": connected_faces,
+                    "boundary": len(connected_faces) < 2,
+                    "nonmanifold": len(connected_faces) > 2,
+                    "angle": angle_value,
+                }
+            )
+        return records
+
+    def _angle_bounds():
+        lower = _validate_scalar(min_angle, "min_angle") if min_angle is not None else _validate_scalar(angle, "angle")
+        upper = _validate_scalar(max_angle, "max_angle") if max_angle is not None else 180.0
+        if lower < 0.0 or lower > 180.0 or upper < 0.0 or upper > 180.0:
+            raise ValueError("angle, min_angle, and max_angle must be between 0 and 180.")
+        if lower > upper:
+            lower, upper = upper, lower
+        return lower, upper
+
+    def _matching_edge_records(edge_items):
+        lower, upper = _angle_bounds()
+        records = []
+        skipped = []
+        for record in _edge_angle_records(edge_items):
+            if record["angle"] is None:
+                if include_boundary_edges and record["boundary"]:
+                    records.append(record)
+                else:
+                    skipped.append(record)
+                continue
+            if lower <= record["angle"] <= upper:
+                records.append(record)
+        return records, skipped, lower, upper
 
     def _query_components(items):
         faces = _to_faces(items)
@@ -203,6 +277,11 @@ def edit_mesh_normals(
             "faces": int(cmds.polyEvaluate(object_name, face=True)),
         }
 
+    def _dag_path_for_shape(shape):
+        selection = om.MSelectionList()
+        selection.add(shape)
+        return selection.getDagPath(0)
+
     if not object_name:
         raise ValueError("object_name is required.")
     operation = operation.lower().strip()
@@ -218,6 +297,10 @@ def edit_mesh_normals(
         "lock_normals",
         "unlock_normals",
         "average_normals",
+        "query_edge_angles",
+        "select_edges_by_angle",
+        "harden_edges_by_angle",
+        "soften_edges_by_angle",
     }
     if operation not in allowed:
         raise ValueError(f"operation must be one of: {', '.join(sorted(allowed))}.")
@@ -225,6 +308,7 @@ def edit_mesh_normals(
     shape_name = _mesh_shape(object_name)
     prefix_name = _prefix(shape_name)
     mesh_fn = _mesh_fn(shape_name)
+    _dag_path = _dag_path_for_shape(shape_name)
     before_counts = _counts()
 
     if operation == "query":
@@ -236,6 +320,58 @@ def edit_mesh_normals(
             "components_preview": resolved[:max_preview],
             "counts": before_counts,
             "query": _query_components(resolved),
+        }
+
+    if operation == "query_edge_angles":
+        edge_targets = _edge_scope_components()
+        records = _edge_angle_records(edge_targets)
+        return {
+            "success": True,
+            "object_name": object_name,
+            "operation": operation,
+            "component_count": len(edge_targets),
+            "components_preview": edge_targets[:max_preview],
+            "counts": before_counts,
+            "records": records[:max_preview],
+            "truncated": len(records) > max_preview,
+            "boundary_count": sum(1 for record in records if record["boundary"]),
+            "nonmanifold_count": sum(1 for record in records if record["nonmanifold"]),
+        }
+
+    if operation in {"select_edges_by_angle", "harden_edges_by_angle", "soften_edges_by_angle"}:
+        edge_targets = _edge_scope_components()
+        records, skipped, lower_angle, upper_angle = _matching_edge_records(edge_targets)
+        matching_edges = [record["component"] for record in records]
+        if operation == "select_edges_by_angle":
+            if matching_edges:
+                cmds.select(matching_edges, replace=True)
+            else:
+                cmds.select(clear=True)
+            node = None
+            applied_angle = None
+        else:
+            applied_angle = 0.0 if operation == "harden_edges_by_angle" else 180.0
+            node = cmds.polySoftEdge(matching_edges, angle=applied_angle, constructionHistory=construction_history) if matching_edges else None
+            if matching_edges:
+                cmds.select(matching_edges, replace=True)
+            else:
+                cmds.select(clear=True)
+        return {
+            "success": True,
+            "object_name": object_name,
+            "operation": operation,
+            "angle_range": [lower_angle, upper_angle],
+            "include_boundary_edges": bool(include_boundary_edges),
+            "input_edge_count": len(edge_targets),
+            "matching_edge_count": len(matching_edges),
+            "matching_edges_preview": matching_edges[:max_preview],
+            "matching_records": records[:max_preview],
+            "skipped_unmeasured_count": len(skipped),
+            "skipped_unmeasured_preview": skipped[:max_preview],
+            "node": node,
+            "applied_soft_edge_angle": applied_angle,
+            "counts_before": before_counts,
+            "counts_after": _counts(),
         }
 
     if operation in {"soften_edges", "harden_edges", "set_edge_softness"}:

--- a/src/mayatools/object/edit_mesh_normals.py
+++ b/src/mayatools/object/edit_mesh_normals.py
@@ -1,0 +1,339 @@
+from typing import Dict, List, Any, Union
+
+
+def edit_mesh_normals(
+    object_name: str,
+    operation: str = "query",
+    component_type: str = None,
+    indices: List[int] = None,
+    components: Union[str, List[str]] = None,
+    normal: List[float] = None,
+    angle: float = 30.0,
+    distance: float = 0.0,
+    normalize_vector: bool = True,
+    construction_history: bool = False,
+    use_selection: bool = True,
+    max_preview: int = 50,
+) -> Dict[str, Any]:
+    """Query and edit polygon face, edge, and vertex normals.
+
+    Operations:
+    - query: report face normals and per-vertex normals for resolved components
+    - soften_edges: set selected edges or the object to 180 degree soft edges
+    - harden_edges: set selected edges or the object to 0 degree hard edges
+    - set_edge_softness: set selected edges or the object to angle
+    - reverse_faces: reverse selected face normals
+    - conform_faces: conform selected face normals to a consistent direction
+    - set_to_face_normals: assign vertex normals from selected face normals
+    - set_vertex_normals: set selected vertex normals to normal [x, y, z]
+    - lock_normals: freeze selected vertex normals
+    - unlock_normals: unfreeze selected vertex normals
+    - average_normals: average selected vertex normals within distance
+
+    This provides Maya-style normal control for localized shading and highlight
+    cleanup without relying on object-wide smoothing shortcuts.
+    """
+    import math
+    import re
+    import maya.cmds as cmds
+    import maya.api.OpenMaya as om
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return int(value)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(item) for item in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(item) for item in values]
+
+    def _normal_vector(values):
+        vector = _validate_vector(values, 3, "normal")
+        if normalize_vector:
+            length = math.sqrt(sum(item * item for item in vector))
+            if length <= 1e-9:
+                raise ValueError("normal must not be a zero vector when normalize_vector is true.")
+            vector = [item / length for item in vector]
+        return vector
+
+    def _mesh_shape(node):
+        if not cmds.objExists(node):
+            raise ValueError(f"Object does not exist: {node}")
+        if cmds.objectType(node) == "mesh":
+            return node
+        shapes = cmds.listRelatives(node, shapes=True, fullPath=True) or []
+        mesh_shapes = []
+        for shape in shapes:
+            if cmds.objectType(shape) != "mesh":
+                continue
+            try:
+                if cmds.attributeQuery("intermediateObject", node=shape, exists=True) and cmds.getAttr(f"{shape}.intermediateObject"):
+                    continue
+            except Exception:
+                pass
+            mesh_shapes.append(shape)
+        if not mesh_shapes:
+            raise ValueError(f"{node} is not a polygon mesh transform or mesh shape.")
+        return mesh_shapes[0]
+
+    def _mesh_fn(shape):
+        selection = om.MSelectionList()
+        selection.add(shape)
+        return om.MFnMesh(selection.getDagPath(0))
+
+    def _prefix(shape):
+        parents = cmds.listRelatives(shape, parent=True, fullPath=False) or []
+        return parents[0] if parents else object_name
+
+    def _flatten(value):
+        if value is None:
+            return []
+        if isinstance(value, str):
+            value = [value]
+        if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+            raise ValueError("components must be a string, a list of strings, or None.")
+        return cmds.ls(value, flatten=True) or []
+
+    def _components_from_indices(kind):
+        if indices is None:
+            return []
+        if not isinstance(indices, list) or not all(isinstance(index, int) and not isinstance(index, bool) for index in indices):
+            raise ValueError("indices must be a list of integers.")
+        return [f"{prefix_name}.{kind}[{index}]" for index in indices]
+
+    def _selected_components():
+        if not use_selection:
+            return []
+        selected = cmds.ls(selection=True, flatten=True) or []
+        object_tokens = {object_name, prefix_name, shape_name}
+        return [item for item in selected if item.split(".", 1)[0] in object_tokens]
+
+    def _resolve_components(default_type=None, allow_object=False):
+        clean_type = (component_type or default_type or "").lower().strip()
+        kind_map = {"vertex": "vtx", "edge": "e", "face": "f", "uv": "map", "vertex_face": "vtxFace"}
+        if components is not None:
+            resolved = _flatten(components)
+        elif clean_type in kind_map and indices is not None:
+            resolved = _components_from_indices(kind_map[clean_type])
+        else:
+            resolved = _selected_components()
+        if not resolved and allow_object:
+            return [object_name]
+        if not resolved:
+            raise ValueError("No components resolved from components, indices, or current selection.")
+        return resolved
+
+    def _component_ids(items, kind):
+        pattern = re.compile(rf"\.{kind}\[(\d+)\]$")
+        ids = []
+        for item in cmds.ls(items, flatten=True) or []:
+            match = pattern.search(item)
+            if match:
+                ids.append(int(match.group(1)))
+        return sorted(set(ids))
+
+    def _to_vertices(items):
+        converted = cmds.polyListComponentConversion(items, toVertex=True) or []
+        return cmds.ls(converted, flatten=True) or []
+
+    def _to_edges(items):
+        converted = cmds.polyListComponentConversion(items, toEdge=True) or []
+        return cmds.ls(converted, flatten=True) or []
+
+    def _to_faces(items):
+        converted = cmds.polyListComponentConversion(items, toFace=True) or []
+        return cmds.ls(converted, flatten=True) or []
+
+    def _normal_triplets(values):
+        triplets = []
+        for index in range(0, len(values or []), 3):
+            if index + 2 < len(values):
+                triplets.append([float(values[index]), float(values[index + 1]), float(values[index + 2])])
+        return triplets
+
+    def _query_components(items):
+        faces = _to_faces(items)
+        vertices = _to_vertices(items)
+        face_records = []
+        for face_id in _component_ids(faces, "f")[:max_preview]:
+            vector = mesh_fn.getPolygonNormal(face_id, om.MSpace.kWorld)
+            face_records.append(
+                {
+                    "component": f"{prefix_name}.f[{face_id}]",
+                    "index": face_id,
+                    "normal": [float(vector.x), float(vector.y), float(vector.z)],
+                }
+            )
+
+        vertex_records = []
+        for vertex in vertices[:max_preview]:
+            vertex_id_match = re.search(r"\.vtx\[(\d+)\]$", vertex)
+            vertex_id = int(vertex_id_match.group(1)) if vertex_id_match else None
+            normals = _normal_triplets(cmds.polyNormalPerVertex(vertex, query=True, xyz=True) or [])
+            locked = cmds.polyNormalPerVertex(vertex, query=True, allLocked=True) or []
+            vertex_records.append(
+                {
+                    "component": vertex,
+                    "index": vertex_id,
+                    "normals": normals,
+                    "all_locked": bool(locked[0]) if locked else None,
+                }
+            )
+
+        return {
+            "faces": face_records,
+            "vertices": vertex_records,
+            "face_count": len(_component_ids(faces, "f")),
+            "vertex_count": len(_component_ids(vertices, "vtx")),
+        }
+
+    def _counts():
+        return {
+            "vertices": int(cmds.polyEvaluate(object_name, vertex=True)),
+            "edges": int(cmds.polyEvaluate(object_name, edge=True)),
+            "faces": int(cmds.polyEvaluate(object_name, face=True)),
+        }
+
+    if not object_name:
+        raise ValueError("object_name is required.")
+    operation = operation.lower().strip()
+    allowed = {
+        "query",
+        "soften_edges",
+        "harden_edges",
+        "set_edge_softness",
+        "reverse_faces",
+        "conform_faces",
+        "set_to_face_normals",
+        "set_vertex_normals",
+        "lock_normals",
+        "unlock_normals",
+        "average_normals",
+    }
+    if operation not in allowed:
+        raise ValueError(f"operation must be one of: {', '.join(sorted(allowed))}.")
+    max_preview = _validate_int(max_preview, "max_preview", 0)
+    shape_name = _mesh_shape(object_name)
+    prefix_name = _prefix(shape_name)
+    mesh_fn = _mesh_fn(shape_name)
+    before_counts = _counts()
+
+    if operation == "query":
+        resolved = _resolve_components(allow_object=True)
+        return {
+            "success": True,
+            "object_name": object_name,
+            "operation": operation,
+            "components_preview": resolved[:max_preview],
+            "counts": before_counts,
+            "query": _query_components(resolved),
+        }
+
+    if operation in {"soften_edges", "harden_edges", "set_edge_softness"}:
+        if operation == "soften_edges":
+            clean_angle = 180.0
+        elif operation == "harden_edges":
+            clean_angle = 0.0
+        else:
+            clean_angle = _validate_scalar(angle, "angle")
+        resolved = _resolve_components("edge", allow_object=True)
+        edge_targets = resolved if resolved == [object_name] else _to_edges(resolved)
+        result = cmds.polySoftEdge(edge_targets, angle=clean_angle, constructionHistory=construction_history)
+        return {
+            "success": True,
+            "object_name": object_name,
+            "operation": operation,
+            "angle": clean_angle,
+            "component_count": len(edge_targets),
+            "components_preview": edge_targets[:max_preview],
+            "node": result,
+            "counts_before": before_counts,
+            "counts_after": _counts(),
+        }
+
+    if operation in {"reverse_faces", "conform_faces"}:
+        resolved = _resolve_components("face", allow_object=True)
+        face_targets = resolved if resolved == [object_name] else _to_faces(resolved)
+        mode = 0 if operation == "reverse_faces" else 1
+        result = cmds.polyNormal(face_targets, normalMode=mode, constructionHistory=construction_history)
+        return {
+            "success": True,
+            "object_name": object_name,
+            "operation": operation,
+            "normal_mode": mode,
+            "component_count": len(face_targets),
+            "components_preview": face_targets[:max_preview],
+            "node": result,
+            "counts_before": before_counts,
+            "counts_after": _counts(),
+            "query_after": _query_components(face_targets),
+        }
+
+    if operation == "set_to_face_normals":
+        resolved = _resolve_components("face")
+        face_targets = _to_faces(resolved)
+        if not face_targets:
+            raise ValueError("set_to_face_normals requires face components.")
+        result = cmds.polySetToFaceNormal(face_targets, setUserNormal=True)
+        return {
+            "success": True,
+            "object_name": object_name,
+            "operation": operation,
+            "component_count": len(face_targets),
+            "components_preview": face_targets[:max_preview],
+            "node": result,
+            "counts_before": before_counts,
+            "counts_after": _counts(),
+            "query_after": _query_components(face_targets),
+        }
+
+    if operation in {"set_vertex_normals", "lock_normals", "unlock_normals", "average_normals"}:
+        resolved = _resolve_components("vertex")
+        vertex_targets = _to_vertices(resolved)
+        if not vertex_targets:
+            raise ValueError(f"{operation} requires vertex, edge, or face components that resolve to vertices.")
+
+        if operation == "set_vertex_normals":
+            clean_normal = _normal_vector(normal)
+            result = cmds.polyNormalPerVertex(vertex_targets, xyz=clean_normal)
+            applied = {"normal": clean_normal, "normalize_vector": bool(normalize_vector)}
+        elif operation == "lock_normals":
+            result = cmds.polyNormalPerVertex(vertex_targets, freezeNormal=True)
+            applied = {"freezeNormal": True}
+        elif operation == "unlock_normals":
+            result = cmds.polyNormalPerVertex(vertex_targets, unFreezeNormal=True)
+            applied = {"unFreezeNormal": True}
+        else:
+            clean_distance = _validate_scalar(distance, "distance")
+            result = cmds.polyAverageNormal(
+                vertex_targets,
+                distance=clean_distance,
+                prenormalize=True,
+                postnormalize=True,
+                allowZeroNormal=False,
+            )
+            applied = {"distance": clean_distance, "prenormalize": True, "postnormalize": True}
+
+        return {
+            "success": True,
+            "object_name": object_name,
+            "operation": operation,
+            "component_count": len(vertex_targets),
+            "components_preview": vertex_targets[:max_preview],
+            "node": result,
+            "applied": applied,
+            "counts_before": before_counts,
+            "counts_after": _counts(),
+            "query_after": _query_components(vertex_targets),
+        }
+
+    raise ValueError(f"Unsupported operation: {operation}")

--- a/src/mayatools/object/edit_mesh_parts.py
+++ b/src/mayatools/object/edit_mesh_parts.py
@@ -1,0 +1,268 @@
+from typing import Dict, List, Any, Union
+
+
+def edit_mesh_parts(
+    object_name: str,
+    operation: str,
+    target_objects: List[str] = None,
+    component_type: str = None,
+    indices: List[int] = None,
+    components: Union[str, List[str]] = None,
+    parameters: Dict[str, Any] = None,
+    use_selection: bool = True,
+    max_preview: int = 50,
+) -> Dict[str, Any]:
+    """Extract, separate, and combine polygon mesh parts.
+
+    Operations:
+    - extract_faces: duplicate selected faces into a separate mesh, optionally
+      deleting them from the source
+    - separate_shells: separate disconnected mesh shells into separate objects
+    - combine_meshes: combine multiple mesh transforms into one mesh, optionally
+      merging coincident vertices
+
+    This covers common Maya artist workflows where local modeled areas become
+    separate editable objects, disconnected shells are split apart, or separate
+    pieces are merged back into a single polygon mesh.
+    """
+    import re
+    import maya.cmds as cmds
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return int(value)
+
+    def _mesh_shape(node):
+        if not cmds.objExists(node):
+            raise ValueError(f"Object does not exist: {node}")
+        if cmds.objectType(node) == "mesh":
+            return node
+        shapes = cmds.listRelatives(node, shapes=True, fullPath=True) or []
+        mesh_shapes = []
+        for shape in shapes:
+            if cmds.objectType(shape) != "mesh":
+                continue
+            try:
+                if cmds.attributeQuery("intermediateObject", node=shape, exists=True) and cmds.getAttr(f"{shape}.intermediateObject"):
+                    continue
+            except Exception:
+                pass
+            mesh_shapes.append(shape)
+        if not mesh_shapes:
+            raise ValueError(f"{node} is not a polygon mesh transform or mesh shape.")
+        return mesh_shapes[0]
+
+    def _prefix(shape):
+        parents = cmds.listRelatives(shape, parent=True, fullPath=False) or []
+        return parents[0] if parents else object_name
+
+    def _flatten(value):
+        if value is None:
+            return []
+        if isinstance(value, str):
+            value = [value]
+        if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+            raise ValueError("components must be a string, a list of strings, or None.")
+        return cmds.ls(value, flatten=True) or []
+
+    def _unique(items):
+        result = []
+        seen = set()
+        for item in cmds.ls(items, flatten=True) or []:
+            if item not in seen:
+                seen.add(item)
+                result.append(item)
+        return result
+
+    def _selected_components():
+        if not use_selection:
+            return []
+        selected = cmds.ls(selection=True, flatten=True) or []
+        object_tokens = {object_name, prefix_name, shape_name}
+        return [item for item in selected if item.split(".", 1)[0] in object_tokens]
+
+    def _components_from_indices(kind):
+        if indices is None:
+            return []
+        if not isinstance(indices, list) or not all(isinstance(index, int) and not isinstance(index, bool) for index in indices):
+            raise ValueError("indices must be a list of integers.")
+        return [f"{prefix_name}.{kind}[{index}]" for index in indices]
+
+    def _resolve_components(default_type=None):
+        clean_type = (component_type or default_type or "").lower().strip()
+        kind_map = {"vertex": "vtx", "edge": "e", "face": "f", "uv": "map", "vertex_face": "vtxFace"}
+        if components is not None:
+            resolved = _flatten(components)
+        elif clean_type in kind_map and indices is not None:
+            resolved = _components_from_indices(kind_map[clean_type])
+        else:
+            resolved = _selected_components()
+        if not resolved:
+            raise ValueError("No components resolved from components, indices, or current selection.")
+        return resolved
+
+    def _component_ids(items, kind):
+        pattern = re.compile(rf"\.{kind}\[(\d+)\]$")
+        ids = []
+        for item in cmds.ls(items, flatten=True) or []:
+            match = pattern.search(item)
+            if match:
+                ids.append(int(match.group(1)))
+        return sorted(set(ids))
+
+    def _face_ids_from_components():
+        resolved = _resolve_components("face")
+        faces = cmds.polyListComponentConversion(resolved, toFace=True) or []
+        face_ids = _component_ids(faces, "f")
+        if not face_ids:
+            raise ValueError("extract_faces requires faces or components convertible to faces.")
+        return face_ids
+
+    def _counts(node):
+        if not cmds.objExists(node):
+            return None
+        return {
+            "vertices": int(cmds.polyEvaluate(node, vertex=True)),
+            "edges": int(cmds.polyEvaluate(node, edge=True)),
+            "faces": int(cmds.polyEvaluate(node, face=True)),
+        }
+
+    def _mesh_transforms(nodes):
+        result = []
+        for node in nodes or []:
+            if not cmds.objExists(node) or cmds.objectType(node) != "transform":
+                continue
+            shapes = cmds.listRelatives(node, shapes=True, fullPath=False) or []
+            if any(cmds.objectType(shape) == "mesh" for shape in shapes):
+                result.append(node)
+        return list(dict.fromkeys(result))
+
+    def _validate_targets(values):
+        if values is None:
+            values = []
+        if isinstance(values, str):
+            values = [values]
+        if not isinstance(values, list) or not all(isinstance(item, str) for item in values):
+            raise ValueError("target_objects must be a list of object names.")
+        for item in values:
+            _mesh_shape(item)
+        return values
+
+    def _delete_history_if_requested(node):
+        if bool(parameters.get("delete_history", True)) and cmds.objExists(node):
+            cmds.delete(node, constructionHistory=True)
+
+    if not object_name:
+        raise ValueError("object_name is required.")
+    if not operation:
+        raise ValueError("operation is required.")
+    operation = operation.lower().strip()
+    if operation not in {"extract_faces", "separate_shells", "combine_meshes"}:
+        raise ValueError("operation must be extract_faces, separate_shells, or combine_meshes.")
+    parameters = parameters or {}
+    max_preview = _validate_int(max_preview, "max_preview", 1)
+    shape_name = _mesh_shape(object_name)
+    prefix_name = _prefix(shape_name)
+    before_counts = _counts(prefix_name)
+
+    if operation == "extract_faces":
+        face_ids = _face_ids_from_components()
+        total_faces = int(cmds.polyEvaluate(prefix_name, face=True))
+        if any(face_id < 0 or face_id >= total_faces for face_id in face_ids):
+            raise ValueError(f"Face indices must be in range 0..{total_faces - 1}.")
+        selected_set = set(face_ids)
+        inverse_face_ids = [face_id for face_id in range(total_faces) if face_id not in selected_set]
+        result_name = parameters.get("name") or f"{prefix_name}_extracted"
+        extracted = cmds.duplicate(prefix_name, name=result_name, renameChildren=True)[0]
+        if inverse_face_ids:
+            cmds.delete([f"{extracted}.f[{face_id}]" for face_id in inverse_face_ids])
+        _delete_history_if_requested(extracted)
+        remove_from_source = bool(parameters.get("remove_from_source", False))
+        if remove_from_source:
+            cmds.delete([f"{prefix_name}.f[{face_id}]" for face_id in face_ids])
+            _delete_history_if_requested(prefix_name)
+        if bool(parameters.get("select_result", True)):
+            cmds.select(extracted, replace=True)
+        return {
+            "success": True,
+            "object_name": object_name,
+            "operation": operation,
+            "source_object": prefix_name,
+            "created_object": extracted,
+            "selected_face_count": len(face_ids),
+            "selected_faces_preview": face_ids[:max_preview],
+            "remove_from_source": remove_from_source,
+            "source_counts_before": before_counts,
+            "source_counts_after": _counts(prefix_name),
+            "created_counts": _counts(extracted),
+        }
+
+    if operation == "separate_shells":
+        result_name = parameters.get("name") or f"{prefix_name}_part"
+        construction_history = bool(parameters.get("construction_history", False))
+        separated = cmds.polySeparate(
+            prefix_name,
+            name=result_name,
+            constructionHistory=construction_history,
+        )
+        objects = _mesh_transforms(separated)
+        if len(objects) < 2:
+            raise RuntimeError("separate_shells did not create multiple mesh objects.")
+        for obj in objects:
+            _delete_history_if_requested(obj)
+        if bool(parameters.get("select_result", True)):
+            cmds.select(objects, replace=True)
+        return {
+            "success": True,
+            "object_name": object_name,
+            "operation": operation,
+            "source_counts_before": before_counts,
+            "created_objects": objects,
+            "created_object_count": len(objects),
+            "created_counts": {obj: _counts(obj) for obj in objects},
+        }
+
+    targets = _validate_targets(target_objects)
+    if not targets:
+        raise ValueError("combine_meshes requires target_objects.")
+    objects_to_combine = [prefix_name] + targets
+    result_name = parameters.get("name") or f"{prefix_name}_combined"
+    construction_history = bool(parameters.get("construction_history", False))
+    merge_uv_sets = _validate_int(parameters.get("merge_uv_sets", 1), "merge_uv_sets", 0)
+    combined = cmds.polyUnite(
+        objects_to_combine,
+        name=result_name,
+        constructionHistory=construction_history,
+        mergeUVSets=merge_uv_sets,
+    )[0]
+    if bool(parameters.get("merge_vertices", False)):
+        distance = _validate_scalar(parameters.get("merge_distance", 0.001), "merge_distance")
+        cmds.polyMergeVertex(
+            combined,
+            distance=distance,
+            texture=bool(parameters.get("merge_texture", True)),
+            constructionHistory=construction_history,
+        )
+    _delete_history_if_requested(combined)
+    if bool(parameters.get("center_pivot", False)):
+        cmds.xform(combined, centerPivots=True)
+    if bool(parameters.get("select_result", True)):
+        cmds.select(combined, replace=True)
+    return {
+        "success": True,
+        "object_name": object_name,
+        "operation": operation,
+        "input_objects": objects_to_combine,
+        "combined_object": combined,
+        "combined_counts": _counts(combined),
+        "merge_vertices": bool(parameters.get("merge_vertices", False)),
+    }

--- a/src/mayatools/object/edit_mesh_topology.py
+++ b/src/mayatools/object/edit_mesh_topology.py
@@ -22,6 +22,8 @@ def edit_mesh_topology(
     - poke_faces: poke selected faces into triangles
     - chip_off_faces: detach or duplicate selected faces with optional transform
     - bridge_edges: bridge selected edge loops or edge groups
+    - connect_edges: connect selected edges across adjacent faces
+    - insert_edge_loop: insert a support loop from seed edges by connecting the edge ring
     - subdivide_faces: subdivide selected faces
     - triangulate_faces: triangulate selected faces
     - quadrangulate_faces: convert selected triangles to quads where possible
@@ -129,6 +131,28 @@ def edit_mesh_topology(
                 ids.append(int(match.group(1)))
         return sorted(set(ids))
 
+    def _unique(items):
+        seen = set()
+        result = []
+        for item in cmds.ls(items, flatten=True) or []:
+            if item in seen:
+                continue
+            seen.add(item)
+            result.append(item)
+        return result
+
+    def _poly_select_edges(flag_name, edge_ids):
+        results = []
+        for edge_id in edge_ids:
+            output = cmds.polySelect(
+                object_name,
+                asSelectString=True,
+                noSelection=True,
+                **{flag_name: int(edge_id)},
+            ) or []
+            results.extend(output)
+        return _unique(results)
+
     def _counts():
         return {
             "vertices": int(cmds.polyEvaluate(object_name, vertex=True)),
@@ -169,6 +193,8 @@ def edit_mesh_topology(
         "poke_faces",
         "chip_off_faces",
         "bridge_edges",
+        "connect_edges",
+        "insert_edge_loop",
         "subdivide_faces",
         "triangulate_faces",
         "quadrangulate_faces",
@@ -222,6 +248,75 @@ def edit_mesh_topology(
             localScale=local_scale,
         )
         return _selection_result(node, edges, before_counts)
+
+    if operation in {"connect_edges", "insert_edge_loop"}:
+        edges = _convert(_resolve_components("edge"), "edge")
+        edge_ids = _component_ids(edges, "e")
+        if not edge_ids:
+            raise ValueError(f"{operation} requires edge components.")
+
+        if operation == "insert_edge_loop":
+            expanded = _poly_select_edges("edgeRing", edge_ids)
+            if expanded:
+                edges = expanded
+                edge_ids = _component_ids(edges, "e")
+        else:
+            expand = str(parameters.get("expand", "none")).lower().strip()
+            expand_flags = {
+                "none": None,
+                "edge_ring": "edgeRing",
+                "edge_loop": "edgeLoop",
+                "edge_loop_or_border": "edgeLoopOrBorder",
+                "edge_border": "edgeBorder",
+            }
+            if expand not in expand_flags:
+                raise ValueError("parameters.expand must be none, edge_ring, edge_loop, edge_loop_or_border, or edge_border.")
+            if expand_flags[expand]:
+                expanded = _poly_select_edges(expand_flags[expand], edge_ids)
+                if expanded:
+                    edges = expanded
+                    edge_ids = _component_ids(edges, "e")
+
+        if len(edge_ids) < 2:
+            raise ValueError(f"{operation} requires at least two resolved edges after expansion.")
+
+        insert_with_edge_flow = bool(parameters.get("insert_with_edge_flow", False))
+        adjust_edge_flow = _validate_scalar(parameters.get("adjust_edge_flow", 0.0), "adjust_edge_flow")
+        old_selection = cmds.ls(selection=True, flatten=True) or []
+        cmds.select(edges, replace=True)
+        try:
+            node = cmds.polyConnectComponents(
+                constructionHistory=construction_history,
+                insertWithEdgeFlow=insert_with_edge_flow,
+                adjustEdgeFlow=adjust_edge_flow,
+            )
+        finally:
+            if bool(parameters.get("restore_selection", False)):
+                if old_selection:
+                    cmds.select(old_selection, replace=True)
+                else:
+                    cmds.select(clear=True)
+
+        after_counts = _counts()
+        if not _changed(before_counts, after_counts):
+            raise RuntimeError(f"{operation} did not change mesh topology. Try a different seed edge or selected edge set.")
+        return {
+            "success": True,
+            "object_name": object_name,
+            "operation": operation,
+            "node": node,
+            "input_component_count": len(edges),
+            "input_components_preview": edges[:max_preview],
+            "edge_ids": edge_ids[:max_preview],
+            "edge_id_count": len(edge_ids),
+            "insert_with_edge_flow": insert_with_edge_flow,
+            "adjust_edge_flow": adjust_edge_flow,
+            "counts_before": before_counts,
+            "counts_after": after_counts,
+            "new_edge_count_delta": after_counts["edges"] - before_counts["edges"],
+            "new_face_count_delta": after_counts["faces"] - before_counts["faces"],
+            "new_vertex_count_delta": after_counts["vertices"] - before_counts["vertices"],
+        }
 
     if operation in {"bevel_edges", "bevel_vertices"}:
         target_type = "edge" if operation == "bevel_edges" else "vertex"

--- a/src/mayatools/object/edit_mesh_topology.py
+++ b/src/mayatools/object/edit_mesh_topology.py
@@ -1,0 +1,324 @@
+from typing import Dict, List, Any, Union
+
+
+def edit_mesh_topology(
+    object_name: str,
+    operation: str,
+    component_type: str = None,
+    indices: List[int] = None,
+    components: Union[str, List[str]] = None,
+    parameters: Dict[str, Any] = None,
+    use_selection: bool = True,
+    max_preview: int = 50,
+) -> Dict[str, Any]:
+    """Run component-level polygon topology edits.
+
+    Operations:
+    - extrude_faces: extrude selected faces with distance, offset, divisions
+    - extrude_edges: extrude selected edges with distance, offset, divisions
+    - inset_faces: inset selected faces using offset or local scale
+    - bevel_edges: bevel selected edges
+    - bevel_vertices: bevel selected vertices
+    - poke_faces: poke selected faces into triangles
+    - chip_off_faces: detach or duplicate selected faces with optional transform
+    - bridge_edges: bridge selected edge loops or edge groups
+    - subdivide_faces: subdivide selected faces
+    - triangulate_faces: triangulate selected faces
+    - quadrangulate_faces: convert selected triangles to quads where possible
+
+    This tool is for Maya-style component topology work. It resolves explicit
+    components, indexed components, or the current selection, runs the topology
+    operation, and reports before/after mesh counts so no-op topology edits are
+    visible.
+    """
+    import re
+    import maya.cmds as cmds
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return int(value)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(item) for item in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(item) for item in values]
+
+    def _mesh_shape(node):
+        if not cmds.objExists(node):
+            raise ValueError(f"Object does not exist: {node}")
+        if cmds.objectType(node) == "mesh":
+            return node
+        shapes = cmds.listRelatives(node, shapes=True, fullPath=True) or []
+        mesh_shapes = []
+        for shape in shapes:
+            if cmds.objectType(shape) != "mesh":
+                continue
+            try:
+                if cmds.attributeQuery("intermediateObject", node=shape, exists=True) and cmds.getAttr(f"{shape}.intermediateObject"):
+                    continue
+            except Exception:
+                pass
+            mesh_shapes.append(shape)
+        if not mesh_shapes:
+            raise ValueError(f"{node} is not a polygon mesh transform or mesh shape.")
+        return mesh_shapes[0]
+
+    def _prefix(shape):
+        parents = cmds.listRelatives(shape, parent=True, fullPath=False) or []
+        return parents[0] if parents else object_name
+
+    def _flatten(value):
+        if value is None:
+            return []
+        if isinstance(value, str):
+            value = [value]
+        if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+            raise ValueError("components must be a string, a list of strings, or None.")
+        return cmds.ls(value, flatten=True) or []
+
+    def _selected_components():
+        if not use_selection:
+            return []
+        selected = cmds.ls(selection=True, flatten=True) or []
+        object_tokens = {object_name, prefix_name, shape_name}
+        return [item for item in selected if item.split(".", 1)[0] in object_tokens]
+
+    def _components_from_indices(kind):
+        if indices is None:
+            return []
+        if not isinstance(indices, list) or not all(isinstance(index, int) and not isinstance(index, bool) for index in indices):
+            raise ValueError("indices must be a list of integers.")
+        return [f"{prefix_name}.{kind}[{index}]" for index in indices]
+
+    def _resolve_components(default_type=None):
+        clean_type = (component_type or default_type or "").lower().strip()
+        kind_map = {"vertex": "vtx", "edge": "e", "face": "f", "uv": "map", "vertex_face": "vtxFace"}
+        if components is not None:
+            resolved = _flatten(components)
+        elif clean_type in kind_map and indices is not None:
+            resolved = _components_from_indices(kind_map[clean_type])
+        else:
+            resolved = _selected_components()
+        if not resolved:
+            raise ValueError("No components resolved from components, indices, or current selection.")
+        return resolved
+
+    def _convert(items, target):
+        flags = {
+            "vertex": {"toVertex": True},
+            "edge": {"toEdge": True},
+            "face": {"toFace": True},
+        }[target]
+        return cmds.ls(cmds.polyListComponentConversion(items, **flags) or [], flatten=True) or []
+
+    def _component_ids(items, kind):
+        pattern = re.compile(rf"\.{kind}\[(\d+)\]$")
+        ids = []
+        for item in cmds.ls(items, flatten=True) or []:
+            match = pattern.search(item)
+            if match:
+                ids.append(int(match.group(1)))
+        return sorted(set(ids))
+
+    def _counts():
+        return {
+            "vertices": int(cmds.polyEvaluate(object_name, vertex=True)),
+            "edges": int(cmds.polyEvaluate(object_name, edge=True)),
+            "faces": int(cmds.polyEvaluate(object_name, face=True)),
+        }
+
+    def _changed(before, after):
+        return any(before[key] != after[key] for key in before)
+
+    def _selection_result(node_result, resolved, before):
+        after = _counts()
+        if not _changed(before, after):
+            raise RuntimeError(f"{operation} did not change mesh topology.")
+        current_selection = cmds.ls(selection=True, flatten=True) or []
+        return {
+            "success": True,
+            "object_name": object_name,
+            "operation": operation,
+            "node": node_result,
+            "input_component_count": len(resolved),
+            "input_components_preview": resolved[:max_preview],
+            "selected_after_count": len(current_selection),
+            "selected_after_preview": current_selection[:max_preview],
+            "counts_before": before,
+            "counts_after": after,
+        }
+
+    if not object_name:
+        raise ValueError("object_name is required.")
+    operation = operation.lower().strip()
+    allowed = {
+        "extrude_faces",
+        "extrude_edges",
+        "inset_faces",
+        "bevel_edges",
+        "bevel_vertices",
+        "poke_faces",
+        "chip_off_faces",
+        "bridge_edges",
+        "subdivide_faces",
+        "triangulate_faces",
+        "quadrangulate_faces",
+    }
+    if operation not in allowed:
+        raise ValueError(f"operation must be one of: {', '.join(sorted(allowed))}.")
+    parameters = parameters or {}
+    max_preview = _validate_int(max_preview, "max_preview", 1)
+    shape_name = _mesh_shape(object_name)
+    prefix_name = _prefix(shape_name)
+    before_counts = _counts()
+
+    construction_history = bool(parameters.get("construction_history", False))
+
+    if operation in {"extrude_faces", "inset_faces"}:
+        faces = _convert(_resolve_components("face"), "face")
+        if not faces:
+            raise ValueError(f"{operation} requires face components.")
+        divisions = _validate_int(parameters.get("divisions", 1), "divisions", 1)
+        keep_faces_together = bool(parameters.get("keep_faces_together", True))
+        local_translate = _validate_vector(parameters.get("local_translate", [0.0, 0.0, float(parameters.get("distance", 0.0))]), 3, "local_translate")
+        offset = _validate_scalar(parameters.get("offset", 0.0), "offset")
+        local_scale = _validate_vector(parameters.get("local_scale", [1.0, 1.0, 1.0]), 3, "local_scale")
+        if operation == "inset_faces" and abs(offset) <= 1e-12 and local_scale == [1.0, 1.0, 1.0]:
+            raise ValueError("inset_faces requires parameters.offset or a non-identity local_scale.")
+        node = cmds.polyExtrudeFacet(
+            faces,
+            constructionHistory=construction_history,
+            divisions=divisions,
+            keepFacesTogether=keep_faces_together,
+            localTranslate=local_translate,
+            offset=offset,
+            localScale=local_scale,
+        )
+        return _selection_result(node, faces, before_counts)
+
+    if operation == "extrude_edges":
+        edges = _convert(_resolve_components("edge"), "edge")
+        if not edges:
+            raise ValueError("extrude_edges requires edge components.")
+        divisions = _validate_int(parameters.get("divisions", 1), "divisions", 1)
+        local_translate = _validate_vector(parameters.get("local_translate", [0.0, float(parameters.get("distance", 0.0)), 0.0]), 3, "local_translate")
+        offset = _validate_scalar(parameters.get("offset", 0.0), "offset")
+        local_scale = _validate_vector(parameters.get("local_scale", [1.0, 1.0, 1.0]), 3, "local_scale")
+        node = cmds.polyExtrudeEdge(
+            edges,
+            constructionHistory=construction_history,
+            divisions=divisions,
+            localTranslate=local_translate,
+            offset=offset,
+            localScale=local_scale,
+        )
+        return _selection_result(node, edges, before_counts)
+
+    if operation in {"bevel_edges", "bevel_vertices"}:
+        target_type = "edge" if operation == "bevel_edges" else "vertex"
+        resolved = _convert(_resolve_components(target_type), target_type)
+        if not resolved:
+            raise ValueError(f"{operation} requires {target_type} components.")
+        fraction = _validate_scalar(parameters.get("fraction", parameters.get("width", 0.1)), "fraction")
+        segments = _validate_int(parameters.get("segments", 1), "segments", 1)
+        merge_vertices = bool(parameters.get("merge_vertices", True))
+        node = cmds.polyBevel3(
+            resolved,
+            constructionHistory=construction_history,
+            fraction=fraction,
+            segments=segments,
+            mergeVertices=merge_vertices,
+        )
+        return _selection_result(node, resolved, before_counts)
+
+    if operation == "poke_faces":
+        faces = _convert(_resolve_components("face"), "face")
+        if not faces:
+            raise ValueError("poke_faces requires face components.")
+        local_translate = _validate_vector(parameters.get("local_translate", [0.0, 0.0, float(parameters.get("distance", 0.0))]), 3, "local_translate")
+        node = cmds.polyPoke(
+            faces,
+            constructionHistory=construction_history,
+            localTranslate=local_translate,
+        )
+        return _selection_result(node, faces, before_counts)
+
+    if operation == "chip_off_faces":
+        faces = _convert(_resolve_components("face"), "face")
+        if not faces:
+            raise ValueError("chip_off_faces requires face components.")
+        duplicate = bool(parameters.get("duplicate", False))
+        keep_faces_together = bool(parameters.get("keep_faces_together", True))
+        local_translate = _validate_vector(parameters.get("local_translate", [0.0, 0.0, float(parameters.get("distance", 0.0))]), 3, "local_translate")
+        node = cmds.polyChipOff(
+            faces,
+            constructionHistory=construction_history,
+            duplicate=duplicate,
+            keepFacesTogether=keep_faces_together,
+            localTranslate=local_translate,
+        )
+        return _selection_result(node, faces, before_counts)
+
+    if operation == "bridge_edges":
+        edges = _convert(_resolve_components("edge"), "edge")
+        if len(edges) < 2:
+            raise ValueError("bridge_edges requires at least two edge components.")
+        divisions = _validate_int(parameters.get("divisions", 1), "divisions", 0)
+        twist = _validate_scalar(parameters.get("twist", 0.0), "twist")
+        bridge_offset = _validate_int(parameters.get("bridge_offset", 0), "bridge_offset", 0)
+        node = cmds.polyBridgeEdge(
+            edges,
+            constructionHistory=construction_history,
+            divisions=divisions,
+            twist=twist,
+            bridgeOffset=bridge_offset,
+        )
+        return _selection_result(node, edges, before_counts)
+
+    if operation == "subdivide_faces":
+        faces = _convert(_resolve_components("face"), "face")
+        if not faces:
+            raise ValueError("subdivide_faces requires face components.")
+        divisions = _validate_int(parameters.get("divisions", 1), "divisions", 1)
+        mode = _validate_int(parameters.get("mode", 0), "mode", 0)
+        node = cmds.polySubdivideFacet(
+            faces,
+            constructionHistory=construction_history,
+            divisions=divisions,
+            mode=mode,
+        )
+        return _selection_result(node, faces, before_counts)
+
+    if operation == "triangulate_faces":
+        faces = _convert(_resolve_components("face"), "face")
+        if not faces:
+            raise ValueError("triangulate_faces requires face components.")
+        node = cmds.polyTriangulate(faces, constructionHistory=construction_history)
+        return _selection_result(node, faces, before_counts)
+
+    if operation == "quadrangulate_faces":
+        faces = _convert(_resolve_components("face"), "face")
+        if not faces:
+            raise ValueError("quadrangulate_faces requires face components.")
+        angle = _validate_scalar(parameters.get("angle", 30.0), "angle")
+        keep_hard_edges = bool(parameters.get("keep_hard_edges", False))
+        keep_texture_borders = bool(parameters.get("keep_texture_borders", True))
+        node = cmds.polyQuad(
+            faces,
+            constructionHistory=construction_history,
+            angle=angle,
+            keepHardEdges=keep_hard_edges,
+            keepTextureBorders=keep_texture_borders,
+        )
+        return _selection_result(node, faces, before_counts)
+
+    raise ValueError(f"Unsupported operation: {operation}")

--- a/src/mayatools/object/edit_mesh_weld.py
+++ b/src/mayatools/object/edit_mesh_weld.py
@@ -1,0 +1,323 @@
+from typing import Dict, List, Any, Union
+
+
+def edit_mesh_weld(
+    object_name: str,
+    operation: str,
+    component_type: str = None,
+    indices: List[int] = None,
+    components: Union[str, List[str]] = None,
+    parameters: Dict[str, Any] = None,
+    use_selection: bool = True,
+    max_preview: int = 50,
+) -> Dict[str, Any]:
+    """Weld, merge, sew, or collapse polygon mesh components.
+
+    Operations:
+    - merge_vertices: merge selected vertices within distance
+    - merge_vertices_to_target: merge selected vertices to one target vertex
+    - collapse_edges: collapse selected edges
+    - collapse_faces: collapse selected faces
+    - sew_edges: sew selected border edges within tolerance
+    - merge_edge_pair: merge exactly two selected edge components
+    - merge_face_pair: merge exactly two adjacent face components
+
+    This covers explicit Maya-style weld/collapse workflows with before/after
+    topology counts and no-op detection.
+    """
+    import re
+    import maya.cmds as cmds
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return int(value)
+
+    def _mesh_shape(node):
+        if not cmds.objExists(node):
+            raise ValueError(f"Object does not exist: {node}")
+        if cmds.objectType(node) == "mesh":
+            return node
+        shapes = cmds.listRelatives(node, shapes=True, fullPath=True) or []
+        mesh_shapes = []
+        for shape in shapes:
+            if cmds.objectType(shape) != "mesh":
+                continue
+            try:
+                if cmds.attributeQuery("intermediateObject", node=shape, exists=True) and cmds.getAttr(f"{shape}.intermediateObject"):
+                    continue
+            except Exception:
+                pass
+            mesh_shapes.append(shape)
+        if not mesh_shapes:
+            raise ValueError(f"{node} is not a polygon mesh transform or mesh shape.")
+        return mesh_shapes[0]
+
+    def _prefix(shape):
+        parents = cmds.listRelatives(shape, parent=True, fullPath=False) or []
+        return parents[0] if parents else object_name
+
+    def _flatten(value):
+        if value is None:
+            return []
+        if isinstance(value, str):
+            value = [value]
+        if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+            raise ValueError("components must be a string, a list of strings, or None.")
+        return cmds.ls(value, flatten=True) or []
+
+    def _selected_components():
+        if not use_selection:
+            return []
+        selected = cmds.ls(selection=True, flatten=True) or []
+        object_tokens = {object_name, prefix_name, shape_name}
+        return [item for item in selected if item.split(".", 1)[0] in object_tokens]
+
+    def _components_from_indices(kind):
+        if indices is None:
+            return []
+        if not isinstance(indices, list) or not all(isinstance(index, int) and not isinstance(index, bool) for index in indices):
+            raise ValueError("indices must be a list of integers.")
+        return [f"{prefix_name}.{kind}[{index}]" for index in indices]
+
+    def _resolve_components(default_type=None):
+        clean_type = (component_type or default_type or "").lower().strip()
+        kind_map = {"vertex": "vtx", "edge": "e", "face": "f", "uv": "map", "vertex_face": "vtxFace"}
+        if components is not None:
+            resolved = _flatten(components)
+        elif clean_type in kind_map and indices is not None:
+            resolved = _components_from_indices(kind_map[clean_type])
+        else:
+            resolved = _selected_components()
+        if not resolved:
+            raise ValueError("No components resolved from components, indices, or current selection.")
+        return resolved
+
+    def _convert(items, target):
+        flags = {
+            "vertex": {"toVertex": True},
+            "edge": {"toEdge": True},
+            "face": {"toFace": True},
+        }[target]
+        return cmds.ls(cmds.polyListComponentConversion(items, **flags) or [], flatten=True) or []
+
+    def _component_ids(items, kind):
+        pattern = re.compile(rf"\.{kind}\[(\d+)\]$")
+        ids = []
+        for item in cmds.ls(items, flatten=True) or []:
+            match = pattern.search(item)
+            if match:
+                ids.append(int(match.group(1)))
+        return list(dict.fromkeys(ids))
+
+    def _face_edge_ids(face_component):
+        edge_components = cmds.polyListComponentConversion(face_component, fromFace=True, toEdge=True) or []
+        return set(_component_ids(edge_components, "e"))
+
+    def _counts():
+        return {
+            "vertices": int(cmds.polyEvaluate(object_name, vertex=True)),
+            "edges": int(cmds.polyEvaluate(object_name, edge=True)),
+            "faces": int(cmds.polyEvaluate(object_name, face=True)),
+        }
+
+    def _changed(before, after):
+        return any(before[key] != after[key] for key in before)
+
+    def _result(node_result, resolved, before, extra=None):
+        after = _counts()
+        if not _changed(before, after):
+            raise RuntimeError(f"{operation} did not change mesh topology.")
+        current_selection = cmds.ls(selection=True, flatten=True) or []
+        payload = {
+            "success": True,
+            "object_name": object_name,
+            "operation": operation,
+            "node": node_result,
+            "input_component_count": len(resolved),
+            "input_components_preview": resolved[:max_preview],
+            "selected_after_count": len(current_selection),
+            "selected_after_preview": current_selection[:max_preview],
+            "counts_before": before,
+            "counts_after": after,
+        }
+        if extra:
+            payload.update(extra)
+        return payload
+
+    def _target_vertex_component(vertices):
+        target_component = parameters.get("target_component")
+        if target_component is not None:
+            flattened = _flatten(target_component)
+            converted = _convert(flattened, "vertex")
+            if len(converted) != 1:
+                raise ValueError("parameters.target_component must resolve to exactly one vertex.")
+            return converted[0]
+        target_index = parameters.get("target_index")
+        if target_index is not None:
+            clean_index = _validate_int(target_index, "target_index", 0)
+            return f"{prefix_name}.vtx[{clean_index}]"
+        return vertices[0]
+
+    if not object_name:
+        raise ValueError("object_name is required.")
+    if not operation:
+        raise ValueError("operation is required.")
+    operation = operation.lower().strip()
+    allowed = {
+        "merge_vertices",
+        "merge_vertices_to_target",
+        "collapse_edges",
+        "collapse_faces",
+        "sew_edges",
+        "merge_edge_pair",
+        "merge_face_pair",
+    }
+    if operation not in allowed:
+        raise ValueError(f"operation must be one of: {', '.join(sorted(allowed))}.")
+
+    parameters = parameters or {}
+    max_preview = _validate_int(max_preview, "max_preview", 1)
+    shape_name = _mesh_shape(object_name)
+    prefix_name = _prefix(shape_name)
+    before_counts = _counts()
+    construction_history = bool(parameters.get("construction_history", False))
+
+    if operation in {"merge_vertices", "merge_vertices_to_target"}:
+        vertices = _convert(_resolve_components("vertex"), "vertex")
+        if len(vertices) < 2:
+            raise ValueError(f"{operation} requires at least two vertices.")
+        distance = _validate_scalar(parameters.get("distance", 0.001), "distance")
+        texture = bool(parameters.get("texture", True))
+        world_space = bool(parameters.get("world_space", False))
+        if operation == "merge_vertices":
+            always_merge = bool(parameters.get("always_merge", False))
+            node = cmds.polyMergeVertex(
+                vertices,
+                distance=distance,
+                alwaysMergeTwoVertices=always_merge,
+                texture=texture,
+                worldSpace=world_space,
+                constructionHistory=construction_history,
+            )
+            return _result(
+                node,
+                vertices,
+                before_counts,
+                {"distance": distance, "always_merge": always_merge, "texture": texture, "world_space": world_space},
+            )
+
+        target_vertex = _target_vertex_component(vertices)
+        if target_vertex not in vertices:
+            vertices = [target_vertex] + vertices
+        node = cmds.polyMergeVertex(
+            vertices,
+            distance=max(distance, 1.0e-9),
+            alwaysMergeTwoVertices=True,
+            mergeToComponents=target_vertex,
+            texture=texture,
+            worldSpace=world_space,
+            constructionHistory=construction_history,
+        )
+        return _result(
+            node,
+            vertices,
+            before_counts,
+            {"distance": distance, "target_component": target_vertex, "texture": texture, "world_space": world_space},
+        )
+
+    if operation == "collapse_edges":
+        edges = _convert(_resolve_components("edge"), "edge")
+        if not edges:
+            raise ValueError("collapse_edges requires edge components.")
+        node = cmds.polyCollapseEdge(edges, constructionHistory=construction_history)
+        return _result(node, edges, before_counts)
+
+    if operation == "collapse_faces":
+        faces = _convert(_resolve_components("face"), "face")
+        if not faces:
+            raise ValueError("collapse_faces requires face components.")
+        use_area_threshold = bool(parameters.get("use_area_threshold", False))
+        area_threshold = _validate_scalar(parameters.get("area_threshold", 0.0), "area_threshold")
+        node = cmds.polyCollapseFacet(
+            faces,
+            constructionHistory=construction_history,
+            useAreaThreshold=use_area_threshold,
+            areaThreshold=area_threshold,
+        )
+        return _result(
+            node,
+            faces,
+            before_counts,
+            {"use_area_threshold": use_area_threshold, "area_threshold": area_threshold},
+        )
+
+    if operation == "sew_edges":
+        edges = _convert(_resolve_components("edge"), "edge")
+        if len(edges) < 2:
+            raise ValueError("sew_edges requires at least two edge components.")
+        tolerance = _validate_scalar(parameters.get("tolerance", 0.001), "tolerance")
+        texture = bool(parameters.get("texture", True))
+        world_space = bool(parameters.get("world_space", False))
+        node = cmds.polySewEdge(
+            edges,
+            tolerance=tolerance,
+            texture=texture,
+            worldSpace=world_space,
+            constructionHistory=construction_history,
+        )
+        return _result(node, edges, before_counts, {"tolerance": tolerance, "texture": texture, "world_space": world_space})
+
+    if operation == "merge_edge_pair":
+        edges = _convert(_resolve_components("edge"), "edge")
+        edge_ids = _component_ids(edges, "e")
+        if len(edge_ids) != 2:
+            raise ValueError("merge_edge_pair requires exactly two edge components.")
+        merge_mode = _validate_int(parameters.get("merge_mode", 0), "merge_mode", 0)
+        merge_texture = bool(parameters.get("merge_texture", True))
+        node = cmds.polyMergeEdge(
+            object_name,
+            firstEdge=edge_ids[0],
+            secondEdge=edge_ids[1],
+            mergeMode=merge_mode,
+            mergeTexture=merge_texture,
+            constructionHistory=construction_history,
+        )
+        return _result(
+            node,
+            edges,
+            before_counts,
+            {"edge_ids": edge_ids, "merge_mode": merge_mode, "merge_texture": merge_texture},
+        )
+
+    if operation == "merge_face_pair":
+        faces = _convert(_resolve_components("face"), "face")
+        face_ids = _component_ids(faces, "f")
+        if len(face_ids) != 2:
+            raise ValueError("merge_face_pair requires exactly two face components.")
+        face_components = [f"{prefix_name}.f[{face_id}]" for face_id in face_ids]
+        shared_edge_ids = sorted(_face_edge_ids(face_components[0]) & _face_edge_ids(face_components[1]))
+        if len(shared_edge_ids) != 1:
+            raise ValueError("merge_face_pair requires two adjacent faces with exactly one shared edge.")
+        clean_vertices = bool(parameters.get("clean_vertices", False))
+        node = cmds.polyDelEdge(
+            f"{prefix_name}.e[{shared_edge_ids[0]}]",
+            cleanVertices=clean_vertices,
+            constructionHistory=construction_history,
+        )
+        return _result(
+            node,
+            faces,
+            before_counts,
+            {"face_ids": face_ids, "shared_edge_id": shared_edge_ids[0], "clean_vertices": clean_vertices},
+        )
+
+    raise ValueError(f"Unsupported operation: {operation}")

--- a/src/mayatools/object/edit_uv_components.py
+++ b/src/mayatools/object/edit_uv_components.py
@@ -1,0 +1,228 @@
+from typing import Dict, List, Any, Union
+
+
+def edit_uv_components(
+    object_name: str,
+    operation: str,
+    uv_indices: List[int] = None,
+    components: Union[str, List[str]] = None,
+    values_by_uv: Dict[str, List[float]] = None,
+    offset: List[float] = None,
+    uv_set: str = None,
+    face_components: Union[str, List[str]] = None,
+    parameters: Dict[str, Any] = None,
+    use_selection: bool = True,
+    max_preview: int = 50,
+) -> Dict[str, Any]:
+    """Query and edit mesh UV components or project UVs onto selected faces.
+
+    Operations:
+    - query: report UV coordinates for explicit UVs or current UV selection
+    - set: set UV coordinates from values_by_uv keyed by UV index
+    - offset: add a UV offset to selected UVs
+    - planar_project_faces: run planar UV projection on explicit or selected faces
+
+    This provides component-level UV control for localized label, panel, and
+    patch work instead of remapping an entire object.
+    """
+    import re
+    import maya.cmds as cmds
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(value) for value in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(value) for value in values]
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return value
+
+    def _mesh_shape(node):
+        if not cmds.objExists(node):
+            raise ValueError(f"Object does not exist: {node}")
+        if cmds.objectType(node) == "mesh":
+            return node
+        shapes = cmds.listRelatives(node, shapes=True, fullPath=True) or []
+        mesh_shapes = []
+        for shape in shapes:
+            if cmds.objectType(shape) != "mesh":
+                continue
+            try:
+                if cmds.attributeQuery("intermediateObject", node=shape, exists=True) and cmds.getAttr(f"{shape}.intermediateObject"):
+                    continue
+            except Exception:
+                pass
+            mesh_shapes.append(shape)
+        if not mesh_shapes:
+            raise ValueError(f"{node} is not a polygon mesh transform or mesh shape.")
+        return mesh_shapes[0]
+
+    def _prefix(shape):
+        parents = cmds.listRelatives(shape, parent=True, fullPath=False) or []
+        return parents[0] if parents else object_name
+
+    def _flatten(value):
+        if value is None:
+            return []
+        if isinstance(value, str):
+            value = [value]
+        if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+            raise ValueError("component arguments must be strings, lists of strings, or None.")
+        return cmds.ls(value, flatten=True) or []
+
+    def _selected():
+        if not use_selection:
+            return []
+        selected = cmds.ls(selection=True, flatten=True) or []
+        object_tokens = {object_name, prefix, shape_name}
+        return [item for item in selected if item.split(".", 1)[0] in object_tokens]
+
+    def _uv_components():
+        if components is not None:
+            resolved = _flatten(components)
+        elif uv_indices is not None:
+            if not isinstance(uv_indices, list) or not all(isinstance(index, int) and not isinstance(index, bool) for index in uv_indices):
+                raise ValueError("uv_indices must be a list of integers.")
+            resolved = [f"{prefix}.map[{index}]" for index in uv_indices]
+        else:
+            resolved = cmds.polyListComponentConversion(_selected(), toUV=True) or []
+            resolved = cmds.ls(resolved, flatten=True) or []
+        resolved = [item for item in resolved if ".map[" in item]
+        if not resolved:
+            raise ValueError("No UV components resolved.")
+        return resolved
+
+    def _face_components():
+        if face_components is not None:
+            resolved = _flatten(face_components)
+        elif components is not None:
+            resolved = cmds.polyListComponentConversion(_flatten(components), toFace=True) or []
+            resolved = cmds.ls(resolved, flatten=True) or []
+        else:
+            resolved = cmds.polyListComponentConversion(_selected(), toFace=True) or []
+            resolved = cmds.ls(resolved, flatten=True) or []
+        resolved = [item for item in resolved if ".f[" in item]
+        if not resolved:
+            raise ValueError("No face components resolved.")
+        return resolved
+
+    def _uv_id(component):
+        match = re.search(r"\.map\[(\d+)\]$", component)
+        return int(match.group(1)) if match else None
+
+    def _query_uvs(items):
+        values = cmds.polyEditUV(items, query=True) or []
+        records = []
+        for index, component in enumerate(items):
+            offset_index = index * 2
+            uv_value = None
+            if offset_index + 1 < len(values):
+                uv_value = [float(values[offset_index]), float(values[offset_index + 1])]
+            records.append({"component": component, "index": _uv_id(component), "uv": uv_value})
+        return records
+
+    if not object_name:
+        raise ValueError("object_name is required.")
+    operation = operation.lower().strip()
+    parameters = parameters or {}
+    max_preview = _validate_int(max_preview, "max_preview", 0)
+    shape_name = _mesh_shape(object_name)
+    prefix = _prefix(shape_name)
+
+    all_uv_sets = cmds.polyUVSet(object_name, query=True, allUVSets=True) or []
+    previous_uv_set = (cmds.polyUVSet(object_name, query=True, currentUVSet=True) or [None])[0]
+    if uv_set:
+        if uv_set not in all_uv_sets:
+            raise ValueError(f"UV set {uv_set} does not exist on {object_name}.")
+        cmds.polyUVSet(object_name, currentUVSet=True, uvSet=uv_set)
+
+    try:
+        if operation == "query":
+            uv_items = _uv_components()
+            records = _query_uvs(uv_items)
+            return {
+                "success": True,
+                "object_name": object_name,
+                "operation": operation,
+                "uv_set": uv_set or previous_uv_set,
+                "uv_count": len(records),
+                "uvs": records[:max_preview],
+            }
+
+        if operation == "set":
+            uv_items = _uv_components()
+            if not isinstance(values_by_uv, dict) or not values_by_uv:
+                raise ValueError("operation=set requires values_by_uv keyed by UV index.")
+            before = _query_uvs(uv_items)
+            edited = []
+            for component in uv_items:
+                uv_id = _uv_id(component)
+                key = str(uv_id)
+                if key not in values_by_uv:
+                    continue
+                value = _validate_vector(values_by_uv[key], 2, f"values_by_uv[{key}]")
+                cmds.polyEditUV(component, relative=False, uValue=value[0], vValue=value[1])
+                edited.append(component)
+            after = _query_uvs(uv_items)
+            return {
+                "success": True,
+                "object_name": object_name,
+                "operation": operation,
+                "uv_set": uv_set or previous_uv_set,
+                "edited_count": len(edited),
+                "edited_components_preview": edited[:max_preview],
+                "before_preview": before[:max_preview],
+                "after_preview": after[:max_preview],
+            }
+
+        if operation == "offset":
+            uv_items = _uv_components()
+            clean_offset = _validate_vector(offset, 2, "offset")
+            before = _query_uvs(uv_items)
+            cmds.polyEditUV(uv_items, relative=True, uValue=clean_offset[0], vValue=clean_offset[1])
+            after = _query_uvs(uv_items)
+            return {
+                "success": True,
+                "object_name": object_name,
+                "operation": operation,
+                "uv_set": uv_set or previous_uv_set,
+                "edited_count": len(uv_items),
+                "offset": clean_offset,
+                "before_preview": before[:max_preview],
+                "after_preview": after[:max_preview],
+            }
+
+        if operation == "planar_project_faces":
+            faces = _face_components()
+            result = cmds.polyPlanarProjection(
+                faces,
+                mapDirection=parameters.get("map_direction", "y"),
+                projectionWidth=float(parameters.get("projection_width", 1.0)),
+                projectionHeight=float(parameters.get("projection_height", 1.0)),
+                imageCenter=parameters.get("image_center", [0.5, 0.5]),
+                imageScale=parameters.get("image_scale", [1.0, 1.0]),
+                rotate=parameters.get("rotate", [0.0, 0.0, 0.0]),
+                constructionHistory=bool(parameters.get("construction_history", True)),
+                worldSpace=bool(parameters.get("world_space", True)),
+            )
+            return {
+                "success": True,
+                "object_name": object_name,
+                "operation": operation,
+                "uv_set": uv_set or previous_uv_set,
+                "face_count": len(faces),
+                "faces_preview": faces[:max_preview],
+                "projection_node": result,
+            }
+
+        raise ValueError("Unknown operation. Use query, set, offset, or planar_project_faces.")
+    finally:
+        if uv_set and previous_uv_set and previous_uv_set in all_uv_sets and cmds.objExists(object_name):
+            try:
+                cmds.polyUVSet(object_name, currentUVSet=True, uvSet=previous_uv_set)
+            except Exception:
+                pass

--- a/src/mayatools/object/edit_uv_shells.py
+++ b/src/mayatools/object/edit_uv_shells.py
@@ -1,0 +1,399 @@
+from typing import Dict, List, Any, Union
+
+
+def edit_uv_shells(
+    object_name: str,
+    operation: str = "query",
+    shell_ids: List[int] = None,
+    components: Union[str, List[str]] = None,
+    target_box: List[float] = None,
+    target_boxes: Any = None,
+    grid_columns: int = 0,
+    padding: float = 0.02,
+    preserve_aspect: bool = True,
+    uv_set: str = None,
+    use_selection: bool = True,
+    max_preview: int = 50,
+) -> Dict[str, Any]:
+    """Query, select, and arrange UV shells deterministically.
+
+    Operations:
+    - query: report UV shell bounds, UV members, and related faces
+    - select: select UVs belonging to resolved shell ids
+    - fit_box: fit each resolved shell to target_box or per-shell target_boxes
+    - layout_grid: place resolved shells into a deterministic grid inside target_box
+
+    This is for UV-editor style organization where texture regions need clear
+    shell-level ownership and repeatable placement, such as labels, decals,
+    panels, and separate material regions.
+    """
+    import math
+    import maya.cmds as cmds
+    import maya.api.OpenMaya as om
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return int(value)
+
+    def _validate_box(value, arg_name):
+        box = value if value is not None else [0.0, 0.0, 1.0, 1.0]
+        if not isinstance(box, list) or len(box) != 4 or not all(_is_number(item) for item in box):
+            raise ValueError(f"{arg_name} must be [min_u, min_v, max_u, max_v].")
+        clean = [float(item) for item in box]
+        if clean[2] <= clean[0] or clean[3] <= clean[1]:
+            raise ValueError(f"{arg_name} must have positive width and height.")
+        return clean
+
+    def _mesh_shape(node):
+        if not cmds.objExists(node):
+            raise ValueError(f"Object does not exist: {node}")
+        if cmds.objectType(node) == "mesh":
+            return node
+        shapes = cmds.listRelatives(node, shapes=True, fullPath=True) or []
+        mesh_shapes = []
+        for shape in shapes:
+            if cmds.objectType(shape) != "mesh":
+                continue
+            try:
+                if cmds.attributeQuery("intermediateObject", node=shape, exists=True) and cmds.getAttr(f"{shape}.intermediateObject"):
+                    continue
+            except Exception:
+                pass
+            mesh_shapes.append(shape)
+        if not mesh_shapes:
+            raise ValueError(f"{node} is not a polygon mesh transform or mesh shape.")
+        return mesh_shapes[0]
+
+    def _mesh_fn(shape):
+        selection = om.MSelectionList()
+        selection.add(shape)
+        return om.MFnMesh(selection.getDagPath(0))
+
+    def _dag_path(shape):
+        selection = om.MSelectionList()
+        selection.add(shape)
+        return selection.getDagPath(0)
+
+    def _prefix(shape):
+        parents = cmds.listRelatives(shape, parent=True, fullPath=False) or []
+        return parents[0] if parents else object_name
+
+    def _flatten(value):
+        if value is None:
+            return []
+        if isinstance(value, str):
+            value = [value]
+        if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+            raise ValueError("components must be a string, a list of strings, or None.")
+        return cmds.ls(value, flatten=True) or []
+
+    def _unique(items):
+        seen = set()
+        result = []
+        for item in cmds.ls(items, flatten=True) or []:
+            if item in seen:
+                continue
+            seen.add(item)
+            result.append(item)
+        return result
+
+    def _selected_components():
+        if not use_selection:
+            return []
+        selected = cmds.ls(selection=True, flatten=True) or []
+        object_tokens = {object_name, prefix_name, shape_name}
+        return [item for item in selected if item.split(".", 1)[0] in object_tokens]
+
+    def _component(name, kind, index):
+        return f"{name}.{kind}[{index}]"
+
+    def _uv_component(uv_id):
+        return _component(prefix_name, "map", uv_id)
+
+    def _face_component(face_id):
+        return _component(prefix_name, "f", face_id)
+
+    def _convert_to_uvs(items):
+        converted = cmds.polyListComponentConversion(items, toUV=True) or []
+        return [item for item in _unique(converted) if ".map[" in item]
+
+    def _uv_id(component):
+        marker = ".map["
+        if marker not in component:
+            return None
+        try:
+            return int(component.rsplit(marker, 1)[1].rstrip("]"))
+        except Exception:
+            return None
+
+    def _uv_position(uv_id):
+        values = cmds.polyEditUV(_uv_component(uv_id), query=True) or [0.0, 0.0]
+        return [float(values[0]), float(values[1])]
+
+    def _set_uv_position(uv_id, position):
+        cmds.polyEditUV(_uv_component(uv_id), relative=False, uValue=float(position[0]), vValue=float(position[1]))
+
+    def _bounds(uv_ids):
+        positions = [_uv_position(uv_id) for uv_id in uv_ids]
+        if not positions:
+            return None
+        min_u = min(position[0] for position in positions)
+        min_v = min(position[1] for position in positions)
+        max_u = max(position[0] for position in positions)
+        max_v = max(position[1] for position in positions)
+        return {
+            "min": [min_u, min_v],
+            "max": [max_u, max_v],
+            "center": [(min_u + max_u) * 0.5, (min_v + max_v) * 0.5],
+            "size": [max_u - min_u, max_v - min_v],
+        }
+
+    def _face_shell_memberships(uv_shell_ids):
+        memberships = {}
+        mixed_faces = []
+        polygon_it = om.MItMeshPolygon(_dag_path(shape_name))
+        while not polygon_it.isDone():
+            face_id = int(polygon_it.index())
+            face_shell_ids = set()
+            for local_index in range(polygon_it.polygonVertexCount()):
+                try:
+                    uv_id = int(polygon_it.getUVIndex(local_index, active_uv_set))
+                except Exception:
+                    continue
+                if 0 <= uv_id < len(uv_shell_ids):
+                    face_shell_ids.add(int(uv_shell_ids[uv_id]))
+            if len(face_shell_ids) > 1:
+                mixed_faces.append(face_id)
+            for shell_id in face_shell_ids:
+                memberships.setdefault(shell_id, []).append(face_id)
+            polygon_it.next()
+        return memberships, mixed_faces
+
+    def _shell_data():
+        shell_count, shell_id_array = mesh_fn.getUvShellsIds(active_uv_set)
+        uv_shell_ids = [int(item) for item in shell_id_array]
+        shells = {index: {"id": index, "uv_ids": [], "face_ids": []} for index in range(int(shell_count))}
+        for uv_id, shell_id in enumerate(uv_shell_ids):
+            shells.setdefault(shell_id, {"id": shell_id, "uv_ids": [], "face_ids": []})
+            shells[shell_id]["uv_ids"].append(uv_id)
+        face_memberships, mixed_faces = _face_shell_memberships(uv_shell_ids)
+        for shell_id, face_ids in face_memberships.items():
+            shells.setdefault(shell_id, {"id": shell_id, "uv_ids": [], "face_ids": []})
+            shells[shell_id]["face_ids"] = sorted(set(face_ids))
+        return shells, mixed_faces
+
+    def _shell_records(shells):
+        records = []
+        for shell_id in sorted(shells):
+            uv_ids = sorted(shells[shell_id]["uv_ids"])
+            face_ids = sorted(shells[shell_id]["face_ids"])
+            bounds = _bounds(uv_ids)
+            records.append({
+                "id": int(shell_id),
+                "uv_count": len(uv_ids),
+                "face_count": len(face_ids),
+                "bounds": bounds,
+                "uv_components": [_uv_component(uv_id) for uv_id in uv_ids[:max_preview]],
+                "face_components": [_face_component(face_id) for face_id in face_ids[:max_preview]],
+                "truncated_uvs": len(uv_ids) > max_preview,
+                "truncated_faces": len(face_ids) > max_preview,
+            })
+        return records
+
+    def _resolve_shell_ids(shells, allow_all=True):
+        if shell_ids is not None:
+            if not isinstance(shell_ids, list) or not all(isinstance(item, int) and not isinstance(item, bool) for item in shell_ids):
+                raise ValueError("shell_ids must be a list of integers.")
+            resolved = list(dict.fromkeys(int(item) for item in shell_ids))
+        else:
+            source = _flatten(components) if components is not None else _selected_components()
+            if source:
+                uv_items = _convert_to_uvs(source)
+                resolved = []
+                for item in uv_items:
+                    uv_index = _uv_id(item)
+                    if uv_index is None:
+                        continue
+                    for shell_id, record in shells.items():
+                        if uv_index in record["uv_ids"] and shell_id not in resolved:
+                            resolved.append(shell_id)
+                            break
+            elif allow_all:
+                resolved = sorted(shells)
+            else:
+                raise ValueError("No shell ids resolved from shell_ids, components, or current selection.")
+        unknown = [item for item in resolved if item not in shells]
+        if unknown:
+            raise ValueError(f"Unknown shell_ids: {unknown}.")
+        if not resolved:
+            raise ValueError("No UV shells resolved.")
+        return resolved
+
+    def _box_for_shell(shell_id, shell_order_index, resolved_shell_ids):
+        if target_boxes is None:
+            return _validate_box(target_box, "target_box")
+        if isinstance(target_boxes, dict):
+            key = str(shell_id)
+            if key not in target_boxes and shell_id not in target_boxes:
+                raise ValueError(f"target_boxes is missing shell id {shell_id}.")
+            return _validate_box(target_boxes.get(key, target_boxes.get(shell_id)), f"target_boxes[{shell_id}]")
+        if isinstance(target_boxes, list):
+            if len(target_boxes) != len(resolved_shell_ids):
+                raise ValueError("target_boxes list length must match resolved shell count.")
+            return _validate_box(target_boxes[shell_order_index], f"target_boxes[{shell_order_index}]")
+        raise ValueError("target_boxes must be a dict, list, or None.")
+
+    def _inner_box(box, pad):
+        width = box[2] - box[0]
+        height = box[3] - box[1]
+        clean_pad = max(0.0, min(pad, width * 0.49, height * 0.49))
+        return [box[0] + clean_pad, box[1] + clean_pad, box[2] - clean_pad, box[3] - clean_pad]
+
+    def _fit_uv_ids_to_box(uv_ids, box):
+        bounds = _bounds(uv_ids)
+        if not bounds:
+            return {"skipped": True, "reason": "empty_shell"}
+        source_size = bounds["size"]
+        target_size = [box[2] - box[0], box[3] - box[1]]
+        target_center = [(box[0] + box[2]) * 0.5, (box[1] + box[3]) * 0.5]
+        if source_size[0] <= 1e-12 and source_size[1] <= 1e-12:
+            for uv_id in uv_ids:
+                _set_uv_position(uv_id, target_center)
+            return {"scale": [0.0, 0.0], "target_box": box}
+        scale_u = target_size[0] / source_size[0] if source_size[0] > 1e-12 else 1.0
+        scale_v = target_size[1] / source_size[1] if source_size[1] > 1e-12 else 1.0
+        if preserve_aspect:
+            scale = min(scale_u, scale_v)
+            scale_u = scale
+            scale_v = scale
+        for uv_id in uv_ids:
+            position = _uv_position(uv_id)
+            _set_uv_position(uv_id, [
+                target_center[0] + (position[0] - bounds["center"][0]) * scale_u,
+                target_center[1] + (position[1] - bounds["center"][1]) * scale_v,
+            ])
+        return {"scale": [scale_u, scale_v], "target_box": box}
+
+    def _layout_boxes(count):
+        box = _validate_box(target_box, "target_box")
+        columns = grid_columns if grid_columns and grid_columns > 0 else int(math.ceil(math.sqrt(float(count))))
+        columns = max(1, columns)
+        rows = int(math.ceil(count / float(columns)))
+        cell_width = (box[2] - box[0]) / float(columns)
+        cell_height = (box[3] - box[1]) / float(rows)
+        boxes = []
+        for index in range(count):
+            column = index % columns
+            row = index // columns
+            min_u = box[0] + column * cell_width
+            max_u = min_u + cell_width
+            max_v = box[3] - row * cell_height
+            min_v = max_v - cell_height
+            boxes.append(_inner_box([min_u, min_v, max_u, max_v], clean_padding))
+        return boxes, {"columns": columns, "rows": rows, "target_box": box, "padding": clean_padding}
+
+    def _summary(shells, mixed_faces):
+        records = _shell_records(shells)
+        return {
+            "uv_set": active_uv_set,
+            "shell_count": len(records),
+            "uv_count": int(cmds.polyEvaluate(object_name, uvcoord=True)),
+            "mixed_face_count": len(mixed_faces),
+            "mixed_faces_preview": [_face_component(face_id) for face_id in mixed_faces[:max_preview]],
+            "shells": records[:max_preview],
+            "truncated_shells": len(records) > max_preview,
+        }
+
+    if not object_name:
+        raise ValueError("object_name is required.")
+    operation = operation.lower().strip()
+    allowed = {"query", "select", "fit_box", "layout_grid"}
+    if operation not in allowed:
+        raise ValueError(f"operation must be one of: {', '.join(sorted(allowed))}.")
+    max_preview = _validate_int(max_preview, "max_preview", 1)
+    clean_padding = _validate_scalar(padding, "padding")
+    if clean_padding < 0.0:
+        raise ValueError("padding must be greater than or equal to zero.")
+
+    shape_name = _mesh_shape(object_name)
+    prefix_name = _prefix(shape_name)
+    mesh_fn = _mesh_fn(shape_name)
+    all_uv_sets = cmds.polyUVSet(object_name, query=True, allUVSets=True) or []
+    previous_uv_set = (cmds.polyUVSet(object_name, query=True, currentUVSet=True) or [None])[0]
+    if uv_set:
+        if uv_set not in all_uv_sets:
+            raise ValueError(f"UV set {uv_set} does not exist on {object_name}.")
+        cmds.polyUVSet(object_name, currentUVSet=True, uvSet=uv_set)
+    active_uv_set = uv_set or previous_uv_set
+
+    try:
+        before_shells, before_mixed_faces = _shell_data()
+        resolved_shell_ids = _resolve_shell_ids(before_shells, allow_all=True)
+
+        if operation == "query":
+            selected_shells = {shell_id: before_shells[shell_id] for shell_id in resolved_shell_ids}
+            return {
+                "success": True,
+                "object_name": object_name,
+                "operation": operation,
+                "resolved_shell_ids": resolved_shell_ids,
+                "summary": _summary(selected_shells, before_mixed_faces),
+            }
+
+        if operation == "select":
+            uv_items = []
+            for shell_id in resolved_shell_ids:
+                uv_items.extend(_uv_component(uv_id) for uv_id in sorted(before_shells[shell_id]["uv_ids"]))
+            cmds.select(uv_items, replace=True)
+            return {
+                "success": True,
+                "object_name": object_name,
+                "operation": operation,
+                "resolved_shell_ids": resolved_shell_ids,
+                "selected_uv_count": len(uv_items),
+                "selected_uvs_preview": uv_items[:max_preview],
+            }
+
+        before_summary = _summary({shell_id: before_shells[shell_id] for shell_id in resolved_shell_ids}, before_mixed_faces)
+        applied = []
+        if operation == "fit_box":
+            for index, shell_id in enumerate(resolved_shell_ids):
+                box = _box_for_shell(shell_id, index, resolved_shell_ids)
+                result = _fit_uv_ids_to_box(before_shells[shell_id]["uv_ids"], box)
+                result["shell_id"] = shell_id
+                applied.append(result)
+
+        elif operation == "layout_grid":
+            boxes, grid_info = _layout_boxes(len(resolved_shell_ids))
+            for index, shell_id in enumerate(resolved_shell_ids):
+                result = _fit_uv_ids_to_box(before_shells[shell_id]["uv_ids"], boxes[index])
+                result["shell_id"] = shell_id
+                applied.append(result)
+            applied.append({"grid": grid_info})
+
+        after_shells, after_mixed_faces = _shell_data()
+        return {
+            "success": True,
+            "object_name": object_name,
+            "operation": operation,
+            "resolved_shell_ids": resolved_shell_ids,
+            "preserve_aspect": bool(preserve_aspect),
+            "applied": applied,
+            "summary_before": before_summary,
+            "summary_after": _summary({shell_id: after_shells[shell_id] for shell_id in resolved_shell_ids}, after_mixed_faces),
+        }
+    finally:
+        if uv_set and previous_uv_set and previous_uv_set in all_uv_sets and cmds.objExists(object_name):
+            try:
+                cmds.polyUVSet(object_name, currentUVSet=True, uvSet=previous_uv_set)
+            except Exception:
+                pass

--- a/src/mayatools/object/edit_uv_topology.py
+++ b/src/mayatools/object/edit_uv_topology.py
@@ -1,0 +1,340 @@
+from typing import Dict, List, Any, Union
+
+
+def edit_uv_topology(
+    object_name: str,
+    operation: str,
+    component_type: str = None,
+    indices: List[int] = None,
+    components: Union[str, List[str]] = None,
+    uv_set: str = None,
+    parameters: Dict[str, Any] = None,
+    use_selection: bool = True,
+    max_preview: int = 50,
+) -> Dict[str, Any]:
+    """Edit UV seams, shells, unfolding, and layout at component level.
+
+    Operations:
+    - cut_edges: cut UV shells along selected mesh edges
+    - sew_edges: sew selected UV border edges without moving shells
+    - sew_move_edges: sew selected UV border edges and move shells together
+    - unitize_faces: map selected faces to 0..1 UV squares
+    - unfold: unfold selected UVs or UV shells
+    - layout: lay out selected UV shells
+    - normalize: normalize selected UVs or UV shells into tile space
+
+    Components can be explicit component strings, built from component_type and
+    indices, or taken from the current selection. This is for UV-editor style
+    work on localized seams, labels, decals, and texture islands.
+    """
+    import maya.cmds as cmds
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return int(value)
+
+    def _mesh_shape(node):
+        if not cmds.objExists(node):
+            raise ValueError(f"Object does not exist: {node}")
+        if cmds.objectType(node) == "mesh":
+            return node
+        shapes = cmds.listRelatives(node, shapes=True, fullPath=True) or []
+        mesh_shapes = []
+        for shape in shapes:
+            if cmds.objectType(shape) != "mesh":
+                continue
+            try:
+                if cmds.attributeQuery("intermediateObject", node=shape, exists=True) and cmds.getAttr(f"{shape}.intermediateObject"):
+                    continue
+            except Exception:
+                pass
+            mesh_shapes.append(shape)
+        if not mesh_shapes:
+            raise ValueError(f"{node} is not a polygon mesh transform or mesh shape.")
+        return mesh_shapes[0]
+
+    def _prefix(shape):
+        parents = cmds.listRelatives(shape, parent=True, fullPath=False) or []
+        return parents[0] if parents else object_name
+
+    def _flatten(value):
+        if value is None:
+            return []
+        if isinstance(value, str):
+            value = [value]
+        if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+            raise ValueError("components must be a string, a list of strings, or None.")
+        return cmds.ls(value, flatten=True) or []
+
+    def _selected_components():
+        if not use_selection:
+            return []
+        selected = cmds.ls(selection=True, flatten=True) or []
+        object_tokens = {object_name, prefix_name, shape_name}
+        return [item for item in selected if item.split(".", 1)[0] in object_tokens]
+
+    def _components_from_indices(kind):
+        if indices is None:
+            return []
+        if not isinstance(indices, list) or not all(isinstance(index, int) and not isinstance(index, bool) for index in indices):
+            raise ValueError("indices must be a list of integers.")
+        return [f"{prefix_name}.{kind}[{index}]" for index in indices]
+
+    def _resolve_components(default_type=None, allow_all=False):
+        scope = str(parameters.get("scope", "components")).lower().strip()
+        clean_type = (component_type or default_type or "").lower().strip()
+        kind_map = {"vertex": "vtx", "edge": "e", "face": "f", "uv": "map", "vertex_face": "vtxFace"}
+        if allow_all and scope == "all":
+            return [object_name]
+        if components is not None:
+            resolved = _flatten(components)
+        elif clean_type in kind_map and indices is not None:
+            resolved = _components_from_indices(kind_map[clean_type])
+        else:
+            resolved = _selected_components()
+        if not resolved:
+            raise ValueError("No components resolved from components, indices, current selection, or parameters.scope='all'.")
+        return resolved
+
+    def _convert(items, target):
+        flags = {
+            "vertex": {"toVertex": True},
+            "edge": {"toEdge": True},
+            "face": {"toFace": True},
+            "uv": {"toUV": True},
+        }[target]
+        converted = cmds.polyListComponentConversion(items, **flags) or []
+        return cmds.ls(converted, flatten=True) or []
+
+    def _uv_components_for_signature():
+        return cmds.ls(f"{prefix_name}.map[*]", flatten=True) or []
+
+    def _uv_values(items):
+        values = cmds.polyEditUV(items, query=True) or []
+        coords = []
+        for index in range(0, len(values), 2):
+            if index + 1 < len(values):
+                coords.append((round(float(values[index]), 6), round(float(values[index + 1]), 6)))
+        return coords
+
+    def _uv_range(coords):
+        if not coords:
+            return None
+        us = [coord[0] for coord in coords]
+        vs = [coord[1] for coord in coords]
+        return {
+            "min_u": min(us),
+            "max_u": max(us),
+            "min_v": min(vs),
+            "max_v": max(vs),
+        }
+
+    def _uv_shell_count():
+        kwargs = {"uvShell": True}
+        if active_uv_set:
+            kwargs["uvSetName"] = active_uv_set
+        return int(cmds.polyEvaluate(object_name, **kwargs))
+
+    def _uv_signature():
+        uv_items = _uv_components_for_signature()
+        coords = _uv_values(uv_items)
+        return {
+            "uv_count": int(cmds.polyEvaluate(object_name, uvcoord=True)),
+            "uv_shell_count": _uv_shell_count(),
+            "uv_range": _uv_range(coords),
+            "coords": coords,
+            "coord_checksum": round(sum((index + 1) * (coord[0] * 1.37 + coord[1] * 2.11) for index, coord in enumerate(coords)), 6),
+        }
+
+    def _public_signature(signature):
+        return {
+            "uv_count": signature["uv_count"],
+            "uv_shell_count": signature["uv_shell_count"],
+            "uv_range": signature["uv_range"],
+            "coord_checksum": signature["coord_checksum"],
+        }
+
+    def _changed(before, after):
+        return (
+            before["uv_count"] != after["uv_count"]
+            or before["uv_shell_count"] != after["uv_shell_count"]
+            or before["coords"] != after["coords"]
+        )
+
+    def _result(node_result, resolved, before, extra=None):
+        after = _uv_signature()
+        changed = _changed(before, after)
+        require_change = bool(parameters.get("require_change", True))
+        if require_change and not changed:
+            raise RuntimeError(f"{operation} did not change UV topology or coordinates.")
+        current_selection = cmds.ls(selection=True, flatten=True) or []
+        payload = {
+            "success": True,
+            "object_name": object_name,
+            "operation": operation,
+            "uv_set": active_uv_set,
+            "node": node_result,
+            "changed": changed,
+            "input_component_count": len(resolved),
+            "input_components_preview": resolved[:max_preview],
+            "selected_after_count": len(current_selection),
+            "selected_after_preview": current_selection[:max_preview],
+            "uv_before": _public_signature(before),
+            "uv_after": _public_signature(after),
+        }
+        if extra:
+            payload.update(extra)
+        return payload
+
+    if not object_name:
+        raise ValueError("object_name is required.")
+    if not operation:
+        raise ValueError("operation is required.")
+    operation = operation.lower().strip()
+    allowed = {
+        "cut_edges",
+        "sew_edges",
+        "sew_move_edges",
+        "unitize_faces",
+        "unfold",
+        "layout",
+        "normalize",
+    }
+    if operation not in allowed:
+        raise ValueError(f"operation must be one of: {', '.join(sorted(allowed))}.")
+
+    parameters = parameters or {}
+    max_preview = _validate_int(max_preview, "max_preview", 1)
+    shape_name = _mesh_shape(object_name)
+    prefix_name = _prefix(shape_name)
+
+    all_uv_sets = cmds.polyUVSet(object_name, query=True, allUVSets=True) or []
+    previous_uv_set = (cmds.polyUVSet(object_name, query=True, currentUVSet=True) or [None])[0]
+    if uv_set:
+        if uv_set not in all_uv_sets:
+            raise ValueError(f"UV set {uv_set} does not exist on {object_name}.")
+        cmds.polyUVSet(object_name, currentUVSet=True, uvSet=uv_set)
+    active_uv_set = uv_set or previous_uv_set
+
+    try:
+        before_signature = _uv_signature()
+        construction_history = bool(parameters.get("construction_history", False))
+
+        if operation == "cut_edges":
+            edges = _convert(_resolve_components("edge"), "edge")
+            if not edges:
+                raise ValueError("cut_edges requires edge components.")
+            move_ratio = _validate_scalar(parameters.get("move_ratio", 0.0), "move_ratio")
+            node = cmds.polyMapCut(
+                edges,
+                constructionHistory=construction_history,
+                moveRatio=move_ratio,
+                usePinning=bool(parameters.get("use_pinning", False)),
+            )
+            return _result(node, edges, before_signature, {"move_ratio": move_ratio})
+
+        if operation == "sew_edges":
+            edges = _convert(_resolve_components("edge"), "edge")
+            if not edges:
+                raise ValueError("sew_edges requires edge components.")
+            node = cmds.polyMapSew(
+                edges,
+                constructionHistory=construction_history,
+                usePinning=bool(parameters.get("use_pinning", False)),
+            )
+            return _result(node, edges, before_signature)
+
+        if operation == "sew_move_edges":
+            edges = _convert(_resolve_components("edge"), "edge")
+            if not edges:
+                raise ValueError("sew_move_edges requires edge components.")
+            node = cmds.polyMapSewMove(
+                edges,
+                constructionHistory=construction_history,
+                limitPieceSize=bool(parameters.get("limit_piece_size", False)),
+                numberFaces=_validate_int(parameters.get("number_faces", 10), "number_faces", 0),
+                uvSetName=active_uv_set,
+                worldSpace=bool(parameters.get("world_space", True)),
+            )
+            return _result(node, edges, before_signature)
+
+        if operation == "unitize_faces":
+            faces = _convert(_resolve_components("face"), "face")
+            if not faces:
+                raise ValueError("unitize_faces requires face components.")
+            node = cmds.polyForceUV(faces, unitize=True, uvSetName=active_uv_set)
+            return _result(node, faces, before_signature)
+
+        if operation == "unfold":
+            uv_items = _convert(_resolve_components("uv", allow_all=True), "uv")
+            if not uv_items:
+                raise ValueError("unfold requires UVs or components convertible to UVs.")
+            node = cmds.unfold(
+                uv_items,
+                iterations=_validate_int(parameters.get("iterations", 10), "iterations", 1),
+                applyToShell=bool(parameters.get("apply_to_shell", True)),
+                areaWeight=_validate_scalar(parameters.get("area_weight", 0.0), "area_weight"),
+                globalBlend=_validate_scalar(parameters.get("global_blend", 0.0), "global_blend"),
+                globalMethodBlend=_validate_scalar(parameters.get("global_method_blend", 0.5), "global_method_blend"),
+                optimizeAxis=_validate_int(parameters.get("optimize_axis", 0), "optimize_axis", 0),
+                pinSelected=bool(parameters.get("pin_selected", False)),
+                pinUvBorder=bool(parameters.get("pin_uv_border", False)),
+                scale=_validate_scalar(parameters.get("scale", 1.0), "scale"),
+                stoppingThreshold=_validate_scalar(parameters.get("stopping_threshold", 0.001), "stopping_threshold"),
+                useScale=bool(parameters.get("use_scale", False)),
+            )
+            return _result(node, uv_items, before_signature)
+
+        if operation == "layout":
+            uv_items = _convert(_resolve_components("uv", allow_all=True), "uv")
+            if not uv_items:
+                raise ValueError("layout requires UVs or components convertible to UVs.")
+            node = cmds.polyLayoutUV(
+                uv_items,
+                layout=_validate_int(parameters.get("layout", 2), "layout", 0),
+                layoutMethod=_validate_int(parameters.get("layout_method", 1), "layout_method", 0),
+                percentageSpace=_validate_scalar(parameters.get("percentage_space", 2.0), "percentage_space"),
+                rotateForBestFit=_validate_int(parameters.get("rotate_for_best_fit", 2), "rotate_for_best_fit", 0),
+                scale=_validate_int(parameters.get("scale_mode", parameters.get("scale", 1)), "scale", 0),
+                separate=_validate_int(parameters.get("separate", 0), "separate", 0),
+                flipReversed=bool(parameters.get("flip_reversed", False)),
+                gridU=_validate_int(parameters.get("grid_u", 1), "grid_u", 1),
+                gridV=_validate_int(parameters.get("grid_v", 1), "grid_v", 1),
+                uvSetName=active_uv_set,
+                worldSpace=bool(parameters.get("world_space", True)),
+                constructionHistory=construction_history,
+            )
+            return _result(node, uv_items, before_signature)
+
+        if operation == "normalize":
+            uv_items = _convert(_resolve_components("uv", allow_all=True), "uv")
+            if not uv_items:
+                raise ValueError("normalize requires UVs or components convertible to UVs.")
+            node = cmds.polyNormalizeUV(
+                uv_items,
+                normalizeType=_validate_int(parameters.get("normalize_type", 0), "normalize_type", 0),
+                normalizeDirection=_validate_int(parameters.get("normalize_direction", 0), "normalize_direction", 0),
+                preserveAspectRatio=bool(parameters.get("preserve_aspect_ratio", True)),
+                centerOnTile=bool(parameters.get("center_on_tile", False)),
+                uvSetName=active_uv_set,
+                worldSpace=bool(parameters.get("world_space", True)),
+                constructionHistory=construction_history,
+            )
+            return _result(node, uv_items, before_signature)
+
+        raise ValueError(f"Unsupported operation: {operation}")
+    finally:
+        if uv_set and previous_uv_set and previous_uv_set in all_uv_sets and cmds.objExists(object_name):
+            try:
+                cmds.polyUVSet(object_name, currentUVSet=True, uvSet=previous_uv_set)
+            except Exception:
+                pass

--- a/src/mayatools/object/extract_image_color_regions.py
+++ b/src/mayatools/object/extract_image_color_regions.py
@@ -1,0 +1,391 @@
+from typing import Dict, List, Any
+
+
+def extract_image_color_regions(
+    image_path: str,
+    target_color: List[float] = None,
+    match_mode: str = "rgb",
+    color_tolerance: float = 0.25,
+    hue_tolerance: float = 0.05,
+    saturation_min: float = 0.25,
+    value_min: float = 0.05,
+    crop: List[float] = [0.0, 0.0, 1.0, 1.0],
+    alpha_threshold: float = 0.05,
+    background_color: List[float] = None,
+    background_tolerance: float = 0.06,
+    reference_bbox_pixels: List[float] = None,
+    target_height: float = 0.0,
+    min_component_pixels: int = 25,
+    min_component_width: int = 2,
+    min_component_height: int = 2,
+    min_band_row_pixels: int = 5,
+    max_regions: int = 20,
+) -> Dict[str, Any]:
+    """Extract connected image regions that match a color or foreground mask.
+
+    This is a generic reference-measurement helper for product modeling. It can
+    find RGB-distance matches, hue matches, or non-background foreground regions,
+    then report connected components, horizontal bands, normalized image bounds,
+    and optional product-height-space measurements.
+    """
+    import os
+
+    try:
+        from PySide6.QtGui import QImage
+    except Exception:
+        try:
+            from PySide2.QtGui import QImage
+        except Exception as exc:
+            raise RuntimeError("PySide QImage is required to read image pixels in Maya.") from exc
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(v) for v in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(value) for value in values]
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return value
+
+    def _clamp(value, lower, upper):
+        return max(lower, min(upper, value))
+
+    def _normalize_color(values, arg_name):
+        color = _validate_vector(values, 3, arg_name)
+        if max(color) > 1.0:
+            color = [value / 255.0 for value in color]
+        return [_clamp(value, 0.0, 1.0) for value in color]
+
+    def _pixel_rgb_alpha(image, x, y):
+        color = image.pixelColor(int(x), int(y))
+        return (
+            color.redF(),
+            color.greenF(),
+            color.blueF(),
+            color.alphaF(),
+        )
+
+    def _color_distance(color_a, color_b):
+        dr = color_a[0] - color_b[0]
+        dg = color_a[1] - color_b[1]
+        db = color_a[2] - color_b[2]
+        return (dr * dr + dg * dg + db * db) ** 0.5
+
+    def _rgb_to_hsv(red, green, blue):
+        max_value = max(red, green, blue)
+        min_value = min(red, green, blue)
+        delta = max_value - min_value
+        if delta == 0.0:
+            hue = 0.0
+        elif max_value == red:
+            hue = ((green - blue) / delta) % 6.0
+        elif max_value == green:
+            hue = ((blue - red) / delta) + 2.0
+        else:
+            hue = ((red - green) / delta) + 4.0
+        hue /= 6.0
+        saturation = 0.0 if max_value == 0.0 else delta / max_value
+        return hue, saturation, max_value
+
+    def _hue_distance(hue_a, hue_b):
+        direct = abs(hue_a - hue_b)
+        return min(direct, 1.0 - direct)
+
+    def _estimate_background(image, x_min, y_min, x_max, y_max):
+        sample_points = []
+        inset_x = max(1, int((x_max - x_min) * 0.03))
+        inset_y = max(1, int((y_max - y_min) * 0.03))
+        radius = max(1, min(inset_x, inset_y, 8))
+        corners = [
+            (x_min + inset_x, y_min + inset_y),
+            (x_max - inset_x, y_min + inset_y),
+            (x_min + inset_x, y_max - inset_y),
+            (x_max - inset_x, y_max - inset_y),
+        ]
+        for corner_x, corner_y in corners:
+            for dy in range(-radius, radius + 1):
+                for dx in range(-radius, radius + 1):
+                    x = int(_clamp(corner_x + dx, x_min, x_max))
+                    y = int(_clamp(corner_y + dy, y_min, y_max))
+                    sample_points.append(_pixel_rgb_alpha(image, x, y)[:3])
+        if not sample_points:
+            return [1.0, 1.0, 1.0]
+        channels = []
+        for index in range(3):
+            values = sorted(point[index] for point in sample_points)
+            channels.append(values[len(values) // 2])
+        return channels
+
+    def _height_space_from_bbox(bbox, reference_bbox):
+        if target_height <= 0.0 or reference_bbox is None:
+            return None
+        ref_height = max(1e-9, float(reference_bbox[3] - reference_bbox[1]))
+        bottom_height = (reference_bbox[3] - bbox[3]) / ref_height * target_height
+        top_height = (reference_bbox[3] - bbox[1]) / ref_height * target_height
+        region_height = max(0.0, top_height - bottom_height)
+        width = (bbox[2] - bbox[0]) / ref_height * target_height
+        return {
+            "bottom": bottom_height,
+            "top": top_height,
+            "center": (bottom_height + top_height) * 0.5,
+            "height": region_height,
+            "width": width,
+        }
+
+    def _normalized_bbox(bbox, image_width, image_height):
+        return [
+            bbox[0] / float(image_width - 1),
+            bbox[1] / float(image_height - 1),
+            bbox[2] / float(image_width - 1),
+            bbox[3] / float(image_height - 1),
+        ]
+
+    if not image_path:
+        raise ValueError("image_path is required.")
+    normalized_image_path = os.path.normpath(image_path)
+    if not os.path.isfile(normalized_image_path):
+        raise ValueError(f"Image path does not exist: {image_path}")
+
+    match_mode = match_mode.lower().strip()
+    if match_mode not in {"rgb", "hue", "foreground"}:
+        raise ValueError("match_mode must be one of rgb, hue, or foreground.")
+    clean_target_color = None
+    target_hsv = None
+    if match_mode in {"rgb", "hue"}:
+        if target_color is None:
+            raise ValueError("target_color is required for rgb and hue match modes.")
+        clean_target_color = _normalize_color(target_color, "target_color")
+        target_hsv = _rgb_to_hsv(clean_target_color[0], clean_target_color[1], clean_target_color[2])
+
+    color_tolerance = _validate_scalar(color_tolerance, "color_tolerance")
+    if color_tolerance > 1.0:
+        color_tolerance /= 255.0
+    if color_tolerance < 0.0:
+        raise ValueError("color_tolerance must be greater than or equal to zero.")
+    hue_tolerance = _validate_scalar(hue_tolerance, "hue_tolerance")
+    if hue_tolerance > 1.0:
+        hue_tolerance /= 360.0
+    if hue_tolerance < 0.0 or hue_tolerance > 0.5:
+        raise ValueError("hue_tolerance must be in the 0..0.5 range, or degrees in the 0..180 range.")
+    saturation_min = _clamp(_validate_scalar(saturation_min, "saturation_min"), 0.0, 1.0)
+    value_min = _clamp(_validate_scalar(value_min, "value_min"), 0.0, 1.0)
+    alpha_threshold = _validate_scalar(alpha_threshold, "alpha_threshold")
+    if alpha_threshold < 0.0 or alpha_threshold > 1.0:
+        raise ValueError("alpha_threshold must be in the 0..1 range.")
+    background_tolerance = _validate_scalar(background_tolerance, "background_tolerance")
+    if background_tolerance > 1.0:
+        background_tolerance /= 255.0
+    if background_tolerance < 0.0:
+        raise ValueError("background_tolerance must be greater than or equal to zero.")
+    target_height = _validate_scalar(target_height, "target_height")
+    if target_height < 0.0:
+        raise ValueError("target_height must be greater than or equal to zero.")
+    crop = _validate_vector(crop, 4, "crop")
+    crop = [_clamp(value, 0.0, 1.0) for value in crop]
+    if crop[2] <= crop[0] or crop[3] <= crop[1]:
+        raise ValueError("crop must be [min_x, min_y, max_x, max_y] in normalized image coordinates.")
+    min_component_pixels = _validate_int(min_component_pixels, "min_component_pixels", 1)
+    min_component_width = _validate_int(min_component_width, "min_component_width", 1)
+    min_component_height = _validate_int(min_component_height, "min_component_height", 1)
+    min_band_row_pixels = _validate_int(min_band_row_pixels, "min_band_row_pixels", 1)
+    max_regions = _validate_int(max_regions, "max_regions", 1)
+
+    image = QImage(normalized_image_path)
+    if image.isNull():
+        raise ValueError(f"Unable to load image: {image_path}")
+    image_width = image.width()
+    image_height = image.height()
+    if image_width < 2 or image_height < 2:
+        raise ValueError("image must be at least 2x2 pixels.")
+
+    x_min = int(round(crop[0] * (image_width - 1)))
+    y_min = int(round(crop[1] * (image_height - 1)))
+    x_max = int(round(crop[2] * (image_width - 1)))
+    y_max = int(round(crop[3] * (image_height - 1)))
+    crop_width = x_max - x_min + 1
+    crop_height = y_max - y_min + 1
+
+    clean_background_color = None
+    if background_color is None:
+        clean_background_color = _estimate_background(image, x_min, y_min, x_max, y_max)
+    else:
+        clean_background_color = _normalize_color(background_color, "background_color")
+
+    reference_bbox = None
+    if reference_bbox_pixels is not None:
+        reference_bbox = _validate_vector(reference_bbox_pixels, 4, "reference_bbox_pixels")
+    matched = [bytearray(crop_width) for _ in range(crop_height)]
+    foreground_bbox = None
+    row_stats = []
+    matched_count = 0
+
+    for local_y, y in enumerate(range(y_min, y_max + 1)):
+        row_count = 0
+        row_min = None
+        row_max = None
+        for local_x, x in enumerate(range(x_min, x_max + 1)):
+            red, green, blue, alpha = _pixel_rgb_alpha(image, x, y)
+            if alpha < alpha_threshold:
+                continue
+            rgb = [red, green, blue]
+            is_foreground = _color_distance(rgb, clean_background_color) > background_tolerance
+            if is_foreground:
+                if foreground_bbox is None:
+                    foreground_bbox = [x, y, x, y]
+                else:
+                    foreground_bbox[0] = min(foreground_bbox[0], x)
+                    foreground_bbox[1] = min(foreground_bbox[1], y)
+                    foreground_bbox[2] = max(foreground_bbox[2], x)
+                    foreground_bbox[3] = max(foreground_bbox[3], y)
+
+            if match_mode == "foreground":
+                is_match = is_foreground
+            elif match_mode == "rgb":
+                is_match = _color_distance(rgb, clean_target_color) <= color_tolerance
+            else:
+                hue, saturation, value = _rgb_to_hsv(red, green, blue)
+                is_match = (
+                    _hue_distance(hue, target_hsv[0]) <= hue_tolerance
+                    and saturation >= saturation_min
+                    and value >= value_min
+                )
+            if not is_match:
+                continue
+            matched[local_y][local_x] = 1
+            matched_count += 1
+            row_count += 1
+            row_min = x if row_min is None else min(row_min, x)
+            row_max = x if row_max is None else max(row_max, x)
+        row_stats.append({"y": y, "count": row_count, "min_x": row_min, "max_x": row_max})
+
+    if reference_bbox is None:
+        reference_bbox = foreground_bbox
+
+    visited = [bytearray(crop_width) for _ in range(crop_height)]
+    components = []
+    for local_y in range(crop_height):
+        for local_x in range(crop_width):
+            if not matched[local_y][local_x] or visited[local_y][local_x]:
+                continue
+            stack = [(local_x, local_y)]
+            visited[local_y][local_x] = 1
+            count = 0
+            min_x = max_x = x_min + local_x
+            min_y = max_y = y_min + local_y
+            sum_red = sum_green = sum_blue = 0.0
+            while stack:
+                current_x, current_y = stack.pop()
+                image_x = x_min + current_x
+                image_y = y_min + current_y
+                red, green, blue, _ = _pixel_rgb_alpha(image, image_x, image_y)
+                sum_red += red
+                sum_green += green
+                sum_blue += blue
+                count += 1
+                min_x = min(min_x, image_x)
+                max_x = max(max_x, image_x)
+                min_y = min(min_y, image_y)
+                max_y = max(max_y, image_y)
+                for next_x, next_y in [
+                    (current_x - 1, current_y),
+                    (current_x + 1, current_y),
+                    (current_x, current_y - 1),
+                    (current_x, current_y + 1),
+                ]:
+                    if next_x < 0 or next_y < 0 or next_x >= crop_width or next_y >= crop_height:
+                        continue
+                    if visited[next_y][next_x] or not matched[next_y][next_x]:
+                        continue
+                    visited[next_y][next_x] = 1
+                    stack.append((next_x, next_y))
+            bbox = [min_x, min_y, max_x, max_y]
+            width = max_x - min_x + 1
+            height = max_y - min_y + 1
+            if count < min_component_pixels or width < min_component_width or height < min_component_height:
+                continue
+            components.append(
+                {
+                    "pixel_count": count,
+                    "bbox_pixels": bbox,
+                    "bbox_normalized": _normalized_bbox(bbox, image_width, image_height),
+                    "center_pixels": [(min_x + max_x) * 0.5, (min_y + max_y) * 0.5],
+                    "width_pixels": width,
+                    "height_pixels": height,
+                    "mean_color": [sum_red / count, sum_green / count, sum_blue / count],
+                    "height_space": _height_space_from_bbox(bbox, reference_bbox),
+                }
+            )
+
+    components.sort(key=lambda component: component["pixel_count"], reverse=True)
+    components = components[:max_regions]
+
+    bands = []
+    active_band = None
+    for row in row_stats:
+        if row["count"] >= min_band_row_pixels:
+            if active_band is None:
+                active_band = {
+                    "min_y": row["y"],
+                    "max_y": row["y"],
+                    "min_x": row["min_x"],
+                    "max_x": row["max_x"],
+                    "pixel_count": row["count"],
+                }
+            else:
+                active_band["max_y"] = row["y"]
+                active_band["min_x"] = min(active_band["min_x"], row["min_x"])
+                active_band["max_x"] = max(active_band["max_x"], row["max_x"])
+                active_band["pixel_count"] += row["count"]
+        elif active_band is not None:
+            bbox = [active_band["min_x"], active_band["min_y"], active_band["max_x"], active_band["max_y"]]
+            bands.append(
+                {
+                    "pixel_count": active_band["pixel_count"],
+                    "bbox_pixels": bbox,
+                    "bbox_normalized": _normalized_bbox(bbox, image_width, image_height),
+                    "height_space": _height_space_from_bbox(bbox, reference_bbox),
+                }
+            )
+            active_band = None
+    if active_band is not None:
+        bbox = [active_band["min_x"], active_band["min_y"], active_band["max_x"], active_band["max_y"]]
+        bands.append(
+            {
+                "pixel_count": active_band["pixel_count"],
+                "bbox_pixels": bbox,
+                "bbox_normalized": _normalized_bbox(bbox, image_width, image_height),
+                "height_space": _height_space_from_bbox(bbox, reference_bbox),
+            }
+        )
+
+    bands.sort(key=lambda band: band["bbox_pixels"][1])
+
+    return {
+        "success": True,
+        "image_path": normalized_image_path,
+        "image_width": image_width,
+        "image_height": image_height,
+        "crop_pixels": [x_min, y_min, x_max, y_max],
+        "target_color": clean_target_color,
+        "match_mode": match_mode,
+        "color_tolerance": color_tolerance,
+        "hue_tolerance": hue_tolerance,
+        "saturation_min": saturation_min,
+        "value_min": value_min,
+        "background_color": clean_background_color,
+        "background_tolerance": background_tolerance,
+        "foreground_bbox_pixels": foreground_bbox,
+        "reference_bbox_pixels": reference_bbox,
+        "matched_count": matched_count,
+        "components": components,
+        "horizontal_bands": bands,
+    }

--- a/src/mayatools/object/extract_image_contours.py
+++ b/src/mayatools/object/extract_image_contours.py
@@ -1,0 +1,538 @@
+from typing import Dict, List, Any
+
+
+def extract_image_contours(
+    image_path: str,
+    bbox_pixels: List[float] = None,
+    bbox_normalized: List[float] = None,
+    match_mode: str = "luminance",
+    target_color: List[float] = None,
+    color_tolerance: float = 0.25,
+    hue_tolerance: float = 0.05,
+    saturation_min: float = 0.25,
+    value_min: float = 0.05,
+    alpha_threshold: float = 0.05,
+    background_color: List[float] = None,
+    background_tolerance: float = 0.06,
+    threshold: float = 0.5,
+    invert: bool = False,
+    component_connectivity: int = 8,
+    min_component_pixels: int = 20,
+    max_components: int = 20,
+    min_contour_points: int = 8,
+    simplify_tolerance_pixels: float = 1.5,
+    max_points_per_contour: int = 160,
+    close_contours: bool = True,
+    create_curves: bool = False,
+    curve_name_prefix: str = None,
+    curve_mapping: str = "image_plane",
+    plane_axis: str = "z",
+    plane_width: float = 1.0,
+    plane_height: float = 1.0,
+    center: List[float] = [0.0, 0.0, 0.0],
+    axis: str = "y",
+    axis_range: List[float] = [0.0, 1.0],
+    angle_range_degrees: List[float] = [-60.0, 60.0],
+    radius: float = 1.0,
+    surface_profile: List[List[float]] = None,
+    profile_interpolation: str = "linear",
+    offset: float = 0.02,
+) -> Dict[str, Any]:
+    """Extract image-mask component contours and optionally create Maya curves.
+
+    The image region can be segmented by luminance, alpha, RGB color, hue, or
+    foreground-vs-background. Connected components are reduced to boundary
+    contours, simplified, and returned in crop-local pixel and normalized
+    coordinates. When requested, contours can be instantiated as generic Maya
+    curves on an image plane or mapped around a cylindrical/lathed surface.
+    This is useful for decals, relief outlines, molded marks, panel seams,
+    engravings, vents, patches, and other reference-derived curve details.
+    """
+    import math
+    import os
+    import maya.cmds as cmds
+
+    try:
+        from PySide6.QtGui import QImage
+    except Exception:
+        try:
+            from PySide2.QtGui import QImage
+        except Exception as exc:
+            raise RuntimeError("PySide QImage is required to extract image contours in Maya.") from exc
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(v) for v in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(value) for value in values]
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return value
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _clamp(value, lower=0.0, upper=1.0):
+        return max(lower, min(upper, value))
+
+    def _normalize_color(values, arg_name):
+        color = _validate_vector(values, 3, arg_name)
+        if max(color) > 1.0:
+            color = [value / 255.0 for value in color]
+        return [_clamp(value) for value in color]
+
+    def _pixel_rgb_alpha(image, x, y):
+        color = image.pixelColor(int(x), int(y))
+        return color.redF(), color.greenF(), color.blueF(), color.alphaF()
+
+    def _color_distance(a, b):
+        dr = a[0] - b[0]
+        dg = a[1] - b[1]
+        db = a[2] - b[2]
+        return (dr * dr + dg * dg + db * db) ** 0.5
+
+    def _rgb_to_hsv(red, green, blue):
+        max_value = max(red, green, blue)
+        min_value = min(red, green, blue)
+        delta = max_value - min_value
+        if delta == 0.0:
+            hue = 0.0
+        elif max_value == red:
+            hue = ((green - blue) / delta) % 6.0
+        elif max_value == green:
+            hue = ((blue - red) / delta) + 2.0
+        else:
+            hue = ((red - green) / delta) + 4.0
+        hue /= 6.0
+        saturation = 0.0 if max_value == 0.0 else delta / max_value
+        return hue, saturation, max_value
+
+    def _hue_distance(a, b):
+        direct = abs(a - b)
+        return min(direct, 1.0 - direct)
+
+    def _estimate_background(image):
+        width = image.width()
+        height = image.height()
+        sample_points = []
+        radius = max(1, min(width, height, 8))
+        corners = [(0, 0), (width - 1, 0), (0, height - 1), (width - 1, height - 1)]
+        for corner_x, corner_y in corners:
+            for dy in range(-radius, radius + 1):
+                for dx in range(-radius, radius + 1):
+                    x = max(0, min(width - 1, corner_x + dx))
+                    y = max(0, min(height - 1, corner_y + dy))
+                    sample_points.append(_pixel_rgb_alpha(image, x, y)[:3])
+        channels = []
+        for index in range(3):
+            values = sorted(point[index] for point in sample_points)
+            channels.append(values[len(values) // 2])
+        return channels
+
+    def _component_neighbors():
+        if component_connectivity == 4:
+            return [(-1, 0), (1, 0), (0, -1), (0, 1)]
+        return [(-1, 0), (1, 0), (0, -1), (0, 1), (-1, -1), (1, -1), (-1, 1), (1, 1)]
+
+    def _boundary_neighbors():
+        return [(-1, 0), (1, 0), (0, -1), (0, 1)]
+
+    def _point_line_distance(point, start, end):
+        px, py = point
+        sx, sy = start
+        ex, ey = end
+        dx = ex - sx
+        dy = ey - sy
+        length_sq = dx * dx + dy * dy
+        if length_sq <= 1e-9:
+            return math.hypot(px - sx, py - sy)
+        t = ((px - sx) * dx + (py - sy) * dy) / length_sq
+        t = max(0.0, min(1.0, t))
+        nx = sx + t * dx
+        ny = sy + t * dy
+        return math.hypot(px - nx, py - ny)
+
+    def _rdp(points, epsilon):
+        if len(points) <= 2 or epsilon <= 0.0:
+            return points[:]
+        start = points[0]
+        end = points[-1]
+        max_distance = -1.0
+        max_index = 0
+        for index in range(1, len(points) - 1):
+            distance = _point_line_distance(points[index], start, end)
+            if distance > max_distance:
+                max_distance = distance
+                max_index = index
+        if max_distance > epsilon:
+            left = _rdp(points[: max_index + 1], epsilon)
+            right = _rdp(points[max_index:], epsilon)
+            return left[:-1] + right
+        return [start, end]
+
+    def _resample_points(points, max_points):
+        if max_points <= 0 or len(points) <= max_points:
+            return points[:]
+        if max_points < 2:
+            return points[:1]
+        return [points[int(round(index * (len(points) - 1) / float(max_points - 1)))] for index in range(max_points)]
+
+    def _profile_radius_at(profile, height, interpolation):
+        if height <= profile[0][0]:
+            return profile[0][1]
+        if height >= profile[-1][0]:
+            return profile[-1][1]
+        segment_index = 0
+        for index in range(len(profile) - 1):
+            if profile[index][0] <= height <= profile[index + 1][0]:
+                segment_index = index
+                break
+        h0, r0 = profile[segment_index]
+        h1, r1 = profile[segment_index + 1]
+        t = (height - h0) / max(1e-9, h1 - h0)
+        if interpolation == "linear":
+            return r0 + (r1 - r0) * t
+
+        def _slope(point_index):
+            if point_index <= 0:
+                ha, ra = profile[0]
+                hb, rb = profile[1]
+            elif point_index >= len(profile) - 1:
+                ha, ra = profile[-2]
+                hb, rb = profile[-1]
+            else:
+                ha, ra = profile[point_index - 1]
+                hb, rb = profile[point_index + 1]
+            return (rb - ra) / max(1e-9, hb - ha)
+
+        m0 = _slope(segment_index)
+        m1 = _slope(segment_index + 1)
+        t2 = t * t
+        t3 = t2 * t
+        span = h1 - h0
+        radius_value = (
+            (2.0 * t3 - 3.0 * t2 + 1.0) * r0
+            + (t3 - 2.0 * t2 + t) * span * m0
+            + (-2.0 * t3 + 3.0 * t2) * r1
+            + (t3 - t2) * span * m1
+        )
+        lower = min(r0, r1)
+        upper = max(r0, r1)
+        return max(0.0, min(upper, max(lower, radius_value)))
+
+    def _map_point_to_plane(point):
+        x, y = point
+        u = 0.0 if crop_width == 1 else x / float(crop_width - 1)
+        v = 0.0 if crop_height == 1 else y / float(crop_height - 1)
+        local_a = (u - 0.5) * plane_width
+        local_b = (0.5 - v) * plane_height
+        mapped = center[:]
+        if plane_axis == "z":
+            mapped[0] += local_a
+            mapped[1] += local_b
+        elif plane_axis == "x":
+            mapped[2] += local_a
+            mapped[1] += local_b
+        else:
+            mapped[0] += local_a
+            mapped[2] += local_b
+        return mapped
+
+    def _map_point_to_cylinder(point):
+        x, y = point
+        u = 0.0 if crop_width == 1 else x / float(crop_width - 1)
+        v = 0.0 if crop_height == 1 else y / float(crop_height - 1)
+        axis_value = axis_start + (1.0 - v) * axis_span
+        angle = math.radians(angle_start + angle_span * u)
+        surface_radius = radius
+        if clean_surface_profile is not None:
+            surface_radius = _profile_radius_at(clean_surface_profile, axis_value, profile_interpolation)
+        surface_radius += offset
+        mapped = center[:]
+        mapped[axis_index] = center[axis_index] + axis_value
+        mapped[radial_a] = center[radial_a] + surface_radius * math.sin(angle)
+        mapped[radial_b] = center[radial_b] + surface_radius * math.cos(angle)
+        return mapped
+
+    if not image_path:
+        raise ValueError("image_path is required.")
+    normalized_image_path = os.path.normpath(image_path)
+    if not os.path.isfile(normalized_image_path):
+        raise ValueError(f"Image path does not exist: {image_path}")
+
+    match_mode = match_mode.lower().strip()
+    if match_mode not in {"luminance", "alpha", "rgb", "hue", "foreground"}:
+        raise ValueError("match_mode must be one of luminance, alpha, rgb, hue, or foreground.")
+    component_connectivity = _validate_int(component_connectivity, "component_connectivity", 4)
+    if component_connectivity not in {4, 8}:
+        raise ValueError("component_connectivity must be 4 or 8.")
+    min_component_pixels = _validate_int(min_component_pixels, "min_component_pixels", 1)
+    max_components = _validate_int(max_components, "max_components", 1)
+    min_contour_points = _validate_int(min_contour_points, "min_contour_points", 2)
+    max_points_per_contour = _validate_int(max_points_per_contour, "max_points_per_contour", 0)
+    simplify_tolerance_pixels = _validate_scalar(simplify_tolerance_pixels, "simplify_tolerance_pixels")
+    if simplify_tolerance_pixels < 0.0:
+        raise ValueError("simplify_tolerance_pixels must be greater than or equal to zero.")
+    threshold = _clamp(_validate_scalar(threshold, "threshold"))
+    alpha_threshold = _clamp(_validate_scalar(alpha_threshold, "alpha_threshold"))
+    saturation_min = _clamp(_validate_scalar(saturation_min, "saturation_min"))
+    value_min = _clamp(_validate_scalar(value_min, "value_min"))
+    color_tolerance = _validate_scalar(color_tolerance, "color_tolerance")
+    if color_tolerance > 1.0:
+        color_tolerance /= 255.0
+    color_tolerance = max(0.0, color_tolerance)
+    hue_tolerance = _validate_scalar(hue_tolerance, "hue_tolerance")
+    if hue_tolerance > 1.0:
+        hue_tolerance /= 360.0
+    if hue_tolerance < 0.0 or hue_tolerance > 0.5:
+        raise ValueError("hue_tolerance must be in the 0..0.5 range, or degrees in the 0..180 range.")
+    background_tolerance = _validate_scalar(background_tolerance, "background_tolerance")
+    if background_tolerance > 1.0:
+        background_tolerance /= 255.0
+    background_tolerance = max(0.0, background_tolerance)
+
+    curve_mapping = curve_mapping.lower().strip()
+    if curve_mapping not in {"image_plane", "cylindrical"}:
+        raise ValueError("curve_mapping must be one of image_plane or cylindrical.")
+    center = _validate_vector(center, 3, "center")
+    plane_width = _validate_scalar(plane_width, "plane_width")
+    plane_height = _validate_scalar(plane_height, "plane_height")
+    if plane_width <= 0.0 or plane_height <= 0.0:
+        raise ValueError("plane_width and plane_height must be greater than zero.")
+    plane_axis = plane_axis.lower().strip()
+    if plane_axis not in {"x", "y", "z"}:
+        raise ValueError("plane_axis must be one of x, y, or z.")
+
+    axis = axis.lower().strip()
+    axes = {"x": (0, 1, 2), "y": (1, 0, 2), "z": (2, 0, 1)}
+    if axis not in axes:
+        raise ValueError("axis must be one of x, y, or z.")
+    axis_index, radial_a, radial_b = axes[axis]
+    axis_range = _validate_vector(axis_range, 2, "axis_range")
+    axis_start, axis_end = axis_range
+    if axis_start > axis_end:
+        axis_start, axis_end = axis_end, axis_start
+    axis_span = axis_end - axis_start
+    if axis_span <= 0.0:
+        raise ValueError("axis_range must cover a positive span.")
+    angle_range_degrees = _validate_vector(angle_range_degrees, 2, "angle_range_degrees")
+    angle_start, angle_end = angle_range_degrees
+    angle_span = angle_end - angle_start
+    if abs(angle_span) <= 1e-9:
+        raise ValueError("angle_range_degrees must cover a non-zero span.")
+    radius = _validate_scalar(radius, "radius")
+    offset = _validate_scalar(offset, "offset")
+    if radius <= 0.0 and surface_profile is None:
+        raise ValueError("radius must be greater than zero when surface_profile is not provided.")
+    profile_interpolation = profile_interpolation.lower().strip()
+    if profile_interpolation not in {"linear", "smooth"}:
+        raise ValueError("profile_interpolation must be one of linear or smooth.")
+
+    clean_surface_profile = None
+    if surface_profile is not None:
+        if not isinstance(surface_profile, list) or len(surface_profile) < 2:
+            raise ValueError("surface_profile must contain at least two [height, radius] points.")
+        clean_surface_profile = []
+        previous_height = None
+        for point in surface_profile:
+            height, profile_radius = _validate_vector(point, 2, "surface_profile point")
+            if profile_radius < 0.0:
+                raise ValueError("surface_profile radii must be greater than or equal to zero.")
+            if previous_height is not None and height <= previous_height:
+                raise ValueError("surface_profile heights must be strictly increasing.")
+            clean_surface_profile.append([height, profile_radius])
+            previous_height = height
+
+    clean_target_color = None
+    target_hsv = None
+    if match_mode in {"rgb", "hue"}:
+        if target_color is None:
+            raise ValueError("target_color is required for rgb and hue match modes.")
+        clean_target_color = _normalize_color(target_color, "target_color")
+        target_hsv = _rgb_to_hsv(clean_target_color[0], clean_target_color[1], clean_target_color[2])
+
+    image = QImage(normalized_image_path)
+    if image.isNull():
+        raise ValueError(f"Unable to load image: {image_path}")
+    image_width = image.width()
+    image_height = image.height()
+    if image_width < 2 or image_height < 2:
+        raise ValueError("image must be at least 2x2 pixels.")
+
+    if bbox_pixels is not None and bbox_normalized is not None:
+        raise ValueError("Provide only one of bbox_pixels or bbox_normalized.")
+    if bbox_normalized is not None:
+        bbox = _validate_vector(bbox_normalized, 4, "bbox_normalized")
+        if bbox[2] <= bbox[0] or bbox[3] <= bbox[1]:
+            raise ValueError("bbox_normalized must be [min_x, min_y, max_x, max_y].")
+        x_min = int(round(_clamp(bbox[0]) * (image_width - 1)))
+        y_min = int(round(_clamp(bbox[1]) * (image_height - 1)))
+        x_max = int(round(_clamp(bbox[2]) * (image_width - 1)))
+        y_max = int(round(_clamp(bbox[3]) * (image_height - 1)))
+    elif bbox_pixels is not None:
+        bbox = _validate_vector(bbox_pixels, 4, "bbox_pixels")
+        if bbox[2] <= bbox[0] or bbox[3] <= bbox[1]:
+            raise ValueError("bbox_pixels must be [min_x, min_y, max_x, max_y].")
+        x_min = int(round(bbox[0]))
+        y_min = int(round(bbox[1]))
+        x_max = int(round(bbox[2]))
+        y_max = int(round(bbox[3]))
+    else:
+        x_min, y_min, x_max, y_max = 0, 0, image_width - 1, image_height - 1
+
+    x_min = max(0, min(image_width - 1, x_min))
+    y_min = max(0, min(image_height - 1, y_min))
+    x_max = max(0, min(image_width - 1, x_max))
+    y_max = max(0, min(image_height - 1, y_max))
+    if x_max <= x_min or y_max <= y_min:
+        raise ValueError("Resolved crop bbox is empty.")
+
+    cropped = image.copy(x_min, y_min, x_max - x_min + 1, y_max - y_min + 1)
+    crop_width = cropped.width()
+    crop_height = cropped.height()
+    clean_background_color = _normalize_color(background_color, "background_color") if background_color else _estimate_background(cropped)
+
+    mask = [bytearray(crop_width) for _ in range(crop_height)]
+    matched_pixels = 0
+    for y in range(crop_height):
+        row = mask[y]
+        for x in range(crop_width):
+            red, green, blue, alpha = _pixel_rgb_alpha(cropped, x, y)
+            if alpha < alpha_threshold:
+                continue
+            rgb = [red, green, blue]
+            if match_mode == "alpha":
+                value = alpha
+                is_match = value >= threshold
+            elif match_mode == "luminance":
+                value = 0.2126 * red + 0.7152 * green + 0.0722 * blue
+                is_match = value < threshold if invert else value >= threshold
+            elif match_mode == "foreground":
+                is_match = _color_distance(rgb, clean_background_color) > background_tolerance
+            elif match_mode == "rgb":
+                is_match = _color_distance(rgb, clean_target_color) <= color_tolerance
+            else:
+                hue, saturation, value = _rgb_to_hsv(red, green, blue)
+                is_match = (
+                    _hue_distance(hue, target_hsv[0]) <= hue_tolerance
+                    and saturation >= saturation_min
+                    and value >= value_min
+                )
+            if is_match:
+                row[x] = 1
+                matched_pixels += 1
+
+    visited = [bytearray(crop_width) for _ in range(crop_height)]
+    components = []
+    for y in range(crop_height):
+        for x in range(crop_width):
+            if not mask[y][x] or visited[y][x]:
+                continue
+            stack = [(x, y)]
+            visited[y][x] = 1
+            pixels = []
+            x0 = x1 = x
+            y0 = y1 = y
+            while stack:
+                current_x, current_y = stack.pop()
+                pixels.append((current_x, current_y))
+                x0 = min(x0, current_x)
+                x1 = max(x1, current_x)
+                y0 = min(y0, current_y)
+                y1 = max(y1, current_y)
+                for dx, dy in _component_neighbors():
+                    next_x = current_x + dx
+                    next_y = current_y + dy
+                    if next_x < 0 or next_x >= crop_width or next_y < 0 or next_y >= crop_height:
+                        continue
+                    if visited[next_y][next_x] or not mask[next_y][next_x]:
+                        continue
+                    visited[next_y][next_x] = 1
+                    stack.append((next_x, next_y))
+            if len(pixels) >= min_component_pixels:
+                components.append({"pixels": pixels, "bbox_pixels": [x0, y0, x1, y1], "pixel_count": len(pixels)})
+    components.sort(key=lambda item: item["pixel_count"], reverse=True)
+
+    contours = []
+    for component_index, component in enumerate(components[:max_components]):
+        boundary = []
+        pixel_set = set(component["pixels"])
+        for x, y in component["pixels"]:
+            is_boundary = False
+            for dx, dy in _boundary_neighbors():
+                nx = x + dx
+                ny = y + dy
+                if nx < 0 or nx >= crop_width or ny < 0 or ny >= crop_height or (nx, ny) not in pixel_set:
+                    is_boundary = True
+                    break
+            if is_boundary:
+                boundary.append((float(x), float(y)))
+        if len(boundary) < min_contour_points:
+            continue
+        centroid_x = sum(point[0] for point in boundary) / float(len(boundary))
+        centroid_y = sum(point[1] for point in boundary) / float(len(boundary))
+        boundary.sort(key=lambda point: math.atan2(point[1] - centroid_y, point[0] - centroid_x))
+        simplified = _rdp(boundary, simplify_tolerance_pixels)
+        simplified = _resample_points(simplified, max_points_per_contour)
+        if close_contours and simplified and simplified[0] != simplified[-1]:
+            simplified.append(simplified[0])
+        normalized = [
+            [
+                0.0 if crop_width == 1 else point[0] / float(crop_width - 1),
+                0.0 if crop_height == 1 else point[1] / float(crop_height - 1),
+            ]
+            for point in simplified
+        ]
+        contours.append({
+            "component_index": component_index,
+            "pixel_count": component["pixel_count"],
+            "bbox_pixels": component["bbox_pixels"],
+            "point_count": len(simplified),
+            "points_pixels": [[point[0], point[1]] for point in simplified],
+            "points_normalized": normalized,
+        })
+
+    created_curves = []
+    if create_curves:
+        if not curve_name_prefix:
+            base_name = os.path.splitext(os.path.basename(normalized_image_path))[0] or "image"
+            curve_name_prefix = f"{base_name}_contour"
+        mapper = _map_point_to_cylinder if curve_mapping == "cylindrical" else _map_point_to_plane
+        for contour in contours:
+            if contour["point_count"] < 2:
+                continue
+            world_points = [mapper(point) for point in contour["points_pixels"]]
+            if len(world_points) < 2:
+                continue
+            curve = cmds.curve(
+                name=f"{curve_name_prefix}_{contour['component_index']:02d}",
+                degree=1,
+                point=world_points,
+            )
+            created_curves.append(curve)
+
+    return {
+        "success": True,
+        "image_path": normalized_image_path,
+        "image_width": image_width,
+        "image_height": image_height,
+        "crop_bbox_pixels": [x_min, y_min, x_max, y_max],
+        "crop_width": crop_width,
+        "crop_height": crop_height,
+        "match_mode": match_mode,
+        "matched_pixels": matched_pixels,
+        "component_count": len(components),
+        "contour_count": len(contours),
+        "contours": contours,
+        "create_curves": bool(create_curves),
+        "curve_mapping": curve_mapping,
+        "created_curves": created_curves,
+        "background_color": clean_background_color,
+        "target_color": clean_target_color,
+    }

--- a/src/mayatools/object/extract_image_contours.py
+++ b/src/mayatools/object/extract_image_contours.py
@@ -23,6 +23,12 @@ def extract_image_contours(
     simplify_tolerance_pixels: float = 1.5,
     max_points_per_contour: int = 160,
     close_contours: bool = True,
+    contour_ordering: str = "trace",
+    min_boundary_points: int = 0,
+    min_bbox_width_pixels: int = 0,
+    min_bbox_height_pixels: int = 0,
+    max_bbox_width_pixels: int = 0,
+    max_bbox_height_pixels: int = 0,
     create_curves: bool = False,
     curve_name_prefix: str = None,
     curve_mapping: str = "image_plane",
@@ -42,12 +48,14 @@ def extract_image_contours(
 
     The image region can be segmented by luminance, alpha, RGB color, hue, or
     foreground-vs-background. Connected components are reduced to boundary
-    contours, simplified, and returned in crop-local pixel and normalized
-    coordinates. When requested, contours can be instantiated as generic Maya
-    curves on an image plane or mapped around a cylindrical/lathed surface.
+    contours, simplified, filtered, and returned in crop-local pixel and
+    normalized coordinates. When requested, contours can be instantiated as
+    generic Maya curves on an image plane or mapped around a
+    cylindrical/lathed surface.
     This is useful for decals, relief outlines, molded marks, panel seams,
     engravings, vents, patches, and other reference-derived curve details.
     """
+    from collections import defaultdict
     import math
     import os
     import maya.cmds as cmds
@@ -183,6 +191,123 @@ def extract_image_contours(
             return points[:1]
         return [points[int(round(index * (len(points) - 1) / float(max_points - 1)))] for index in range(max_points)]
 
+    def _point_distance(a, b):
+        return math.hypot(a[0] - b[0], a[1] - b[1])
+
+    def _simplify_ordered_points(points, epsilon, is_closed):
+        if len(points) <= 2 or epsilon <= 0.0:
+            return points[:]
+        if not is_closed or len(points) <= 4:
+            return _rdp(points, epsilon)
+
+        anchor_index = max(range(1, len(points)), key=lambda index: _point_distance(points[0], points[index]))
+        first_half = points[: anchor_index + 1]
+        second_half = points[anchor_index:] + [points[0]]
+        simplified_first = _rdp(first_half, epsilon)
+        simplified_second = _rdp(second_half, epsilon)
+        return simplified_first[:-1] + simplified_second[:-1]
+
+    def _component_boundary_points(pixel_set):
+        boundary_points = []
+        for x, y in pixel_set:
+            for dx, dy in _boundary_neighbors():
+                if (x + dx, y + dy) not in pixel_set:
+                    boundary_points.append((float(x), float(y)))
+                    break
+        return boundary_points
+
+    def _sort_boundary_by_angle(boundary):
+        centroid_x = sum(point[0] for point in boundary) / float(len(boundary))
+        centroid_y = sum(point[1] for point in boundary) / float(len(boundary))
+        return sorted(boundary, key=lambda point: math.atan2(point[1] - centroid_y, point[0] - centroid_x))
+
+    def _vertex_to_pixel_point(vertex):
+        x, y = vertex
+        return (
+            max(0.0, min(float(crop_width - 1), float(x) - 0.5)),
+            max(0.0, min(float(crop_height - 1), float(y) - 0.5)),
+        )
+
+    def _add_boundary_edge(edges, start, end):
+        edges.append((start, end))
+
+    def _boundary_edges_from_pixels(pixel_set):
+        edges = []
+        for x, y in pixel_set:
+            if (x, y - 1) not in pixel_set:
+                _add_boundary_edge(edges, (x, y), (x + 1, y))
+            if (x + 1, y) not in pixel_set:
+                _add_boundary_edge(edges, (x + 1, y), (x + 1, y + 1))
+            if (x, y + 1) not in pixel_set:
+                _add_boundary_edge(edges, (x + 1, y + 1), (x, y + 1))
+            if (x - 1, y) not in pixel_set:
+                _add_boundary_edge(edges, (x, y + 1), (x, y))
+        return edges
+
+    def _edge_key(edge):
+        return (edge[0][1], edge[0][0], edge[1][1], edge[1][0])
+
+    def _choose_next_edge(previous_vertex, current_vertex, candidate_edges):
+        prev_dx = current_vertex[0] - previous_vertex[0]
+        prev_dy = current_vertex[1] - previous_vertex[1]
+
+        def _score(edge):
+            next_vertex = edge[1]
+            next_dx = next_vertex[0] - current_vertex[0]
+            next_dy = next_vertex[1] - current_vertex[1]
+            dot = prev_dx * next_dx + prev_dy * next_dy
+            cross = prev_dx * next_dy - prev_dy * next_dx
+            turn_rank = 0 if cross > 0 else 1 if dot > 0 else 2 if cross == 0 else 3
+            return (turn_rank, -dot, _edge_key(edge))
+
+        return min(candidate_edges, key=_score)
+
+    def _trace_boundary_chains(pixel_set):
+        edges = _boundary_edges_from_pixels(pixel_set)
+        edges_by_start = defaultdict(list)
+        for edge in edges:
+            edges_by_start[edge[0]].append(edge)
+        for start in edges_by_start:
+            edges_by_start[start].sort(key=_edge_key)
+
+        unused_edges = set(edges)
+        chains = []
+        while unused_edges:
+            start_edge = min(unused_edges, key=_edge_key)
+            unused_edges.remove(start_edge)
+            chain_vertices = [start_edge[0], start_edge[1]]
+            previous_vertex, current_vertex = start_edge
+            is_closed = False
+
+            while current_vertex != chain_vertices[0]:
+                candidates = [edge for edge in edges_by_start.get(current_vertex, []) if edge in unused_edges]
+                if not candidates:
+                    break
+                next_edge = _choose_next_edge(previous_vertex, current_vertex, candidates)
+                unused_edges.remove(next_edge)
+                previous_vertex, current_vertex = next_edge
+                chain_vertices.append(current_vertex)
+
+            if current_vertex == chain_vertices[0]:
+                is_closed = True
+
+            points = []
+            for vertex in chain_vertices:
+                point = _vertex_to_pixel_point(vertex)
+                if not points or points[-1] != point:
+                    points.append(point)
+            if is_closed and points and points[0] != points[-1]:
+                points.append(points[0])
+            chains.append({"points": points, "is_closed": is_closed})
+
+        chains.sort(key=lambda item: len(item["points"]), reverse=True)
+        return chains
+
+    def _contour_bbox(points):
+        x_values = [point[0] for point in points]
+        y_values = [point[1] for point in points]
+        return [min(x_values), min(y_values), max(x_values), max(y_values)]
+
     def _profile_radius_at(profile, height, interpolation):
         if height <= profile[0][0]:
             return profile[0][1]
@@ -276,9 +401,21 @@ def extract_image_contours(
     max_components = _validate_int(max_components, "max_components", 1)
     min_contour_points = _validate_int(min_contour_points, "min_contour_points", 2)
     max_points_per_contour = _validate_int(max_points_per_contour, "max_points_per_contour", 0)
+    min_boundary_points = _validate_int(min_boundary_points, "min_boundary_points", 0)
+    min_bbox_width_pixels = _validate_int(min_bbox_width_pixels, "min_bbox_width_pixels", 0)
+    min_bbox_height_pixels = _validate_int(min_bbox_height_pixels, "min_bbox_height_pixels", 0)
+    max_bbox_width_pixels = _validate_int(max_bbox_width_pixels, "max_bbox_width_pixels", 0)
+    max_bbox_height_pixels = _validate_int(max_bbox_height_pixels, "max_bbox_height_pixels", 0)
+    if max_bbox_width_pixels > 0 and min_bbox_width_pixels > max_bbox_width_pixels:
+        raise ValueError("min_bbox_width_pixels cannot be greater than max_bbox_width_pixels.")
+    if max_bbox_height_pixels > 0 and min_bbox_height_pixels > max_bbox_height_pixels:
+        raise ValueError("min_bbox_height_pixels cannot be greater than max_bbox_height_pixels.")
     simplify_tolerance_pixels = _validate_scalar(simplify_tolerance_pixels, "simplify_tolerance_pixels")
     if simplify_tolerance_pixels < 0.0:
         raise ValueError("simplify_tolerance_pixels must be greater than or equal to zero.")
+    contour_ordering = contour_ordering.lower().strip()
+    if contour_ordering not in {"trace", "angle"}:
+        raise ValueError("contour_ordering must be one of trace or angle.")
     threshold = _clamp(_validate_scalar(threshold, "threshold"))
     alpha_threshold = _clamp(_validate_scalar(alpha_threshold, "alpha_threshold"))
     saturation_min = _clamp(_validate_scalar(saturation_min, "saturation_min"))
@@ -430,6 +567,7 @@ def extract_image_contours(
 
     visited = [bytearray(crop_width) for _ in range(crop_height)]
     components = []
+    raw_component_count = 0
     for y in range(crop_height):
         for x in range(crop_width):
             if not mask[y][x] or visited[y][x]:
@@ -456,47 +594,69 @@ def extract_image_contours(
                     visited[next_y][next_x] = 1
                     stack.append((next_x, next_y))
             if len(pixels) >= min_component_pixels:
-                components.append({"pixels": pixels, "bbox_pixels": [x0, y0, x1, y1], "pixel_count": len(pixels)})
+                raw_component_count += 1
+                bbox_width = x1 - x0 + 1
+                bbox_height = y1 - y0 + 1
+                if bbox_width < min_bbox_width_pixels or bbox_height < min_bbox_height_pixels:
+                    continue
+                if max_bbox_width_pixels > 0 and bbox_width > max_bbox_width_pixels:
+                    continue
+                if max_bbox_height_pixels > 0 and bbox_height > max_bbox_height_pixels:
+                    continue
+                components.append({
+                    "pixels": pixels,
+                    "bbox_pixels": [x0, y0, x1, y1],
+                    "bbox_size_pixels": [bbox_width, bbox_height],
+                    "pixel_count": len(pixels),
+                })
     components.sort(key=lambda item: item["pixel_count"], reverse=True)
 
     contours = []
     for component_index, component in enumerate(components[:max_components]):
-        boundary = []
         pixel_set = set(component["pixels"])
-        for x, y in component["pixels"]:
-            is_boundary = False
-            for dx, dy in _boundary_neighbors():
-                nx = x + dx
-                ny = y + dy
-                if nx < 0 or nx >= crop_width or ny < 0 or ny >= crop_height or (nx, ny) not in pixel_set:
-                    is_boundary = True
-                    break
-            if is_boundary:
-                boundary.append((float(x), float(y)))
-        if len(boundary) < min_contour_points:
+        boundary = _component_boundary_points(pixel_set)
+        if len(boundary) < min_contour_points or len(boundary) < min_boundary_points:
             continue
-        centroid_x = sum(point[0] for point in boundary) / float(len(boundary))
-        centroid_y = sum(point[1] for point in boundary) / float(len(boundary))
-        boundary.sort(key=lambda point: math.atan2(point[1] - centroid_y, point[0] - centroid_x))
-        simplified = _rdp(boundary, simplify_tolerance_pixels)
-        simplified = _resample_points(simplified, max_points_per_contour)
-        if close_contours and simplified and simplified[0] != simplified[-1]:
-            simplified.append(simplified[0])
-        normalized = [
-            [
-                0.0 if crop_width == 1 else point[0] / float(crop_width - 1),
-                0.0 if crop_height == 1 else point[1] / float(crop_height - 1),
+
+        if contour_ordering == "angle":
+            raw_chains = [{"points": _sort_boundary_by_angle(boundary), "is_closed": True}]
+        else:
+            raw_chains = _trace_boundary_chains(pixel_set)
+
+        for chain_index, chain in enumerate(raw_chains):
+            raw_points = chain["points"]
+            if len(raw_points) < min_contour_points:
+                continue
+            is_closed = bool(chain["is_closed"])
+            working_points = raw_points[:-1] if is_closed and raw_points[0] == raw_points[-1] else raw_points[:]
+            if len(working_points) < min_contour_points:
+                continue
+            simplified = _simplify_ordered_points(working_points, simplify_tolerance_pixels, is_closed)
+            simplified = _resample_points(simplified, max_points_per_contour)
+            should_close = close_contours and (is_closed or contour_ordering == "angle")
+            if should_close and simplified and simplified[0] != simplified[-1]:
+                simplified.append(simplified[0])
+            normalized = [
+                [
+                    0.0 if crop_width == 1 else point[0] / float(crop_width - 1),
+                    0.0 if crop_height == 1 else point[1] / float(crop_height - 1),
+                ]
+                for point in simplified
             ]
-            for point in simplified
-        ]
-        contours.append({
-            "component_index": component_index,
-            "pixel_count": component["pixel_count"],
-            "bbox_pixels": component["bbox_pixels"],
-            "point_count": len(simplified),
-            "points_pixels": [[point[0], point[1]] for point in simplified],
-            "points_normalized": normalized,
-        })
+            contours.append({
+                "component_index": component_index,
+                "chain_index": chain_index,
+                "pixel_count": component["pixel_count"],
+                "boundary_point_count": len(boundary),
+                "raw_chain_point_count": len(raw_points),
+                "bbox_pixels": component["bbox_pixels"],
+                "bbox_size_pixels": component["bbox_size_pixels"],
+                "contour_bbox_pixels": _contour_bbox(simplified),
+                "is_closed": is_closed,
+                "point_count": len(simplified),
+                "points_pixels": [[point[0], point[1]] for point in simplified],
+                "points_normalized": normalized,
+            })
 
     created_curves = []
     if create_curves:
@@ -511,7 +671,7 @@ def extract_image_contours(
             if len(world_points) < 2:
                 continue
             curve = cmds.curve(
-                name=f"{curve_name_prefix}_{contour['component_index']:02d}",
+                name=f"{curve_name_prefix}_{contour['component_index']:02d}_{contour['chain_index']:02d}",
                 degree=1,
                 point=world_points,
             )
@@ -527,7 +687,9 @@ def extract_image_contours(
         "crop_height": crop_height,
         "match_mode": match_mode,
         "matched_pixels": matched_pixels,
+        "raw_component_count": raw_component_count,
         "component_count": len(components),
+        "contour_ordering": contour_ordering,
         "contour_count": len(contours),
         "contours": contours,
         "create_curves": bool(create_curves),

--- a/src/mayatools/object/extract_revolved_profile_from_image.py
+++ b/src/mayatools/object/extract_revolved_profile_from_image.py
@@ -1,0 +1,279 @@
+from typing import Dict, List, Any
+
+
+def extract_revolved_profile_from_image(
+    image_path: str,
+    target_height: float = 1.0,
+    height_samples: int = 64,
+    background_color: List[float] = None,
+    background_tolerance: float = 0.06,
+    alpha_threshold: float = 0.05,
+    crop: List[float] = [0.0, 0.0, 1.0, 1.0],
+    axis_x: float = None,
+    side: str = "both",
+    smoothing_window: int = 3,
+    min_row_pixels: int = 2,
+    radius_scale: float = 1.0,
+    radius_offset: float = 0.0,
+    create_profile_curve: bool = False,
+    curve_name: str = None,
+    center: List[float] = [0.0, 0.0, 0.0],
+) -> Dict[str, Any]:
+    """Extract a lathe-ready radius/height profile from a product silhouette image.
+
+    The image is segmented by comparing pixels against a background color. If no
+    background_color is provided, it is estimated from the crop corners. Explicit
+    background_color values may be provided in either 0..1 or 0..255 range. The
+    returned profile is ordered bottom-to-top as [height, radius] points, making
+    it directly usable with create_revolved_mesh, create_revolved_shell, and
+    create_textured_label surface_profile.
+    """
+    import os
+    import maya.cmds as cmds
+
+    try:
+        from PySide6.QtGui import QImage
+    except Exception:
+        try:
+            from PySide2.QtGui import QImage
+        except Exception as exc:
+            raise RuntimeError("PySide QImage is required to read image pixels in Maya.") from exc
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(v) for v in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(value) for value in values]
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _clamp(value, lower, upper):
+        return max(lower, min(upper, value))
+
+    def _pixel_rgb_alpha(image, x, y):
+        color = image.pixelColor(int(x), int(y))
+        return (
+            color.redF(),
+            color.greenF(),
+            color.blueF(),
+            color.alphaF(),
+        )
+
+    def _color_distance(color_a, color_b):
+        dr = color_a[0] - color_b[0]
+        dg = color_a[1] - color_b[1]
+        db = color_a[2] - color_b[2]
+        return (dr * dr + dg * dg + db * db) ** 0.5
+
+    def _estimate_background(image, x_min, y_min, x_max, y_max):
+        sample_points = []
+        inset_x = max(1, int((x_max - x_min) * 0.03))
+        inset_y = max(1, int((y_max - y_min) * 0.03))
+        corners = [
+            (x_min + inset_x, y_min + inset_y),
+            (x_max - inset_x, y_min + inset_y),
+            (x_min + inset_x, y_max - inset_y),
+            (x_max - inset_x, y_max - inset_y),
+        ]
+        radius = max(1, min(inset_x, inset_y, 8))
+        for corner_x, corner_y in corners:
+            for dy in range(-radius, radius + 1):
+                for dx in range(-radius, radius + 1):
+                    x = int(_clamp(corner_x + dx, x_min, x_max))
+                    y = int(_clamp(corner_y + dy, y_min, y_max))
+                    sample_points.append(_pixel_rgb_alpha(image, x, y)[:3])
+        if not sample_points:
+            return [1.0, 1.0, 1.0]
+        channels = []
+        for index in range(3):
+            values = sorted(point[index] for point in sample_points)
+            channels.append(values[len(values) // 2])
+        return channels
+
+    def _moving_average(values, window):
+        if window <= 1:
+            return values[:]
+        half = window // 2
+        smoothed = []
+        for index in range(len(values)):
+            start = max(0, index - half)
+            end = min(len(values), index + half + 1)
+            smoothed.append(sum(values[start:end]) / float(end - start))
+        return smoothed
+
+    if not image_path:
+        raise ValueError("image_path is required.")
+    normalized_image_path = os.path.normpath(image_path)
+    if not os.path.isfile(normalized_image_path):
+        raise ValueError(f"Image path does not exist: {image_path}")
+    target_height = _validate_scalar(target_height, "target_height")
+    if target_height <= 0.0:
+        raise ValueError("target_height must be greater than zero.")
+    if not isinstance(height_samples, int) or isinstance(height_samples, bool) or height_samples < 2:
+        raise ValueError("height_samples must be an integer greater than or equal to 2.")
+    background_tolerance = _validate_scalar(background_tolerance, "background_tolerance")
+    if background_tolerance < 0.0:
+        raise ValueError("background_tolerance must be greater than or equal to zero.")
+    alpha_threshold = _validate_scalar(alpha_threshold, "alpha_threshold")
+    if alpha_threshold < 0.0 or alpha_threshold > 1.0:
+        raise ValueError("alpha_threshold must be in the 0..1 range.")
+    crop = _validate_vector(crop, 4, "crop")
+    if crop[2] <= crop[0] or crop[3] <= crop[1]:
+        raise ValueError("crop must be [min_x, min_y, max_x, max_y] in normalized image coordinates.")
+    crop = [_clamp(value, 0.0, 1.0) for value in crop]
+    if crop[2] <= crop[0] or crop[3] <= crop[1]:
+        raise ValueError("crop must define a non-empty normalized region.")
+    if axis_x is not None:
+        axis_x = _validate_scalar(axis_x, "axis_x")
+        if axis_x < 0.0 or axis_x > 1.0:
+            raise ValueError("axis_x must be None or a normalized 0..1 image coordinate.")
+    side = side.lower().strip()
+    if side not in {"both", "left", "right"}:
+        raise ValueError("side must be one of both, left, or right.")
+    if not isinstance(smoothing_window, int) or isinstance(smoothing_window, bool) or smoothing_window < 1:
+        raise ValueError("smoothing_window must be an integer greater than or equal to 1.")
+    if smoothing_window % 2 == 0:
+        smoothing_window += 1
+    if not isinstance(min_row_pixels, int) or isinstance(min_row_pixels, bool) or min_row_pixels < 1:
+        raise ValueError("min_row_pixels must be an integer greater than or equal to 1.")
+    radius_scale = _validate_scalar(radius_scale, "radius_scale")
+    radius_offset = _validate_scalar(radius_offset, "radius_offset")
+    center = _validate_vector(center, 3, "center")
+
+    image = QImage(normalized_image_path)
+    if image.isNull():
+        raise ValueError(f"Unable to load image: {image_path}")
+    image_width = image.width()
+    image_height = image.height()
+    if image_width < 2 or image_height < 2:
+        raise ValueError("image must be at least 2x2 pixels.")
+
+    x_min = int(round(crop[0] * (image_width - 1)))
+    y_min = int(round(crop[1] * (image_height - 1)))
+    x_max = int(round(crop[2] * (image_width - 1)))
+    y_max = int(round(crop[3] * (image_height - 1)))
+    x_min = max(0, min(image_width - 1, x_min))
+    x_max = max(0, min(image_width - 1, x_max))
+    y_min = max(0, min(image_height - 1, y_min))
+    y_max = max(0, min(image_height - 1, y_max))
+
+    if background_color is None:
+        clean_background_color = _estimate_background(image, x_min, y_min, x_max, y_max)
+    else:
+        clean_background_color = _validate_vector(background_color, 3, "background_color")
+        if max(clean_background_color) > 1.0:
+            clean_background_color = [value / 255.0 for value in clean_background_color]
+        clean_background_color = [_clamp(value, 0.0, 1.0) for value in clean_background_color]
+
+    foreground_rows = {}
+    foreground_count = 0
+    foreground_bbox = None
+    for y in range(y_min, y_max + 1):
+        row_xs = []
+        for x in range(x_min, x_max + 1):
+            red, green, blue, alpha = _pixel_rgb_alpha(image, x, y)
+            if alpha < alpha_threshold:
+                continue
+            if _color_distance([red, green, blue], clean_background_color) <= background_tolerance:
+                continue
+            row_xs.append(x)
+        if len(row_xs) >= min_row_pixels:
+            foreground_rows[y] = row_xs
+            foreground_count += len(row_xs)
+            row_min = min(row_xs)
+            row_max = max(row_xs)
+            if foreground_bbox is None:
+                foreground_bbox = [row_min, y, row_max, y]
+            else:
+                foreground_bbox[0] = min(foreground_bbox[0], row_min)
+                foreground_bbox[1] = min(foreground_bbox[1], y)
+                foreground_bbox[2] = max(foreground_bbox[2], row_max)
+                foreground_bbox[3] = max(foreground_bbox[3], y)
+
+    if foreground_bbox is None:
+        raise ValueError("No foreground silhouette pixels were found. Adjust crop, background_color, or background_tolerance.")
+
+    if axis_x is None:
+        axis_x_pixels = (foreground_bbox[0] + foreground_bbox[2]) * 0.5
+    else:
+        axis_x_pixels = axis_x * (image_width - 1)
+
+    foreground_height_pixels = max(1.0, float(foreground_bbox[3] - foreground_bbox[1]))
+    raw_heights = []
+    raw_radii = []
+    source_rows = []
+    band_radius = max(0, int(round((foreground_bbox[3] - foreground_bbox[1]) / max(1.0, height_samples * 2.0))))
+    for sample_index in range(height_samples):
+        t = sample_index / float(height_samples - 1)
+        source_y = foreground_bbox[3] - t * (foreground_bbox[3] - foreground_bbox[1])
+        row_radius_values = []
+        for row_y in range(int(round(source_y)) - band_radius, int(round(source_y)) + band_radius + 1):
+            if row_y not in foreground_rows:
+                continue
+            row_xs = foreground_rows[row_y]
+            left_x = min(row_xs)
+            right_x = max(row_xs)
+            if side == "left":
+                radius_pixels = max(0.0, axis_x_pixels - left_x)
+            elif side == "right":
+                radius_pixels = max(0.0, right_x - axis_x_pixels)
+            else:
+                radius_pixels = (max(0.0, axis_x_pixels - left_x) + max(0.0, right_x - axis_x_pixels)) * 0.5
+            row_radius_values.append(radius_pixels)
+        if not row_radius_values:
+            if raw_radii:
+                height = t * target_height
+                raw_heights.append(height)
+                raw_radii.append(raw_radii[-1])
+                source_rows.append(int(round(source_y)))
+                continue
+            else:
+                radius_pixels = 0.0
+        else:
+            row_radius_values = sorted(row_radius_values)
+            radius_pixels = row_radius_values[len(row_radius_values) // 2]
+        height = t * target_height
+        radius = radius_pixels / foreground_height_pixels * target_height
+        raw_heights.append(height)
+        raw_radii.append(max(0.0, radius * radius_scale + radius_offset))
+        source_rows.append(int(round(source_y)))
+
+    smoothed_radii = _moving_average(raw_radii, smoothing_window)
+    profile = []
+    for height, radius in zip(raw_heights, smoothed_radii):
+        profile.append([height, max(0.0, radius)])
+
+    created_curve = None
+    if create_profile_curve:
+        if curve_name is None:
+            base_name = os.path.splitext(os.path.basename(normalized_image_path))[0] or "image"
+            curve_name = f"{base_name}_silhouette_profile_curve"
+        points = [[center[0] + radius, center[1] + height, center[2]] for height, radius in profile]
+        created_curve = cmds.curve(name=curve_name, degree=1, point=points)
+
+    return {
+        "success": True,
+        "image_path": normalized_image_path,
+        "image_width": image_width,
+        "image_height": image_height,
+        "crop_pixels": [x_min, y_min, x_max, y_max],
+        "background_color": clean_background_color,
+        "background_tolerance": background_tolerance,
+        "foreground_count": foreground_count,
+        "foreground_bbox_pixels": foreground_bbox,
+        "axis_x_pixels": axis_x_pixels,
+        "side": side,
+        "target_height": target_height,
+        "height_samples": height_samples,
+        "smoothing_window": smoothing_window,
+        "radius_scale": radius_scale,
+        "radius_offset": radius_offset,
+        "profile": profile,
+        "source_rows": source_rows,
+        "created_curve": created_curve,
+    }

--- a/src/mayatools/object/fit_objects_to_bounds.py
+++ b/src/mayatools/object/fit_objects_to_bounds.py
@@ -1,0 +1,237 @@
+from typing import Dict, List, Any, Union
+
+
+def fit_objects_to_bounds(
+    object_names: Union[str, List[str]],
+    target_bounds: List[float] = None,
+    target_center: List[float] = None,
+    target_size: List[float] = None,
+    axes: List[str] = None,
+    scale_mode: str = "independent",
+    anchor: str = "center",
+    pivot: List[float] = None,
+    apply_mode: str = "points",
+    min_size: float = 1e-6,
+) -> Dict[str, Any]:
+    """Fit one or more scene objects to target world-space bounds.
+
+    This is a generic bounds-fitting utility for resizing and positioning
+    separate parts, labels, panels, cards, props, fixtures, and other geometry.
+    It computes scale and translation from the current combined bounding box to
+    a target bounding box or target center/size.
+
+    With apply_mode="points", mesh vertices and curve CVs are transformed in
+    world space. This preserves transform channels and is useful for fitted
+    geometry layers. With apply_mode="transform", object transforms are moved
+    and scaled, which is useful for simple transform-level fitting.
+
+    scale_mode:
+    - independent: scale each fitted axis independently.
+    - uniform_fit: use the smallest fitted-axis scale on all fitted axes.
+    - uniform_fill: use the largest fitted-axis scale on all fitted axes.
+
+    anchor controls post-scale alignment to the target bounds: center, min, or
+    max. Axes omitted from axes are left unchanged.
+    """
+    import maya.cmds as cmds
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(value) for value in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(value) for value in values]
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _combined_bbox(objects):
+        bbox = None
+        for obj in objects:
+            obj_bbox = cmds.exactWorldBoundingBox(obj)
+            if bbox is None:
+                bbox = obj_bbox[:]
+            else:
+                bbox[0] = min(bbox[0], obj_bbox[0])
+                bbox[1] = min(bbox[1], obj_bbox[1])
+                bbox[2] = min(bbox[2], obj_bbox[2])
+                bbox[3] = max(bbox[3], obj_bbox[3])
+                bbox[4] = max(bbox[4], obj_bbox[4])
+                bbox[5] = max(bbox[5], obj_bbox[5])
+        return bbox
+
+    def _bbox_center_size(bbox):
+        center = [
+            (bbox[0] + bbox[3]) * 0.5,
+            (bbox[1] + bbox[4]) * 0.5,
+            (bbox[2] + bbox[5]) * 0.5,
+        ]
+        size = [
+            bbox[3] - bbox[0],
+            bbox[4] - bbox[1],
+            bbox[5] - bbox[2],
+        ]
+        return center, size
+
+    def _target_bbox():
+        if target_bounds is not None:
+            bounds = _validate_vector(target_bounds, 6, "target_bounds")
+            if bounds[3] < bounds[0] or bounds[4] < bounds[1] or bounds[5] < bounds[2]:
+                raise ValueError("target_bounds must be [min_x, min_y, min_z, max_x, max_y, max_z].")
+            return bounds
+        if target_center is None or target_size is None:
+            raise ValueError("Provide target_bounds or both target_center and target_size.")
+        center = _validate_vector(target_center, 3, "target_center")
+        size = _validate_vector(target_size, 3, "target_size")
+        if any(value < 0.0 for value in size):
+            raise ValueError("target_size values must be greater than or equal to zero.")
+        return [
+            center[0] - size[0] * 0.5,
+            center[1] - size[1] * 0.5,
+            center[2] - size[2] * 0.5,
+            center[0] + size[0] * 0.5,
+            center[1] + size[1] * 0.5,
+            center[2] + size[2] * 0.5,
+        ]
+
+    def _object_components(obj):
+        components = []
+        if cmds.objectType(obj) == "mesh":
+            components.extend(cmds.ls(f"{obj}.vtx[*]", flatten=True) or [])
+        else:
+            shapes = cmds.listRelatives(obj, shapes=True, fullPath=True) or []
+            for shape in shapes:
+                shape_type = cmds.objectType(shape)
+                if shape_type == "mesh":
+                    components.extend(cmds.ls(f"{shape}.vtx[*]", flatten=True) or [])
+                elif shape_type in {"nurbsCurve", "bezierCurve"}:
+                    components.extend(cmds.ls(f"{shape}.cv[*]", flatten=True) or [])
+        return components
+
+    def _scale_translate_for_bbox(source_bbox, target_bbox, fit_axes):
+        source_center, source_size = _bbox_center_size(source_bbox)
+        target_center_value, target_size_value = _bbox_center_size(target_bbox)
+        scales = [1.0, 1.0, 1.0]
+        for index in fit_axes:
+            if source_size[index] <= min_size:
+                scales[index] = 1.0
+            else:
+                scales[index] = target_size_value[index] / source_size[index]
+        if scale_mode != "independent" and fit_axes:
+            axis_scales = [scales[index] for index in fit_axes]
+            uniform = min(axis_scales) if scale_mode == "uniform_fit" else max(axis_scales)
+            for index in fit_axes:
+                scales[index] = uniform
+
+        scale_pivot = clean_pivot or source_center
+        scaled_min = []
+        scaled_max = []
+        for index in range(3):
+            scaled_min.append(scale_pivot[index] + (source_bbox[index] - scale_pivot[index]) * scales[index])
+            scaled_max.append(scale_pivot[index] + (source_bbox[index + 3] - scale_pivot[index]) * scales[index])
+
+        translation = [0.0, 0.0, 0.0]
+        for index in fit_axes:
+            if anchor == "min":
+                translation[index] = target_bbox[index] - scaled_min[index]
+            elif anchor == "max":
+                translation[index] = target_bbox[index + 3] - scaled_max[index]
+            else:
+                scaled_center = (scaled_min[index] + scaled_max[index]) * 0.5
+                translation[index] = target_center_value[index] - scaled_center
+        return scales, translation, scale_pivot
+
+    if isinstance(object_names, str):
+        objects = [object_names]
+    elif isinstance(object_names, list) and object_names and all(isinstance(obj, str) for obj in object_names):
+        objects = object_names[:]
+    else:
+        raise ValueError("object_names must be a string or a non-empty list of strings.")
+
+    for obj in objects:
+        if not cmds.objExists(obj):
+            raise ValueError(f"Object does not exist: {obj}")
+
+    axis_lookup = {"x": 0, "y": 1, "z": 2}
+    if axes is None:
+        axes = ["x", "y", "z"]
+    if isinstance(axes, str):
+        axes = [axes]
+    if not isinstance(axes, list) or not axes:
+        raise ValueError("axes must be a non-empty list containing x, y, and/or z.")
+    fit_axes = []
+    for axis in axes:
+        axis = axis.lower().strip()
+        if axis not in axis_lookup:
+            raise ValueError("axes must contain only x, y, or z.")
+        fit_axes.append(axis_lookup[axis])
+    fit_axes = sorted(set(fit_axes))
+
+    scale_mode = scale_mode.lower().strip()
+    if scale_mode not in {"independent", "uniform_fit", "uniform_fill"}:
+        raise ValueError("scale_mode must be independent, uniform_fit, or uniform_fill.")
+    anchor = anchor.lower().strip()
+    if anchor not in {"center", "min", "max"}:
+        raise ValueError("anchor must be center, min, or max.")
+    apply_mode = apply_mode.lower().strip()
+    if apply_mode not in {"points", "transform"}:
+        raise ValueError("apply_mode must be points or transform.")
+    min_size = _validate_scalar(min_size, "min_size")
+    if min_size < 0.0:
+        raise ValueError("min_size must be greater than or equal to zero.")
+
+    clean_pivot = _validate_vector(pivot, 3, "pivot") if pivot is not None else None
+    target_bbox = _target_bbox()
+    source_bbox = _combined_bbox(objects)
+    scales, translation, scale_pivot = _scale_translate_for_bbox(source_bbox, target_bbox, fit_axes)
+
+    transformed_points = 0
+    transformed_objects = 0
+    if apply_mode == "points":
+        for obj in objects:
+            components = _object_components(obj)
+            if not components:
+                raise ValueError(f"No supported mesh vertices or curve CVs found on {obj}.")
+            for component in components:
+                position = cmds.xform(component, query=True, worldSpace=True, translation=True)
+                for index in fit_axes:
+                    position[index] = scale_pivot[index] + (position[index] - scale_pivot[index]) * scales[index] + translation[index]
+                cmds.xform(component, worldSpace=True, translation=position)
+                transformed_points += 1
+            transformed_objects += 1
+            if cmds.objExists(obj):
+                try:
+                    cmds.polySoftEdge(obj, angle=180, constructionHistory=False)
+                except Exception:
+                    pass
+    else:
+        for obj in objects:
+            current_scale = list(cmds.getAttr(f"{obj}.scale")[0])
+            current_position = cmds.xform(obj, query=True, worldSpace=True, translation=True)
+            for index in fit_axes:
+                current_scale[index] *= scales[index]
+                current_position[index] = scale_pivot[index] + (current_position[index] - scale_pivot[index]) * scales[index] + translation[index]
+            cmds.setAttr(f"{obj}.scale", current_scale[0], current_scale[1], current_scale[2], type="double3")
+            cmds.xform(obj, worldSpace=True, translation=current_position)
+            transformed_objects += 1
+
+    final_bbox = _combined_bbox(objects)
+    return {
+        "success": True,
+        "object_names": objects,
+        "apply_mode": apply_mode,
+        "axes": axes,
+        "scale_mode": scale_mode,
+        "anchor": anchor,
+        "source_bounds": source_bbox,
+        "target_bounds": target_bbox,
+        "final_bounds": final_bbox,
+        "scale": scales,
+        "translation": translation,
+        "pivot": scale_pivot,
+        "transformed_objects": transformed_objects,
+        "transformed_points": transformed_points,
+    }

--- a/src/mayatools/object/get_node_connections.py
+++ b/src/mayatools/object/get_node_connections.py
@@ -1,0 +1,77 @@
+from typing import Any, Dict, List
+
+
+def get_node_connections(
+    node_name: str,
+    attribute_name: str = None,
+    source: bool = True,
+    destination: bool = True,
+    plugs: bool = True,
+    connections: bool = True,
+    skip_conversion_nodes: bool = False,
+) -> Dict[str, Any]:
+    """Inspect dependency-graph connections for a Maya node or attribute.
+
+    This is a generic debugging utility for materials, textures, deformers,
+    constraints, utility nodes, and other Maya dependency-graph networks. When
+    attribute_name is provided, only that plug is inspected; otherwise all
+    visible connections on the node are returned.
+    """
+    import maya.cmds as cmds
+
+    if not node_name:
+        raise ValueError("node_name is required.")
+    if not cmds.objExists(node_name):
+        raise ValueError(f"Node does not exist: {node_name}")
+
+    target = node_name
+    if attribute_name:
+        if not cmds.attributeQuery(attribute_name, node=node_name, exists=True):
+            raise ValueError(f"Attribute {attribute_name} does not exist on {node_name}")
+        target = f"{node_name}.{attribute_name}"
+
+    raw = cmds.listConnections(
+        target,
+        source=bool(source),
+        destination=bool(destination),
+        plugs=bool(plugs),
+        connections=bool(connections),
+        skipConversionNodes=bool(skip_conversion_nodes),
+    ) or []
+
+    pairs: List[Dict[str, Any]] = []
+    if connections:
+        for index in range(0, len(raw), 2):
+            local_plug = raw[index]
+            connected_plug = raw[index + 1] if index + 1 < len(raw) else None
+            connected_node = connected_plug.split(".", 1)[0] if isinstance(connected_plug, str) else None
+            pairs.append(
+                {
+                    "plug": local_plug,
+                    "connected_plug": connected_plug,
+                    "connected_node": connected_node,
+                }
+            )
+    else:
+        for item in raw:
+            connected_node = item.split(".", 1)[0] if isinstance(item, str) else item
+            pairs.append(
+                {
+                    "connected_plug": item,
+                    "connected_node": connected_node,
+                }
+            )
+
+    return {
+        "success": True,
+        "node_name": node_name,
+        "attribute_name": attribute_name,
+        "target": target,
+        "source": bool(source),
+        "destination": bool(destination),
+        "plugs": bool(plugs),
+        "connections": bool(connections),
+        "skip_conversion_nodes": bool(skip_conversion_nodes),
+        "connection_count": len(pairs),
+        "connections_list": pairs,
+    }

--- a/src/mayatools/object/get_object_bounds.py
+++ b/src/mayatools/object/get_object_bounds.py
@@ -1,0 +1,92 @@
+from typing import Dict, List, Any, Union
+
+
+def get_object_bounds(
+    object_names: Union[str, List[str]],
+    visible_only: bool = False,
+) -> Dict[str, Any]:
+    """Return world-space bounds for one or more scene objects.
+
+    This is a generic measurement utility for modeling and layout workflows. It
+    reports each object's exact world-space bounding box, plus the combined
+    bounds, center, and size for the requested set. The output can be used to
+    fit parts, map image/profile measurements onto geometry, or validate object
+    placement without relying on ad hoc Maya scripts.
+    """
+    import maya.cmds as cmds
+
+    if isinstance(object_names, str):
+        objects = [object_names]
+    elif isinstance(object_names, list) and object_names and all(isinstance(obj, str) for obj in object_names):
+        objects = object_names[:]
+    else:
+        raise ValueError("object_names must be a string or a non-empty list of strings.")
+
+    def _is_visible(node):
+        current = node
+        while current:
+            try:
+                if cmds.attributeQuery("visibility", node=current, exists=True) and not cmds.getAttr(f"{current}.visibility"):
+                    return False
+            except Exception:
+                pass
+            parents = cmds.listRelatives(current, parent=True, fullPath=True) or []
+            current = parents[0] if parents else None
+        return True
+
+    def _center_size(bounds):
+        center = [
+            (bounds[0] + bounds[3]) * 0.5,
+            (bounds[1] + bounds[4]) * 0.5,
+            (bounds[2] + bounds[5]) * 0.5,
+        ]
+        size = [
+            bounds[3] - bounds[0],
+            bounds[4] - bounds[1],
+            bounds[5] - bounds[2],
+        ]
+        return center, size
+
+    item_bounds = []
+    combined_bounds = None
+    skipped_hidden = []
+    for obj in objects:
+        if not cmds.objExists(obj):
+            raise ValueError(f"Object does not exist: {obj}")
+        if visible_only and not _is_visible(obj):
+            skipped_hidden.append(obj)
+            continue
+
+        bounds = [float(value) for value in cmds.exactWorldBoundingBox(obj)]
+        center, size = _center_size(bounds)
+        item_bounds.append({
+            "object_name": obj,
+            "bounds": bounds,
+            "center": center,
+            "size": size,
+        })
+
+        if combined_bounds is None:
+            combined_bounds = bounds[:]
+        else:
+            combined_bounds[0] = min(combined_bounds[0], bounds[0])
+            combined_bounds[1] = min(combined_bounds[1], bounds[1])
+            combined_bounds[2] = min(combined_bounds[2], bounds[2])
+            combined_bounds[3] = max(combined_bounds[3], bounds[3])
+            combined_bounds[4] = max(combined_bounds[4], bounds[4])
+            combined_bounds[5] = max(combined_bounds[5], bounds[5])
+
+    if combined_bounds is None:
+        raise ValueError("No visible objects remain after filtering.")
+
+    combined_center, combined_size = _center_size(combined_bounds)
+    return {
+        "success": True,
+        "object_names": objects,
+        "visible_only": bool(visible_only),
+        "skipped_hidden": skipped_hidden,
+        "objects": item_bounds,
+        "combined_bounds": combined_bounds,
+        "combined_center": combined_center,
+        "combined_size": combined_size,
+    }

--- a/src/mayatools/object/insert_mesh_support_loop.py
+++ b/src/mayatools/object/insert_mesh_support_loop.py
@@ -1,0 +1,314 @@
+from typing import Dict, List, Any, Union
+
+
+def insert_mesh_support_loop(
+    object_name: str,
+    component_type: str = "edge",
+    indices: List[int] = None,
+    components: Union[str, List[str]] = None,
+    expand: str = "edge_ring",
+    axis: str = None,
+    target_value: float = None,
+    offset: float = 0.0,
+    position_mode: str = "centered",
+    insert_with_edge_flow: bool = False,
+    adjust_edge_flow: float = 0.0,
+    construction_history: bool = False,
+    space: str = "world",
+    use_selection: bool = True,
+    select_result: bool = True,
+    result_type: str = "vertex",
+    max_preview: int = 100,
+) -> Dict[str, Any]:
+    """Insert one support loop from seed edges and report the new components.
+
+    Position modes:
+    - centered: keep Maya's inserted loop at the default connected position
+    - axis_value: move the new vertices to target_value along axis
+    - axis_offset: add offset to the new vertices along axis
+
+    This wraps Maya's component-level edge-ring connect operation for common
+    artist modeling work: adding a support loop, immediately selecting the new
+    loop, and optionally aligning it to a precise coordinate for lips, seams,
+    shoulder breaks, panel borders, hard-surface bevel support, or gridded mesh
+    cleanup.
+    """
+    import re
+    import maya.cmds as cmds
+    import maya.api.OpenMaya as om
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return int(value)
+
+    def _axis_index(axis_name):
+        clean_axis = (axis_name or "").lower().strip()
+        if clean_axis not in {"x", "y", "z"}:
+            raise ValueError("axis must be x, y, or z.")
+        return {"x": 0, "y": 1, "z": 2}[clean_axis]
+
+    def _mesh_shape(node):
+        if not cmds.objExists(node):
+            raise ValueError(f"Object does not exist: {node}")
+        if cmds.objectType(node) == "mesh":
+            return node
+        shapes = cmds.listRelatives(node, shapes=True, fullPath=True) or []
+        mesh_shapes = []
+        for shape in shapes:
+            if cmds.objectType(shape) != "mesh":
+                continue
+            try:
+                if cmds.attributeQuery("intermediateObject", node=shape, exists=True) and cmds.getAttr(f"{shape}.intermediateObject"):
+                    continue
+            except Exception:
+                pass
+            mesh_shapes.append(shape)
+        if not mesh_shapes:
+            raise ValueError(f"{node} is not a polygon mesh transform or mesh shape.")
+        return mesh_shapes[0]
+
+    def _dag_path(shape):
+        selection = om.MSelectionList()
+        selection.add(shape)
+        return selection.getDagPath(0)
+
+    def _prefix(shape):
+        parents = cmds.listRelatives(shape, parent=True, fullPath=False) or []
+        return parents[0] if parents else object_name
+
+    def _flatten(value):
+        if value is None:
+            return []
+        if isinstance(value, str):
+            value = [value]
+        if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+            raise ValueError("components must be a string, a list of strings, or None.")
+        return cmds.ls(value, flatten=True) or []
+
+    def _components_from_indices(kind):
+        if indices is None:
+            return []
+        if not isinstance(indices, list) or not all(isinstance(index, int) and not isinstance(index, bool) for index in indices):
+            raise ValueError("indices must be a list of integers.")
+        return [f"{prefix_name}.{kind}[{index}]" for index in indices]
+
+    def _selected_components():
+        if not use_selection:
+            return []
+        selected = cmds.ls(selection=True, flatten=True) or []
+        object_tokens = {object_name, prefix_name, shape_name}
+        return [item for item in selected if item.split(".", 1)[0] in object_tokens]
+
+    def _resolve_edges():
+        clean_type = component_type.lower().strip()
+        kind_map = {"vertex": "vtx", "edge": "e", "face": "f", "uv": "map", "vertex_face": "vtxFace"}
+        if components is not None:
+            resolved = _flatten(components)
+        elif clean_type in kind_map and indices is not None:
+            resolved = _components_from_indices(kind_map[clean_type])
+        else:
+            resolved = _selected_components()
+        if not resolved:
+            raise ValueError("No components resolved from components, indices, or current selection.")
+        edges = cmds.polyListComponentConversion(resolved, toEdge=True) or []
+        edges = cmds.ls(edges, flatten=True) or []
+        if not edges:
+            raise ValueError("Support loop insertion requires edge components or components convertible to edges.")
+        return _unique(edges)
+
+    def _unique(items):
+        seen = set()
+        result = []
+        for item in cmds.ls(items, flatten=True) or []:
+            if item in seen:
+                continue
+            seen.add(item)
+            result.append(item)
+        return result
+
+    def _component_ids(items, kind):
+        pattern = re.compile(rf"\.{kind}\[(\d+)\]$")
+        ids = []
+        for item in cmds.ls(items, flatten=True) or []:
+            match = pattern.search(item)
+            if match:
+                ids.append(int(match.group(1)))
+        return list(dict.fromkeys(ids))
+
+    def _expanded_edges(edge_items):
+        clean_expand = expand.lower().strip()
+        if clean_expand == "none":
+            return edge_items
+        flag_map = {
+            "edge_ring": "edgeRing",
+            "edge_loop": "edgeLoop",
+            "edge_loop_or_border": "edgeLoopOrBorder",
+            "edge_border": "edgeBorder",
+        }
+        if clean_expand not in flag_map:
+            raise ValueError("expand must be none, edge_ring, edge_loop, edge_loop_or_border, or edge_border.")
+        edge_ids = _component_ids(edge_items, "e")
+        results = []
+        for edge_id in edge_ids:
+            output = cmds.polySelect(
+                object_name,
+                asSelectString=True,
+                noSelection=True,
+                **{flag_map[clean_expand]: int(edge_id)},
+            ) or []
+            results.extend(output)
+        expanded = _unique(results)
+        return expanded or edge_items
+
+    def _counts():
+        return {
+            "vertices": int(cmds.polyEvaluate(object_name, vertex=True)),
+            "edges": int(cmds.polyEvaluate(object_name, edge=True)),
+            "faces": int(cmds.polyEvaluate(object_name, face=True)),
+        }
+
+    def _point_values(point):
+        return [float(point.x), float(point.y), float(point.z)]
+
+    def _set_new_vertex_positions(vertex_ids):
+        if clean_position_mode == "centered":
+            return []
+        axis_idx = _axis_index(axis)
+        points = mesh_fn.getPoints(om_space)
+        before_after = []
+        for vertex_id in vertex_ids:
+            before = _point_values(points[vertex_id])
+            after = before[:]
+            if clean_position_mode == "axis_value":
+                after[axis_idx] = clean_target_value
+            else:
+                after[axis_idx] += clean_offset
+            points[vertex_id] = om.MPoint(after[0], after[1], after[2])
+            before_after.append(
+                {
+                    "index": vertex_id,
+                    "component": f"{prefix_name}.vtx[{vertex_id}]",
+                    "before": before,
+                    "after": after,
+                }
+            )
+        mesh_fn.setPoints(points, om_space)
+        try:
+            mesh_fn.updateSurface()
+        except Exception:
+            pass
+        return before_after
+
+    def _components_from_range(kind, start, end):
+        if end <= start:
+            return []
+        return [f"{prefix_name}.{kind}[{index}]" for index in range(start, end)]
+
+    def _select_components(items):
+        if items:
+            cmds.select(items, replace=True)
+        elif result_type.lower().strip() == "vertex":
+            cmds.select(clear=True)
+
+    if not object_name:
+        raise ValueError("object_name is required.")
+    clean_position_mode = position_mode.lower().strip()
+    if clean_position_mode not in {"centered", "axis_value", "axis_offset"}:
+        raise ValueError("position_mode must be centered, axis_value, or axis_offset.")
+    if clean_position_mode in {"axis_value", "axis_offset"} and axis is None:
+        raise ValueError("axis is required when position_mode is axis_value or axis_offset.")
+    clean_target_value = _validate_scalar(target_value, "target_value") if clean_position_mode == "axis_value" else None
+    clean_offset = _validate_scalar(offset, "offset")
+    adjust_edge_flow = _validate_scalar(adjust_edge_flow, "adjust_edge_flow")
+    max_preview = _validate_int(max_preview, "max_preview", 1)
+    clean_result_type = result_type.lower().strip()
+    if clean_result_type not in {"vertex", "edge", "face"}:
+        raise ValueError("result_type must be vertex, edge, or face.")
+    space = space.lower().strip()
+    if space not in {"world", "object"}:
+        raise ValueError("space must be world or object.")
+
+    shape_name = _mesh_shape(object_name)
+    prefix_name = _prefix(shape_name)
+    dag_path = _dag_path(shape_name)
+    mesh_fn = om.MFnMesh(dag_path)
+    om_space = om.MSpace.kWorld if space == "world" else om.MSpace.kObject
+    before = _counts()
+
+    seed_edges = _resolve_edges()
+    target_edges = _expanded_edges(seed_edges)
+    if len(target_edges) < 2:
+        raise ValueError("At least two resolved edges are required to insert a support loop.")
+
+    old_selection = cmds.ls(selection=True, flatten=True) or []
+    cmds.select(target_edges, replace=True)
+    try:
+        node = cmds.polyConnectComponents(
+            constructionHistory=construction_history,
+            insertWithEdgeFlow=bool(insert_with_edge_flow),
+            adjustEdgeFlow=adjust_edge_flow,
+        )
+    finally:
+        if old_selection:
+            cmds.select(old_selection, replace=True)
+        else:
+            cmds.select(clear=True)
+
+    after = _counts()
+    if after["vertices"] <= before["vertices"] or after["edges"] <= before["edges"] or after["faces"] <= before["faces"]:
+        raise RuntimeError("Support loop insertion did not change mesh topology.")
+
+    new_vertex_ids = list(range(before["vertices"], after["vertices"]))
+    new_vertices = _components_from_range("vtx", before["vertices"], after["vertices"])
+    new_edges = _components_from_range("e", before["edges"], after["edges"])
+    new_faces = _components_from_range("f", before["faces"], after["faces"])
+    moved_records = _set_new_vertex_positions(new_vertex_ids)
+
+    selection_items = {"vertex": new_vertices, "edge": new_edges, "face": new_faces}[clean_result_type]
+    if select_result:
+        _select_components(selection_items)
+
+    return {
+        "success": True,
+        "object_name": object_name,
+        "shape_name": shape_name,
+        "operation": "insert_mesh_support_loop",
+        "node": node,
+        "component_type": component_type,
+        "expand": expand.lower().strip(),
+        "seed_edge_count": len(seed_edges),
+        "target_edge_count": len(target_edges),
+        "seed_edges_preview": seed_edges[:max_preview],
+        "target_edges_preview": target_edges[:max_preview],
+        "insert_with_edge_flow": bool(insert_with_edge_flow),
+        "adjust_edge_flow": adjust_edge_flow,
+        "position_mode": clean_position_mode,
+        "axis": axis.lower().strip() if axis else None,
+        "target_value": clean_target_value,
+        "offset": clean_offset,
+        "space": space,
+        "counts_before": before,
+        "counts_after": after,
+        "new_vertex_count": len(new_vertices),
+        "new_edge_count": len(new_edges),
+        "new_face_count": len(new_faces),
+        "new_vertices": new_vertices[:max_preview],
+        "new_edges": new_edges[:max_preview],
+        "new_faces": new_faces[:max_preview],
+        "new_vertices_truncated": len(new_vertices) > max_preview,
+        "new_edges_truncated": len(new_edges) > max_preview,
+        "new_faces_truncated": len(new_faces) > max_preview,
+        "position_changes": moved_records[:max_preview],
+        "position_changes_truncated": len(moved_records) > max_preview,
+        "selected": bool(select_result),
+        "result_type": clean_result_type if select_result else None,
+    }

--- a/src/mayatools/object/inspect_mesh_components.py
+++ b/src/mayatools/object/inspect_mesh_components.py
@@ -1,0 +1,264 @@
+from typing import Dict, List, Any, Union
+
+
+def inspect_mesh_components(
+    object_name: str,
+    component_type: str = "summary",
+    indices: List[int] = None,
+    components: Union[str, List[str]] = None,
+    max_items: int = 100,
+    space: str = "world",
+    include_positions: bool = True,
+    include_normals: bool = True,
+    include_topology: bool = True,
+    include_uvs: bool = False,
+    uv_set: str = None,
+) -> Dict[str, Any]:
+    """Inspect polygon mesh components at vertex, edge, face, UV, or summary level.
+
+    This is a generic component-level query tool for Maya-style modeling. It
+    reports mesh counts and can inspect selected or indexed vertices, edges,
+    faces, and UVs with world/object positions, normals, topology, centers, and
+    optional UV assignments. Use it before localized edits so component IDs,
+    coordinates, face centers, and edge/vertex relationships are explicit.
+    """
+    import re
+    import maya.cmds as cmds
+    import maya.api.OpenMaya as om
+
+    def _is_int(value):
+        return isinstance(value, int) and not isinstance(value, bool)
+
+    def _validate_int(value, arg_name, minimum):
+        if not _is_int(value) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return value
+
+    def _mesh_shape(node):
+        if not cmds.objExists(node):
+            raise ValueError(f"Object does not exist: {node}")
+        if cmds.objectType(node) == "mesh":
+            return node
+        shapes = cmds.listRelatives(node, shapes=True, fullPath=True) or []
+        mesh_shapes = []
+        for shape in shapes:
+            if cmds.objectType(shape) != "mesh":
+                continue
+            try:
+                if cmds.attributeQuery("intermediateObject", node=shape, exists=True) and cmds.getAttr(f"{shape}.intermediateObject"):
+                    continue
+            except Exception:
+                pass
+            mesh_shapes.append(shape)
+        if not mesh_shapes:
+            raise ValueError(f"{node} is not a polygon mesh transform or mesh shape.")
+        return mesh_shapes[0]
+
+    def _mesh_fn(shape):
+        selection = om.MSelectionList()
+        selection.add(shape)
+        return om.MFnMesh(selection.getDagPath(0))
+
+    def _component_prefix():
+        parents = cmds.listRelatives(shape_name, parent=True, fullPath=False) or []
+        return parents[0] if parents else object_name
+
+    def _flatten_components(value):
+        if value is None:
+            return []
+        if isinstance(value, str):
+            value = [value]
+        if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+            raise ValueError("components must be a string, a list of strings, or None.")
+        return cmds.ls(value, flatten=True) or []
+
+    def _indices_from_components(kind, value):
+        pattern = re.compile(rf"\.{kind}\[(\d+)\]$")
+        found = []
+        for component in _flatten_components(value):
+            match = pattern.search(component)
+            if match:
+                found.append(int(match.group(1)))
+        return found
+
+    def _component_indices(kind, count):
+        if indices is not None:
+            if not isinstance(indices, list) or not all(_is_int(index) for index in indices):
+                raise ValueError("indices must be a list of integers.")
+            clean = list(dict.fromkeys(indices))
+        elif components is not None:
+            clean = _indices_from_components(kind, components)
+        else:
+            selected = cmds.ls(selection=True, flatten=True) or []
+            clean = _indices_from_components(kind, selected)
+        for index in clean:
+            if index < 0 or index >= count:
+                raise ValueError(f"{kind}[{index}] is out of range 0..{count - 1}.")
+        return clean[:max_items]
+
+    def _component_id_list(items, kind):
+        pattern = re.compile(rf"\.{kind}\[(\d+)\]$")
+        ids = []
+        for item in cmds.ls(items, flatten=True) or []:
+            match = pattern.search(item)
+            if match:
+                ids.append(int(match.group(1)))
+        return sorted(set(ids))
+
+    def _point_list(points, index):
+        point = points[index]
+        return [float(point.x), float(point.y), float(point.z)]
+
+    def _vector_list(vector):
+        return [float(vector.x), float(vector.y), float(vector.z)]
+
+    def _face_center(points, face_vertices):
+        center = [0.0, 0.0, 0.0]
+        for vertex_id in face_vertices:
+            point = points[vertex_id]
+            center[0] += point.x
+            center[1] += point.y
+            center[2] += point.z
+        count = float(max(1, len(face_vertices)))
+        return [center[0] / count, center[1] / count, center[2] / count]
+
+    def _uv_values_for_face(face_id, face_vertices):
+        if not include_uvs:
+            return None
+        face_uvs = []
+        for local_index, vertex_id in enumerate(face_vertices):
+            try:
+                uv_id = mesh_fn.getPolygonUVid(face_id, local_index, clean_uv_set)
+                u_value, v_value = mesh_fn.getUV(uv_id, clean_uv_set)
+                face_uvs.append({"vertex_index": vertex_id, "uv_index": uv_id, "uv": [float(u_value), float(v_value)]})
+            except Exception:
+                face_uvs.append({"vertex_index": vertex_id, "uv_index": None, "uv": None})
+        return face_uvs
+
+    if not object_name:
+        raise ValueError("object_name is required.")
+    component_type = component_type.lower().strip()
+    if component_type not in {"summary", "vertex", "edge", "face", "uv", "selection"}:
+        raise ValueError("component_type must be summary, vertex, edge, face, uv, or selection.")
+    max_items = _validate_int(max_items, "max_items", 1)
+    space = space.lower().strip()
+    if space not in {"world", "object"}:
+        raise ValueError("space must be world or object.")
+    om_space = om.MSpace.kWorld if space == "world" else om.MSpace.kObject
+
+    shape_name = _mesh_shape(object_name)
+    mesh_fn = _mesh_fn(shape_name)
+    prefix = _component_prefix()
+    points = mesh_fn.getPoints(om_space)
+    clean_uv_set = uv_set or (mesh_fn.currentUVSetName() if mesh_fn.numUVs() else None)
+
+    counts = {
+        "vertices": int(mesh_fn.numVertices),
+        "edges": int(mesh_fn.numEdges),
+        "faces": int(mesh_fn.numPolygons),
+        "uvs": int(mesh_fn.numUVs(clean_uv_set)) if clean_uv_set else 0,
+    }
+
+    result = {
+        "success": True,
+        "object_name": object_name,
+        "shape_name": shape_name,
+        "component_type": component_type,
+        "space": space,
+        "counts": counts,
+        "uv_sets": list(mesh_fn.getUVSetNames()),
+        "uv_set": clean_uv_set,
+    }
+
+    if component_type == "summary":
+        result["bounding_box"] = cmds.exactWorldBoundingBox(object_name)
+        return result
+
+    if component_type == "selection":
+        selection = cmds.ls(selection=True, flatten=True) or []
+        result["selection"] = selection[:max_items]
+        result["selection_count"] = len(selection)
+        return result
+
+    if component_type == "vertex":
+        vertex_indices = _component_indices("vtx", counts["vertices"])
+        items = []
+        for vertex_id in vertex_indices:
+            item = {"index": vertex_id, "component": f"{prefix}.vtx[{vertex_id}]"}
+            if include_positions:
+                item["position"] = _point_list(points, vertex_id)
+            if include_normals:
+                try:
+                    item["normal"] = _vector_list(mesh_fn.getVertexNormal(vertex_id, True, om_space))
+                except Exception:
+                    item["normal"] = None
+            if include_topology:
+                vertex_component = f"{prefix}.vtx[{vertex_id}]"
+                item["connected_edges"] = _component_id_list(
+                    cmds.polyListComponentConversion(vertex_component, fromVertex=True, toEdge=True) or [],
+                    "e",
+                )
+                item["connected_faces"] = _component_id_list(
+                    cmds.polyListComponentConversion(vertex_component, fromVertex=True, toFace=True) or [],
+                    "f",
+                )
+            items.append(item)
+        result["vertices"] = items
+        result["returned_count"] = len(items)
+        return result
+
+    if component_type == "edge":
+        edge_indices = _component_indices("e", counts["edges"])
+        items = []
+        for edge_id in edge_indices:
+            vertices = list(mesh_fn.getEdgeVertices(edge_id))
+            item = {"index": edge_id, "component": f"{prefix}.e[{edge_id}]"}
+            if include_topology:
+                item["vertices"] = vertices
+                item["connected_faces"] = _component_id_list(
+                    cmds.polyListComponentConversion(f"{prefix}.e[{edge_id}]", fromEdge=True, toFace=True) or [],
+                    "f",
+                )
+            if include_positions:
+                item["points"] = [_point_list(points, vertex_id) for vertex_id in vertices]
+                item["center"] = _face_center(points, vertices)
+            items.append(item)
+        result["edges"] = items
+        result["returned_count"] = len(items)
+        return result
+
+    if component_type == "face":
+        face_indices = _component_indices("f", counts["faces"])
+        items = []
+        for face_id in face_indices:
+            vertices = list(mesh_fn.getPolygonVertices(face_id))
+            item = {"index": face_id, "component": f"{prefix}.f[{face_id}]"}
+            if include_topology:
+                item["vertices"] = vertices
+            if include_positions:
+                item["center"] = _face_center(points, vertices)
+                item["points"] = [_point_list(points, vertex_id) for vertex_id in vertices]
+            if include_normals:
+                try:
+                    item["normal"] = _vector_list(mesh_fn.getPolygonNormal(face_id, om_space))
+                except Exception:
+                    item["normal"] = None
+            if include_uvs:
+                item["uvs"] = _uv_values_for_face(face_id, vertices)
+            items.append(item)
+        result["faces"] = items
+        result["returned_count"] = len(items)
+        return result
+
+    uv_indices = _component_indices("map", counts["uvs"])
+    items = []
+    for uv_id in uv_indices:
+        try:
+            u_value, v_value = mesh_fn.getUV(uv_id, clean_uv_set)
+            uv_value = [float(u_value), float(v_value)]
+        except Exception:
+            uv_value = None
+        items.append({"index": uv_id, "component": f"{prefix}.map[{uv_id}]", "uv": uv_value})
+    result["uvs"] = items
+    result["returned_count"] = len(items)
+    return result

--- a/src/mayatools/object/inspect_mesh_quality.py
+++ b/src/mayatools/object/inspect_mesh_quality.py
@@ -1,0 +1,272 @@
+from typing import Dict, List, Any
+
+
+def inspect_mesh_quality(
+    object_name: str,
+    operation: str = "inspect",
+    issue_types: List[str] = None,
+    area_epsilon: float = 1.0e-8,
+    high_valence_threshold: int = 8,
+    select_components: bool = False,
+    max_items: int = 200,
+) -> Dict[str, Any]:
+    """Inspect polygon mesh quality and optionally select problem components.
+
+    Reported issue types:
+    - border_edges: boundary/open edges
+    - nonmanifold_edges, nonmanifold_vertices, lamina_faces
+    - invalid_edges, invalid_vertices
+    - triangles, ngons
+    - zero_area_faces, zero_uv_area_faces
+    - isolated_vertices
+    - high_valence_vertices
+
+    Use this after component-level modeling edits to catch topology problems
+    before they become shading, UV, bridge, bevel, or shrinkwrap failures.
+    """
+    import re
+    import maya.cmds as cmds
+    import maya.api.OpenMaya as om
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return int(value)
+
+    def _mesh_shape(node):
+        if not cmds.objExists(node):
+            raise ValueError(f"Object does not exist: {node}")
+        if cmds.objectType(node) == "mesh":
+            return node
+        shapes = cmds.listRelatives(node, shapes=True, fullPath=True) or []
+        mesh_shapes = []
+        for shape in shapes:
+            if cmds.objectType(shape) != "mesh":
+                continue
+            try:
+                if cmds.attributeQuery("intermediateObject", node=shape, exists=True) and cmds.getAttr(f"{shape}.intermediateObject"):
+                    continue
+            except Exception:
+                pass
+            mesh_shapes.append(shape)
+        if not mesh_shapes:
+            raise ValueError(f"{node} is not a polygon mesh transform or mesh shape.")
+        return mesh_shapes[0]
+
+    def _prefix(shape):
+        parents = cmds.listRelatives(shape, parent=True, fullPath=False) or []
+        return parents[0] if parents else object_name
+
+    def _mesh_dag(shape):
+        selection = om.MSelectionList()
+        selection.add(shape)
+        return selection.getDagPath(0)
+
+    def _flatten_components(items):
+        if not items:
+            return []
+        return cmds.ls(items, flatten=True) or []
+
+    def _poly_info_components(flag_name):
+        flag_map = {
+            "nonmanifold_edges": {"nonManifoldEdges": True},
+            "nonmanifold_vertices": {"nonManifoldVertices": True},
+            "lamina_faces": {"laminaFaces": True},
+            "invalid_edges": {"invalidEdges": True},
+            "invalid_vertices": {"invalidVertices": True},
+        }
+        lines = cmds.polyInfo(object_name, **flag_map[flag_name]) or []
+        raw_components = []
+        for line in lines:
+            raw_components.extend(re.findall(r"\S+\.(?:e|f|vtx)\[\d+(?::\d+)?\]", line))
+        return _flatten_components(raw_components)
+
+    def _issue_record(components, extra_records=None):
+        clean_components = list(dict.fromkeys(components))
+        return {
+            "count": len(clean_components),
+            "components": clean_components[:max_items],
+            "truncated": len(clean_components) > max_items,
+            "records": (extra_records or [])[:max_items],
+        }
+
+    def _component(name, kind, index):
+        return f"{prefix_name}.{kind}[{index}]"
+
+    if not object_name:
+        raise ValueError("object_name is required.")
+    operation = operation.lower().strip()
+    if operation not in {"inspect", "select"}:
+        raise ValueError("operation must be inspect or select.")
+    area_epsilon = _validate_scalar(area_epsilon, "area_epsilon")
+    if area_epsilon < 0.0:
+        raise ValueError("area_epsilon must be greater than or equal to zero.")
+    high_valence_threshold = _validate_int(high_valence_threshold, "high_valence_threshold", 1)
+    max_items = _validate_int(max_items, "max_items", 1)
+
+    all_issue_types = [
+        "border_edges",
+        "nonmanifold_edges",
+        "nonmanifold_vertices",
+        "lamina_faces",
+        "invalid_edges",
+        "invalid_vertices",
+        "triangles",
+        "ngons",
+        "zero_area_faces",
+        "zero_uv_area_faces",
+        "isolated_vertices",
+        "high_valence_vertices",
+    ]
+    if issue_types is None:
+        clean_issue_types = all_issue_types
+    else:
+        if not isinstance(issue_types, list) or not all(isinstance(item, str) for item in issue_types):
+            raise ValueError("issue_types must be a list of strings or None.")
+        clean_issue_types = [item.lower().strip() for item in issue_types]
+        unknown = sorted(set(clean_issue_types) - set(all_issue_types))
+        if unknown:
+            raise ValueError(f"Unknown issue_types: {unknown}.")
+
+    shape_name = _mesh_shape(object_name)
+    prefix_name = _prefix(shape_name)
+    dag_path = _mesh_dag(shape_name)
+    mesh_fn = om.MFnMesh(dag_path)
+
+    counts = {
+        "vertices": int(mesh_fn.numVertices),
+        "edges": int(mesh_fn.numEdges),
+        "faces": int(mesh_fn.numPolygons),
+        "uvs": int(mesh_fn.numUVs(mesh_fn.currentUVSetName())) if mesh_fn.numUVs() else 0,
+        "triangles": int(cmds.polyEvaluate(object_name, triangle=True)),
+        "shells": int(cmds.polyEvaluate(object_name, shell=True)),
+    }
+
+    issues = {}
+
+    if "border_edges" in clean_issue_types:
+        edge_it = om.MItMeshEdge(dag_path)
+        components = []
+        records = []
+        while not edge_it.isDone():
+            if edge_it.onBoundary():
+                edge_id = int(edge_it.index())
+                faces = list(edge_it.getConnectedFaces())
+                components.append(_component(prefix_name, "e", edge_id))
+                records.append({"component": _component(prefix_name, "e", edge_id), "connected_faces": [int(face) for face in faces]})
+            edge_it.next()
+        issues["border_edges"] = _issue_record(components, records)
+
+    for poly_info_type in ["nonmanifold_edges", "nonmanifold_vertices", "lamina_faces", "invalid_edges", "invalid_vertices"]:
+        if poly_info_type in clean_issue_types:
+            issues[poly_info_type] = _issue_record(_poly_info_components(poly_info_type))
+
+    polygon_it = om.MItMeshPolygon(dag_path)
+    triangle_components = []
+    ngon_components = []
+    zero_area_components = []
+    zero_uv_area_components = []
+    triangle_records = []
+    ngon_records = []
+    zero_area_records = []
+    zero_uv_records = []
+    while not polygon_it.isDone():
+        face_id = int(polygon_it.index())
+        face_component = _component(prefix_name, "f", face_id)
+        vertex_count = int(polygon_it.polygonVertexCount())
+        area = float(polygon_it.getArea(om.MSpace.kWorld))
+        if "triangles" in clean_issue_types and vertex_count == 3:
+            triangle_components.append(face_component)
+            triangle_records.append({"component": face_component, "vertex_count": vertex_count, "area": area})
+        if "ngons" in clean_issue_types and vertex_count > 4:
+            ngon_components.append(face_component)
+            ngon_records.append({"component": face_component, "vertex_count": vertex_count, "area": area})
+        if "zero_area_faces" in clean_issue_types and (area <= area_epsilon or polygon_it.zeroArea()):
+            zero_area_components.append(face_component)
+            zero_area_records.append({"component": face_component, "vertex_count": vertex_count, "area": area})
+        if "zero_uv_area_faces" in clean_issue_types:
+            try:
+                zero_uv = bool(polygon_it.zeroUVArea())
+            except Exception:
+                zero_uv = False
+            if zero_uv:
+                zero_uv_area_components.append(face_component)
+                zero_uv_records.append({"component": face_component, "vertex_count": vertex_count})
+        polygon_it.next()
+
+    if "triangles" in clean_issue_types:
+        issues["triangles"] = _issue_record(triangle_components, triangle_records)
+    if "ngons" in clean_issue_types:
+        issues["ngons"] = _issue_record(ngon_components, ngon_records)
+    if "zero_area_faces" in clean_issue_types:
+        issues["zero_area_faces"] = _issue_record(zero_area_components, zero_area_records)
+    if "zero_uv_area_faces" in clean_issue_types:
+        issues["zero_uv_area_faces"] = _issue_record(zero_uv_area_components, zero_uv_records)
+
+    if "isolated_vertices" in clean_issue_types or "high_valence_vertices" in clean_issue_types:
+        vertex_it = om.MItMeshVertex(dag_path)
+        isolated_components = []
+        high_valence_components = []
+        isolated_records = []
+        high_valence_records = []
+        while not vertex_it.isDone():
+            vertex_id = int(vertex_it.index())
+            component = _component(prefix_name, "vtx", vertex_id)
+            connected_edges = list(vertex_it.getConnectedEdges())
+            connected_faces = list(vertex_it.getConnectedFaces())
+            edge_count = int(vertex_it.numConnectedEdges())
+            face_count = int(vertex_it.numConnectedFaces())
+            if "isolated_vertices" in clean_issue_types and edge_count == 0 and face_count == 0:
+                isolated_components.append(component)
+                isolated_records.append({"component": component, "connected_edges": 0, "connected_faces": 0})
+            if "high_valence_vertices" in clean_issue_types and edge_count > high_valence_threshold:
+                high_valence_components.append(component)
+                high_valence_records.append(
+                    {
+                        "component": component,
+                        "connected_edge_count": edge_count,
+                        "connected_face_count": face_count,
+                        "connected_edges": [int(edge) for edge in connected_edges],
+                        "connected_faces": [int(face) for face in connected_faces],
+                    }
+                )
+            vertex_it.next()
+        if "isolated_vertices" in clean_issue_types:
+            issues["isolated_vertices"] = _issue_record(isolated_components, isolated_records)
+        if "high_valence_vertices" in clean_issue_types:
+            issues["high_valence_vertices"] = _issue_record(high_valence_components, high_valence_records)
+
+    summary = {issue_type: issues[issue_type]["count"] for issue_type in issues}
+    selected = []
+    if operation == "select" or select_components:
+        for issue_type in clean_issue_types:
+            if issue_type in issues:
+                selected.extend(issues[issue_type]["components"])
+        selected = list(dict.fromkeys(selected))
+        if selected:
+            cmds.select(selected, replace=True)
+        else:
+            cmds.select(clear=True)
+
+    return {
+        "success": True,
+        "object_name": object_name,
+        "shape_name": shape_name,
+        "operation": operation,
+        "counts": counts,
+        "area_epsilon": area_epsilon,
+        "high_valence_threshold": high_valence_threshold,
+        "issue_types": clean_issue_types,
+        "summary": summary,
+        "issues": issues,
+        "selected_count": len(selected),
+        "selected_preview": selected[:max_items],
+    }

--- a/src/mayatools/object/inspect_mesh_quality.py
+++ b/src/mayatools/object/inspect_mesh_quality.py
@@ -6,6 +6,8 @@ def inspect_mesh_quality(
     operation: str = "inspect",
     issue_types: List[str] = None,
     area_epsilon: float = 1.0e-8,
+    edge_length_epsilon: float = 1.0e-5,
+    face_aspect_threshold: float = 20.0,
     high_valence_threshold: int = 8,
     select_components: bool = False,
     max_items: int = 200,
@@ -18,6 +20,7 @@ def inspect_mesh_quality(
     - invalid_edges, invalid_vertices
     - triangles, ngons
     - zero_area_faces, zero_uv_area_faces
+    - short_edges, skinny_faces
     - isolated_vertices
     - high_valence_vertices
 
@@ -109,6 +112,12 @@ def inspect_mesh_quality(
     area_epsilon = _validate_scalar(area_epsilon, "area_epsilon")
     if area_epsilon < 0.0:
         raise ValueError("area_epsilon must be greater than or equal to zero.")
+    edge_length_epsilon = _validate_scalar(edge_length_epsilon, "edge_length_epsilon")
+    if edge_length_epsilon < 0.0:
+        raise ValueError("edge_length_epsilon must be greater than or equal to zero.")
+    face_aspect_threshold = _validate_scalar(face_aspect_threshold, "face_aspect_threshold")
+    if face_aspect_threshold < 1.0:
+        raise ValueError("face_aspect_threshold must be greater than or equal to 1.")
     high_valence_threshold = _validate_int(high_valence_threshold, "high_valence_threshold", 1)
     max_items = _validate_int(max_items, "max_items", 1)
 
@@ -123,6 +132,8 @@ def inspect_mesh_quality(
         "ngons",
         "zero_area_faces",
         "zero_uv_area_faces",
+        "short_edges",
+        "skinny_faces",
         "isolated_vertices",
         "high_valence_vertices",
     ]
@@ -152,6 +163,19 @@ def inspect_mesh_quality(
 
     issues = {}
 
+    points = mesh_fn.getPoints(om.MSpace.kWorld)
+    edge_lengths = {}
+
+    def _edge_length(edge_id):
+        if edge_id not in edge_lengths:
+            vertex_a, vertex_b = mesh_fn.getEdgeVertices(edge_id)
+            point_a = points[int(vertex_a)]
+            point_b = points[int(vertex_b)]
+            edge_lengths[edge_id] = float(
+                ((point_a.x - point_b.x) ** 2 + (point_a.y - point_b.y) ** 2 + (point_a.z - point_b.z) ** 2) ** 0.5
+            )
+        return edge_lengths[edge_id]
+
     if "border_edges" in clean_issue_types:
         edge_it = om.MItMeshEdge(dag_path)
         components = []
@@ -165,6 +189,27 @@ def inspect_mesh_quality(
             edge_it.next()
         issues["border_edges"] = _issue_record(components, records)
 
+    if "short_edges" in clean_issue_types:
+        edge_it = om.MItMeshEdge(dag_path)
+        components = []
+        records = []
+        while not edge_it.isDone():
+            edge_id = int(edge_it.index())
+            length = _edge_length(edge_id)
+            if length <= edge_length_epsilon:
+                component = _component(prefix_name, "e", edge_id)
+                vertex_a, vertex_b = mesh_fn.getEdgeVertices(edge_id)
+                components.append(component)
+                records.append(
+                    {
+                        "component": component,
+                        "length": length,
+                        "vertices": [int(vertex_a), int(vertex_b)],
+                    }
+                )
+            edge_it.next()
+        issues["short_edges"] = _issue_record(components, records)
+
     for poly_info_type in ["nonmanifold_edges", "nonmanifold_vertices", "lamina_faces", "invalid_edges", "invalid_vertices"]:
         if poly_info_type in clean_issue_types:
             issues[poly_info_type] = _issue_record(_poly_info_components(poly_info_type))
@@ -174,10 +219,12 @@ def inspect_mesh_quality(
     ngon_components = []
     zero_area_components = []
     zero_uv_area_components = []
+    skinny_face_components = []
     triangle_records = []
     ngon_records = []
     zero_area_records = []
     zero_uv_records = []
+    skinny_face_records = []
     while not polygon_it.isDone():
         face_id = int(polygon_it.index())
         face_component = _component(prefix_name, "f", face_id)
@@ -200,6 +247,27 @@ def inspect_mesh_quality(
             if zero_uv:
                 zero_uv_area_components.append(face_component)
                 zero_uv_records.append({"component": face_component, "vertex_count": vertex_count})
+        if "skinny_faces" in clean_issue_types:
+            edge_ids = [int(edge_id) for edge_id in polygon_it.getEdges()]
+            lengths = [_edge_length(edge_id) for edge_id in edge_ids]
+            nonzero_lengths = [length for length in lengths if length > 1.0e-12]
+            if nonzero_lengths:
+                shortest = min(nonzero_lengths)
+                longest = max(nonzero_lengths)
+                aspect_ratio = longest / shortest
+                if aspect_ratio >= face_aspect_threshold:
+                    skinny_face_components.append(face_component)
+                    skinny_face_records.append(
+                        {
+                            "component": face_component,
+                            "vertex_count": vertex_count,
+                            "area": area,
+                            "shortest_edge_length": shortest,
+                            "longest_edge_length": longest,
+                            "aspect_ratio": aspect_ratio,
+                            "edges": [_component(prefix_name, "e", edge_id) for edge_id in edge_ids],
+                        }
+                    )
         polygon_it.next()
 
     if "triangles" in clean_issue_types:
@@ -210,6 +278,8 @@ def inspect_mesh_quality(
         issues["zero_area_faces"] = _issue_record(zero_area_components, zero_area_records)
     if "zero_uv_area_faces" in clean_issue_types:
         issues["zero_uv_area_faces"] = _issue_record(zero_uv_area_components, zero_uv_records)
+    if "skinny_faces" in clean_issue_types:
+        issues["skinny_faces"] = _issue_record(skinny_face_components, skinny_face_records)
 
     if "isolated_vertices" in clean_issue_types or "high_valence_vertices" in clean_issue_types:
         vertex_it = om.MItMeshVertex(dag_path)
@@ -263,6 +333,8 @@ def inspect_mesh_quality(
         "operation": operation,
         "counts": counts,
         "area_epsilon": area_epsilon,
+        "edge_length_epsilon": edge_length_epsilon,
+        "face_aspect_threshold": face_aspect_threshold,
         "high_valence_threshold": high_valence_threshold,
         "issue_types": clean_issue_types,
         "summary": summary,

--- a/src/mayatools/object/linear_profile_deform.py
+++ b/src/mayatools/object/linear_profile_deform.py
@@ -1,0 +1,227 @@
+from typing import Dict, List, Any
+
+
+def linear_profile_deform(
+    object_name: str,
+    profile_points: List[List[float]],
+    axis: str = "y",
+    deform_axis: str = "x",
+    center: List[float] = None,
+    position_mode: str = "normalized",
+    value_mode: str = "scale",
+    interpolation: str = "smooth",
+    axis_range: List[float] = None,
+    blend: float = 1.0,
+    max_abs_displacement: float = None,
+    min_abs_delta: float = 1e-8,
+    smooth: bool = True,
+) -> Dict[str, Any]:
+    """Apply an axial profile deformation along one coordinate axis.
+
+    The tool samples a profile along one axis and changes vertex coordinates
+    along a second axis. It is useful for generic non-radial profile shaping:
+    tapering planar decals, front-facing mesh layers, panels, ribbons, cloth
+    strips, sprite cards, label overlays, and other geometry where visible
+    width should change without moving depth.
+
+    profile_points are [position, value] pairs. With position_mode="normalized",
+    positions are 0..1 over axis_range or the object's bounding box. value_mode
+    controls how sampled values are applied:
+    - scale: multiply distance from center along deform_axis.
+    - offset: add value directly to the deform_axis coordinate.
+    - target_coordinate: blend toward an absolute deform_axis coordinate.
+    - target_distance: blend toward a signed distance from center, preserving
+      the vertex side relative to center.
+    """
+    import maya.cmds as cmds
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(value) for value in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(value) for value in values]
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _clamp(value, lower, upper):
+        return max(lower, min(upper, value))
+
+    def _smoothstep(value):
+        value = _clamp(value, 0.0, 1.0)
+        return value * value * (3.0 - 2.0 * value)
+
+    def _validate_profile(points):
+        if not isinstance(points, list) or len(points) < 2:
+            raise ValueError("profile_points must contain at least two [position, value] points.")
+        clean = []
+        previous_position = None
+        for point in points:
+            position, value = _validate_vector(point, 2, "profile_points point")
+            if position_mode == "normalized" and (position < 0.0 or position > 1.0):
+                raise ValueError("Normalized profile point positions must be in the range 0..1.")
+            if previous_position is not None and position <= previous_position:
+                raise ValueError("profile_points positions must be strictly increasing.")
+            clean.append([position, value])
+            previous_position = position
+        return clean
+
+    def _sample_profile(position):
+        if position <= clean_profile[0][0]:
+            return clean_profile[0][1]
+        if position >= clean_profile[-1][0]:
+            return clean_profile[-1][1]
+        for index in range(len(clean_profile) - 1):
+            x0, y0 = clean_profile[index]
+            x1, y1 = clean_profile[index + 1]
+            if x0 <= position <= x1:
+                if abs(x1 - x0) <= 1e-9:
+                    return y1
+                t = (position - x0) / (x1 - x0)
+                if interpolation == "smooth":
+                    t = _smoothstep(t)
+                return y0 + (y1 - y0) * t
+        return clean_profile[-1][1]
+
+    if not cmds.objExists(object_name):
+        raise ValueError(f"Object does not exist: {object_name}")
+
+    axes = {"x": 0, "y": 1, "z": 2}
+    axis = axis.lower().strip()
+    deform_axis = deform_axis.lower().strip()
+    if axis not in axes:
+        raise ValueError("axis must be one of x, y, or z.")
+    if deform_axis not in axes:
+        raise ValueError("deform_axis must be one of x, y, or z.")
+    axis_index = axes[axis]
+    deform_index = axes[deform_axis]
+
+    position_mode = position_mode.lower().strip()
+    if position_mode not in {"normalized", "world"}:
+        raise ValueError("position_mode must be normalized or world.")
+    value_mode = value_mode.lower().strip()
+    if value_mode not in {"scale", "offset", "target_coordinate", "target_distance"}:
+        raise ValueError("value_mode must be scale, offset, target_coordinate, or target_distance.")
+    interpolation = interpolation.lower().strip()
+    if interpolation not in {"linear", "smooth"}:
+        raise ValueError("interpolation must be linear or smooth.")
+
+    clean_profile = _validate_profile(profile_points)
+    blend = _validate_scalar(blend, "blend")
+    if blend < 0.0 or blend > 1.0:
+        raise ValueError("blend must be in the range 0..1.")
+    min_abs_delta = _validate_scalar(min_abs_delta, "min_abs_delta")
+    if min_abs_delta < 0.0:
+        raise ValueError("min_abs_delta must be greater than or equal to zero.")
+    if max_abs_displacement is not None:
+        max_abs_displacement = _validate_scalar(max_abs_displacement, "max_abs_displacement")
+        if max_abs_displacement < 0.0:
+            raise ValueError("max_abs_displacement must be greater than or equal to zero.")
+
+    shapes = cmds.listRelatives(object_name, shapes=True, fullPath=True) or []
+    if cmds.objectType(object_name) == "mesh":
+        shapes = [object_name]
+    if not any(cmds.objectType(shape) == "mesh" for shape in shapes):
+        raise ValueError(f"{object_name} is not a polygon mesh transform or mesh shape.")
+
+    bbox = cmds.exactWorldBoundingBox(object_name)
+    if center is None:
+        clean_center = [
+            (bbox[0] + bbox[3]) * 0.5,
+            (bbox[1] + bbox[4]) * 0.5,
+            (bbox[2] + bbox[5]) * 0.5,
+        ]
+    else:
+        clean_center = _validate_vector(center, 3, "center")
+
+    if axis_range is None:
+        clean_axis_range = [bbox[axis_index], bbox[axis_index + 3]]
+    else:
+        clean_axis_range = _validate_vector(axis_range, 2, "axis_range")
+    if clean_axis_range[1] < clean_axis_range[0]:
+        clean_axis_range = [clean_axis_range[1], clean_axis_range[0]]
+    axis_span = clean_axis_range[1] - clean_axis_range[0]
+    if position_mode == "normalized" and abs(axis_span) <= 1e-9:
+        raise ValueError("axis_range must have non-zero length when position_mode is normalized.")
+
+    vertices = cmds.ls(f"{object_name}.vtx[*]", flatten=True) or []
+    if not vertices:
+        raise ValueError(f"No vertices found on {object_name}.")
+
+    displacements = []
+    deformed_vertices = 0
+    skipped_vertices = 0
+
+    for vertex in vertices:
+        position = cmds.xform(vertex, query=True, worldSpace=True, translation=True)
+        axis_value = position[axis_index]
+        if axis_value < clean_axis_range[0] or axis_value > clean_axis_range[1]:
+            skipped_vertices += 1
+            continue
+
+        if position_mode == "normalized":
+            profile_position = (axis_value - clean_axis_range[0]) / axis_span
+        else:
+            profile_position = axis_value
+
+        value = _sample_profile(profile_position)
+        current_coordinate = position[deform_index]
+        delta = current_coordinate - clean_center[deform_index]
+
+        if value_mode == "scale":
+            if abs(delta) < min_abs_delta:
+                skipped_vertices += 1
+                continue
+            target_coordinate = clean_center[deform_index] + delta * value
+        elif value_mode == "offset":
+            target_coordinate = current_coordinate + value
+        elif value_mode == "target_coordinate":
+            target_coordinate = value
+        else:
+            if abs(delta) < min_abs_delta:
+                skipped_vertices += 1
+                continue
+            side = 1.0 if delta >= 0.0 else -1.0
+            target_coordinate = clean_center[deform_index] + side * abs(value)
+
+        displacement = (target_coordinate - current_coordinate) * blend
+        if max_abs_displacement is not None:
+            displacement = _clamp(displacement, -max_abs_displacement, max_abs_displacement)
+        if abs(displacement) <= 1e-12:
+            continue
+
+        position[deform_index] = current_coordinate + displacement
+        cmds.xform(vertex, worldSpace=True, translation=position)
+        displacements.append(displacement)
+        deformed_vertices += 1
+
+    if smooth:
+        cmds.polySoftEdge(object_name, angle=180, constructionHistory=False)
+
+    return {
+        "success": True,
+        "object_name": object_name,
+        "axis": axis,
+        "deform_axis": deform_axis,
+        "center": clean_center,
+        "axis_range": clean_axis_range,
+        "position_mode": position_mode,
+        "value_mode": value_mode,
+        "interpolation": interpolation,
+        "profile_points": clean_profile,
+        "blend": blend,
+        "max_abs_displacement": max_abs_displacement,
+        "deformed_vertices": deformed_vertices,
+        "skipped_vertices": skipped_vertices,
+        "min_displacement": min(displacements) if displacements else 0.0,
+        "max_displacement": max(displacements) if displacements else 0.0,
+        "mean_abs_displacement": (
+            sum(abs(value) for value in displacements) / float(len(displacements))
+            if displacements else 0.0
+        ),
+        "bounding_box": cmds.exactWorldBoundingBox(object_name),
+    }

--- a/src/mayatools/object/list_objects_by_type.py
+++ b/src/mayatools/object/list_objects_by_type.py
@@ -1,10 +1,106 @@
+from typing import List
 
-def list_objects_by_type(filter_by:str=None) -> list:
-    """ Get a list of objects in the scene. Use filter_by to filter for 
-        certain objects such as "cameras", "lights", "materials", or "shapes". """
+
+def list_objects_by_type(
+    filter_by: str = None,
+    visible_only: bool = False,
+    long_names: bool = False,
+) -> List[str]:
+    """List scene nodes by common Maya categories.
+
+    Supported filters include objects/all, transforms, meshes, mesh_shapes,
+    curves, curve_shapes, geometry, cameras, lights, materials, textures,
+    file_textures, shading_groups, and shapes. The common mesh/curve filters
+    return transform nodes so the results can be passed directly to modeling
+    tools; use mesh_shapes or curve_shapes when shape nodes are required.
+    """
     import maya.cmds as cmds
-    if filter_by in ("object", "objects", "all", 'null', None):
-        filter_by = "dag"
-    args = { filter_by: True }
-    return cmds.ls(**args) 
 
+    def _unique(values):
+        result = []
+        seen = set()
+        for value in values or []:
+            if value not in seen:
+                seen.add(value)
+                result.append(value)
+        return result
+
+    def _is_visible(node):
+        current = node
+        while current:
+            try:
+                if cmds.attributeQuery("visibility", node=current, exists=True) and not cmds.getAttr(f"{current}.visibility"):
+                    return False
+            except Exception:
+                pass
+            parents = cmds.listRelatives(current, parent=True, fullPath=True) or []
+            current = parents[0] if parents else None
+        return True
+
+    def _shape_parents(shape_type):
+        parents = []
+        for shape in cmds.ls(type=shape_type, long=long_names) or []:
+            try:
+                if cmds.attributeQuery("intermediateObject", node=shape, exists=True) and cmds.getAttr(f"{shape}.intermediateObject"):
+                    continue
+            except Exception:
+                pass
+            parent = cmds.listRelatives(shape, parent=True, fullPath=long_names) or []
+            if parent:
+                parents.append(parent[0])
+        return _unique(parents)
+
+    key = "objects" if filter_by in (None, "", "null") else str(filter_by).lower().strip()
+    key = key.replace("-", "_")
+
+    if key in {"object", "objects", "all", "dag"}:
+        nodes = cmds.ls(dag=True, long=long_names) or []
+    elif key in {"transform", "transforms"}:
+        nodes = cmds.ls(type="transform", long=long_names) or []
+    elif key in {"mesh", "meshes"}:
+        nodes = _shape_parents("mesh")
+    elif key in {"mesh_shape", "mesh_shapes"}:
+        nodes = cmds.ls(type="mesh", long=long_names) or []
+    elif key in {"curve", "curves", "nurbs_curve", "nurbs_curves"}:
+        nodes = _shape_parents("nurbsCurve") + _shape_parents("bezierCurve")
+    elif key in {"curve_shape", "curve_shapes", "nurbs_curve_shape", "nurbs_curve_shapes"}:
+        nodes = (cmds.ls(type="nurbsCurve", long=long_names) or []) + (cmds.ls(type="bezierCurve", long=long_names) or [])
+    elif key == "geometry":
+        nodes = _shape_parents("mesh") + _shape_parents("nurbsCurve") + _shape_parents("bezierCurve")
+    elif key in {"camera", "cameras"}:
+        nodes = cmds.ls(cameras=True, long=long_names) or []
+    elif key in {"light", "lights"}:
+        nodes = cmds.ls(lights=True, long=long_names) or []
+    elif key in {"material", "materials"}:
+        nodes = cmds.ls(materials=True) or []
+    elif key in {"texture", "textures"}:
+        nodes = cmds.ls(textures=True) or []
+    elif key in {"file", "files", "file_texture", "file_textures"}:
+        nodes = cmds.ls(type="file") or []
+    elif key in {"shading_group", "shading_groups", "shading_engine", "shading_engines"}:
+        nodes = cmds.ls(type="shadingEngine") or []
+    elif key in {"shape", "shapes"}:
+        nodes = cmds.ls(shapes=True, long=long_names) or []
+    else:
+        supported = [
+            "objects",
+            "transforms",
+            "meshes",
+            "mesh_shapes",
+            "curves",
+            "curve_shapes",
+            "geometry",
+            "cameras",
+            "lights",
+            "materials",
+            "textures",
+            "file_textures",
+            "shading_groups",
+            "shapes",
+        ]
+        raise ValueError(f"Unsupported filter_by value: {filter_by}. Supported values: {', '.join(supported)}.")
+
+    nodes = _unique(nodes)
+    if visible_only and key not in {"material", "materials", "texture", "textures", "file", "files", "file_texture", "file_textures", "shading_group", "shading_groups", "shading_engine", "shading_engines"}:
+        nodes = [node for node in nodes if _is_visible(node)]
+    return nodes

--- a/src/mayatools/object/localized_radial_pattern_deform.py
+++ b/src/mayatools/object/localized_radial_pattern_deform.py
@@ -1,0 +1,201 @@
+from typing import Dict, List, Any
+
+
+def localized_radial_pattern_deform(
+    object_name: str,
+    center: List[float] = [0.0, 0.0, 0.0],
+    axis: str = "y",
+    axis_range: List[float] = [0.0, 1.0],
+    angle_range_degrees: List[float] = [-45.0, 45.0],
+    axis_count: int = 6,
+    angle_count: int = 8,
+    feature_axis_radius: float = 0.05,
+    feature_angle_radius_degrees: float = 4.0,
+    amplitude: float = -0.02,
+    falloff: str = "smooth",
+    stagger: bool = False,
+    stagger_offset_degrees: float = 0.0,
+    smooth: bool = True,
+) -> Dict[str, Any]:
+    """Apply localized repeated radial features to a cylindrical or lathed mesh.
+
+    The tool deforms vertices radially inside a bounded angular and axial
+    region. It is useful for generic grip dimples, raised dot fields, localized
+    emboss/deboss patterns, perforation-like dents, and other repeated surface
+    details on bottles, cans, cups, knobs, handles, and similar forms. UVs are
+    not edited; only vertex positions are moved.
+    """
+    import math
+    import maya.cmds as cmds
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(v) for v in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(v) for v in values]
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _validate_count(value, arg_name):
+        if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to 1.")
+        return value
+
+    def _positive_span(start_degrees, end_degrees):
+        span = (end_degrees - start_degrees) % 360.0
+        return 360.0 if abs(span) < 1e-8 else span
+
+    def _angle_delta_degrees(a, b):
+        return (a - b + 180.0) % 360.0 - 180.0
+
+    def _angle_range_t(angle, start_degrees, span_degrees):
+        delta = (angle - start_degrees) % 360.0
+        if delta < -1e-8 or delta > span_degrees + 1e-8:
+            return None
+        return max(0.0, min(1.0, delta / span_degrees))
+
+    def _feature_weight(distance):
+        if distance > 1.0:
+            return 0.0
+        if falloff == "hard":
+            return 1.0
+        if falloff == "linear":
+            return 1.0 - distance
+        if falloff == "gaussian":
+            return math.exp(-4.0 * distance * distance)
+        t = max(0.0, min(1.0, distance))
+        return 1.0 - (t * t * (3.0 - 2.0 * t))
+
+    if not cmds.objExists(object_name):
+        raise ValueError(f"Object does not exist: {object_name}")
+
+    center = _validate_vector(center, 3, "center")
+    axis_range = _validate_vector(axis_range, 2, "axis_range")
+    angle_range_degrees = _validate_vector(angle_range_degrees, 2, "angle_range_degrees")
+    axis_count = _validate_count(axis_count, "axis_count")
+    angle_count = _validate_count(angle_count, "angle_count")
+    feature_axis_radius = _validate_scalar(feature_axis_radius, "feature_axis_radius")
+    feature_angle_radius_degrees = _validate_scalar(feature_angle_radius_degrees, "feature_angle_radius_degrees")
+    amplitude = _validate_scalar(amplitude, "amplitude")
+    stagger_offset_degrees = _validate_scalar(stagger_offset_degrees, "stagger_offset_degrees")
+    if feature_axis_radius <= 0.0:
+        raise ValueError("feature_axis_radius must be greater than zero.")
+    if feature_angle_radius_degrees <= 0.0:
+        raise ValueError("feature_angle_radius_degrees must be greater than zero.")
+
+    falloff = falloff.lower()
+    if falloff not in {"smooth", "linear", "gaussian", "hard"}:
+        raise ValueError("falloff must be one of smooth, linear, gaussian, or hard.")
+
+    axis = axis.lower()
+    axes = {
+        "x": (0, 1, 2),
+        "y": (1, 0, 2),
+        "z": (2, 0, 1),
+    }
+    if axis not in axes:
+        raise ValueError("axis must be one of x, y, or z.")
+    axis_index, radial_a, radial_b = axes[axis]
+
+    shapes = cmds.listRelatives(object_name, shapes=True, fullPath=True) or []
+    if cmds.objectType(object_name) == "mesh":
+        shapes = [object_name]
+    if not any(cmds.objectType(shape) == "mesh" for shape in shapes):
+        raise ValueError(f"{object_name} is not a polygon mesh transform or mesh shape.")
+
+    vertices = cmds.ls(f"{object_name}.vtx[*]", flatten=True) or []
+    if not vertices:
+        raise ValueError(f"No vertices found on {object_name}.")
+
+    axis_start, axis_end = axis_range
+    if axis_start > axis_end:
+        axis_start, axis_end = axis_end, axis_start
+    axis_span = axis_end - axis_start
+    if axis_span <= 0.0:
+        raise ValueError("axis_range must cover a positive span.")
+
+    angle_start, angle_end = angle_range_degrees
+    angle_span = _positive_span(angle_start, angle_end)
+    angle_spacing = angle_span / float(angle_count)
+    if stagger and abs(stagger_offset_degrees) < 1e-8:
+        stagger_offset_degrees = angle_spacing * 0.5
+
+    feature_centers = []
+    for axis_index_center in range(axis_count):
+        axis_t = (axis_index_center + 0.5) / float(axis_count)
+        axis_value = axis_start + axis_span * axis_t
+        row_offset = stagger_offset_degrees if stagger and axis_index_center % 2 == 1 else 0.0
+        for angle_index in range(angle_count):
+            angle_t = (angle_index + 0.5) / float(angle_count)
+            angle_value = angle_start + angle_span * angle_t + row_offset
+            feature_centers.append((axis_value, angle_value))
+
+    displacement_values = []
+    deformed_vertices = 0
+    for vertex in vertices:
+        position = cmds.xform(vertex, query=True, worldSpace=True, translation=True)
+        local_axis = position[axis_index] - center[axis_index]
+        if local_axis < axis_start or local_axis > axis_end:
+            continue
+
+        delta_a = position[radial_a] - center[radial_a]
+        delta_b = position[radial_b] - center[radial_b]
+        radius = math.sqrt(delta_a * delta_a + delta_b * delta_b)
+        if radius <= 1e-8:
+            continue
+
+        angle = math.degrees(math.atan2(delta_a, delta_b))
+        if _angle_range_t(angle, angle_start, angle_span) is None:
+            continue
+
+        weight = 0.0
+        for feature_axis, feature_angle in feature_centers:
+            axis_distance = abs(local_axis - feature_axis) / feature_axis_radius
+            if axis_distance > 1.0:
+                continue
+            angle_distance = abs(_angle_delta_degrees(angle, feature_angle)) / feature_angle_radius_degrees
+            if angle_distance > 1.0:
+                continue
+            distance = math.sqrt(axis_distance * axis_distance + angle_distance * angle_distance)
+            weight = max(weight, _feature_weight(distance))
+
+        if weight <= 0.0:
+            continue
+
+        displacement = amplitude * weight
+        new_radius = max(0.0, radius + displacement)
+        scale = new_radius / radius
+        position[radial_a] = center[radial_a] + delta_a * scale
+        position[radial_b] = center[radial_b] + delta_b * scale
+        cmds.xform(vertex, worldSpace=True, translation=position)
+        displacement_values.append(displacement)
+        deformed_vertices += 1
+
+    if smooth:
+        cmds.polySoftEdge(object_name, angle=180, constructionHistory=False)
+
+    return {
+        "success": True,
+        "object_name": object_name,
+        "deformed_vertices": deformed_vertices,
+        "feature_count": len(feature_centers),
+        "axis": axis,
+        "axis_range": [axis_start, axis_end],
+        "angle_range_degrees": angle_range_degrees,
+        "axis_count": axis_count,
+        "angle_count": angle_count,
+        "feature_axis_radius": feature_axis_radius,
+        "feature_angle_radius_degrees": feature_angle_radius_degrees,
+        "amplitude": amplitude,
+        "falloff": falloff,
+        "stagger": bool(stagger),
+        "stagger_offset_degrees": stagger_offset_degrees,
+        "min_displacement": min(displacement_values) if displacement_values else 0.0,
+        "max_displacement": max(displacement_values) if displacement_values else 0.0,
+        "bounding_box": cmds.exactWorldBoundingBox(object_name),
+    }

--- a/src/mayatools/object/mesh_component_operations.py
+++ b/src/mayatools/object/mesh_component_operations.py
@@ -1,0 +1,286 @@
+from typing import Dict, List, Any, Union
+
+
+def mesh_component_operations(
+    object_name: str,
+    operation: str,
+    component_type: str = None,
+    indices: List[int] = None,
+    components: Union[str, List[str]] = None,
+    parameters: Dict[str, Any] = None,
+    use_selection: bool = True,
+) -> Dict[str, Any]:
+    """Run common Maya polygon component operations.
+
+    Operations include select, delete, merge_vertices, set_normals,
+    soften_edges, harden_edges, insert_support_loop, and insert_edge_loop.
+    Components can be passed explicitly, built from component_type plus
+    indices, or taken from the current Maya selection. This covers low-level
+    artist operations such as selecting faces/edges/vertices, welding points,
+    changing soft/hard edges, deleting local geometry, and inserting support
+    loops.
+    """
+    import re
+    import maya.cmds as cmds
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _mesh_shape(node):
+        if not cmds.objExists(node):
+            raise ValueError(f"Object does not exist: {node}")
+        if cmds.objectType(node) == "mesh":
+            return node
+        shapes = cmds.listRelatives(node, shapes=True, fullPath=True) or []
+        mesh_shapes = []
+        for shape in shapes:
+            if cmds.objectType(shape) != "mesh":
+                continue
+            try:
+                if cmds.attributeQuery("intermediateObject", node=shape, exists=True) and cmds.getAttr(f"{shape}.intermediateObject"):
+                    continue
+            except Exception:
+                pass
+            mesh_shapes.append(shape)
+        if not mesh_shapes:
+            raise ValueError(f"{node} is not a polygon mesh transform or mesh shape.")
+        return mesh_shapes[0]
+
+    def _component_prefix(shape):
+        parents = cmds.listRelatives(shape, parent=True, fullPath=False) or []
+        return parents[0] if parents else object_name
+
+    def _flatten(value):
+        if value is None:
+            return []
+        if isinstance(value, str):
+            value = [value]
+        if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+            raise ValueError("components must be a string, a list of strings, or None.")
+        return cmds.ls(value, flatten=True) or []
+
+    def _components_from_indices(kind):
+        if indices is None:
+            return []
+        if not isinstance(indices, list) or not all(isinstance(index, int) and not isinstance(index, bool) for index in indices):
+            raise ValueError("indices must be a list of integers.")
+        return [f"{prefix}.{kind}[{index}]" for index in indices]
+
+    def _selected_components():
+        if not use_selection:
+            return []
+        selected = cmds.ls(selection=True, flatten=True) or []
+        object_tokens = {object_name, prefix, shape_name}
+        filtered = []
+        for item in selected:
+            item_object = item.split(".", 1)[0]
+            if item_object in object_tokens:
+                filtered.append(item)
+        return filtered
+
+    def _resolve_components(default_type=None):
+        clean_type = (component_type or default_type or "").lower().strip()
+        kind_map = {"vertex": "vtx", "edge": "e", "face": "f", "uv": "map"}
+        if components is not None:
+            resolved = _flatten(components)
+        elif clean_type in kind_map and indices is not None:
+            resolved = _components_from_indices(kind_map[clean_type])
+        else:
+            resolved = _selected_components()
+        if not resolved:
+            raise ValueError("No components resolved from components, indices, or current selection.")
+        return resolved
+
+    def _convert_to_vertices(items):
+        converted = cmds.polyListComponentConversion(items, toVertex=True) or []
+        vertices = cmds.ls(converted, flatten=True) or []
+        return sorted(set(vertices), key=lambda item: int(re.search(r"\.vtx\[(\d+)\]$", item).group(1)) if re.search(r"\.vtx\[(\d+)\]$", item) else -1)
+
+    def _counts():
+        return {
+            "vertices": int(cmds.polyEvaluate(object_name, vertex=True)),
+            "edges": int(cmds.polyEvaluate(object_name, edge=True)),
+            "faces": int(cmds.polyEvaluate(object_name, face=True)),
+        }
+
+    if not object_name:
+        raise ValueError("object_name is required.")
+    operation = operation.lower().strip()
+    parameters = parameters or {}
+    shape_name = _mesh_shape(object_name)
+    prefix = _component_prefix(shape_name)
+    before_counts = _counts()
+
+    if operation == "select":
+        resolved = _resolve_components()
+        cmds.select(resolved, replace=True)
+        return {
+            "success": True,
+            "object_name": object_name,
+            "operation": operation,
+            "selected_count": len(resolved),
+            "selected_components_preview": resolved[:50],
+            "counts_before": before_counts,
+            "counts_after": _counts(),
+        }
+
+    if operation == "delete":
+        resolved = _resolve_components()
+        cmds.delete(resolved)
+        return {
+            "success": True,
+            "object_name": object_name,
+            "operation": operation,
+            "deleted_count": len(resolved),
+            "deleted_components_preview": resolved[:50],
+            "counts_before": before_counts,
+            "counts_after": _counts() if cmds.objExists(object_name) else None,
+        }
+
+    if operation == "merge_vertices":
+        resolved = _resolve_components("vertex")
+        vertices = _convert_to_vertices(resolved)
+        if len(vertices) < 2:
+            raise ValueError("merge_vertices requires at least two vertices.")
+        distance = _validate_scalar(parameters.get("distance", 0.001), "distance")
+        always_merge = bool(parameters.get("always_merge", False))
+        construction_history = bool(parameters.get("construction_history", False))
+        result = cmds.polyMergeVertex(
+            vertices,
+            distance=distance,
+            alwaysMergeTwoVertices=always_merge,
+            constructionHistory=construction_history,
+        )
+        return {
+            "success": True,
+            "object_name": object_name,
+            "operation": operation,
+            "input_vertex_count": len(vertices),
+            "input_vertices_preview": vertices[:50],
+            "node": result,
+            "distance": distance,
+            "always_merge": always_merge,
+            "counts_before": before_counts,
+            "counts_after": _counts(),
+        }
+
+    if operation in {"set_normals", "soften_edges", "harden_edges"}:
+        if operation == "soften_edges":
+            angle = 180.0
+        elif operation == "harden_edges":
+            angle = 0.0
+        else:
+            angle = _validate_scalar(parameters.get("angle", 30.0), "angle")
+        construction_history = bool(parameters.get("construction_history", False))
+        try:
+            resolved = _resolve_components("edge")
+        except ValueError:
+            resolved = [object_name]
+        result = cmds.polySoftEdge(resolved, angle=angle, constructionHistory=construction_history)
+        return {
+            "success": True,
+            "object_name": object_name,
+            "operation": operation,
+            "angle": angle,
+            "component_count": len(resolved),
+            "components_preview": resolved[:50],
+            "node": result,
+            "counts_before": before_counts,
+            "counts_after": _counts(),
+        }
+
+    if operation == "insert_support_loop":
+        axis = str(parameters.get("axis", "y")).lower().strip()
+        if axis not in {"x", "y", "z"}:
+            raise ValueError("parameters.axis must be x, y, or z.")
+        position = _validate_scalar(parameters.get("position", 0.0), "position")
+        construction_history = bool(parameters.get("construction_history", False))
+        delete_faces = bool(parameters.get("delete_faces", False))
+        bbox = cmds.exactWorldBoundingBox(object_name)
+        center = [
+            (bbox[0] + bbox[3]) * 0.5,
+            (bbox[1] + bbox[4]) * 0.5,
+            (bbox[2] + bbox[5]) * 0.5,
+        ]
+        center[{"x": 0, "y": 1, "z": 2}[axis]] = position
+        result = cmds.polyCut(
+            object_name,
+            constructionHistory=construction_history,
+            cutPlaneCenter=center,
+            cuttingDirection=axis,
+            deleteFaces=delete_faces,
+        )
+        after_counts = _counts()
+        if after_counts == before_counts:
+            raise RuntimeError("insert_support_loop did not change mesh topology.")
+        return {
+            "success": True,
+            "object_name": object_name,
+            "operation": operation,
+            "axis": axis,
+            "position": position,
+            "cut_plane_center": center,
+            "node": result,
+            "counts_before": before_counts,
+            "counts_after": after_counts,
+        }
+
+    if operation == "insert_edge_loop":
+        edges = _resolve_components("edge")
+        if not any(".e[" in item for item in edges):
+            raise ValueError("insert_edge_loop requires edge components.")
+        divisions = int(parameters.get("divisions", 1))
+        weight = _validate_scalar(parameters.get("weight", 0.5), "weight")
+        smoothing_angle = _validate_scalar(parameters.get("smoothing_angle", 30.0), "smoothing_angle")
+        construction_history = bool(parameters.get("construction_history", True))
+        insert_with_edge_flow = bool(parameters.get("insert_with_edge_flow", False))
+        nodes = []
+        for edge in edges:
+            try:
+                node = cmds.polySplitRing(
+                    edge,
+                    constructionHistory=construction_history,
+                    splitType=1,
+                    divisions=divisions,
+                    weight=weight,
+                    smoothingAngle=smoothing_angle,
+                    insertWithEdgeFlow=insert_with_edge_flow,
+                )
+            except TypeError:
+                node = cmds.polySplitRing(
+                    edge,
+                    ch=construction_history,
+                    splitType=1,
+                    divisions=divisions,
+                    weight=weight,
+                    smoothingAngle=smoothing_angle,
+                )
+            nodes.append(node)
+        after_counts = _counts()
+        if after_counts == before_counts:
+            raise RuntimeError(
+                "insert_edge_loop did not change mesh topology. "
+                "Use insert_support_loop with axis and position for a plane-based support cut."
+            )
+        return {
+            "success": True,
+            "object_name": object_name,
+            "operation": operation,
+            "edge_count": len(edges),
+            "edges_preview": edges[:50],
+            "divisions": divisions,
+            "weight": weight,
+            "nodes": nodes,
+            "counts_before": before_counts,
+            "counts_after": after_counts,
+        }
+
+    raise ValueError(
+        "Unknown operation. Use select, delete, merge_vertices, set_normals, "
+        "soften_edges, harden_edges, insert_support_loop, or insert_edge_loop."
+    )

--- a/src/mayatools/object/mesh_component_operations.py
+++ b/src/mayatools/object/mesh_component_operations.py
@@ -101,6 +101,37 @@ def mesh_component_operations(
         vertices = cmds.ls(converted, flatten=True) or []
         return sorted(set(vertices), key=lambda item: int(re.search(r"\.vtx\[(\d+)\]$", item).group(1)) if re.search(r"\.vtx\[(\d+)\]$", item) else -1)
 
+    def _component_ids(items, kind):
+        pattern = re.compile(rf"\.{kind}\[(\d+)\]$")
+        ids = []
+        for item in cmds.ls(items, flatten=True) or []:
+            match = pattern.search(item)
+            if match:
+                ids.append(int(match.group(1)))
+        return sorted(set(ids))
+
+    def _unique(items):
+        seen = set()
+        result = []
+        for item in cmds.ls(items, flatten=True) or []:
+            if item in seen:
+                continue
+            seen.add(item)
+            result.append(item)
+        return result
+
+    def _poly_select_edges(flag_name, edge_ids):
+        results = []
+        for edge_id in edge_ids:
+            output = cmds.polySelect(
+                object_name,
+                asSelectString=True,
+                noSelection=True,
+                **{flag_name: int(edge_id)},
+            ) or []
+            results.extend(output)
+        return _unique(results)
+
     def _counts():
         return {
             "vertices": int(cmds.polyEvaluate(object_name, vertex=True)),
@@ -232,40 +263,29 @@ def mesh_component_operations(
 
     if operation == "insert_edge_loop":
         edges = _resolve_components("edge")
-        if not any(".e[" in item for item in edges):
+        edges = cmds.ls(cmds.polyListComponentConversion(edges, toEdge=True) or [], flatten=True) or []
+        edge_ids = _component_ids(edges, "e")
+        if not edge_ids:
             raise ValueError("insert_edge_loop requires edge components.")
-        divisions = int(parameters.get("divisions", 1))
-        weight = _validate_scalar(parameters.get("weight", 0.5), "weight")
-        smoothing_angle = _validate_scalar(parameters.get("smoothing_angle", 30.0), "smoothing_angle")
+        expanded = _poly_select_edges("edgeRing", edge_ids)
+        if expanded:
+            edges = expanded
+            edge_ids = _component_ids(edges, "e")
+        if len(edge_ids) < 2:
+            raise ValueError("insert_edge_loop requires at least two resolved edges after edge-ring expansion.")
         construction_history = bool(parameters.get("construction_history", True))
         insert_with_edge_flow = bool(parameters.get("insert_with_edge_flow", False))
-        nodes = []
-        for edge in edges:
-            try:
-                node = cmds.polySplitRing(
-                    edge,
-                    constructionHistory=construction_history,
-                    splitType=1,
-                    divisions=divisions,
-                    weight=weight,
-                    smoothingAngle=smoothing_angle,
-                    insertWithEdgeFlow=insert_with_edge_flow,
-                )
-            except TypeError:
-                node = cmds.polySplitRing(
-                    edge,
-                    ch=construction_history,
-                    splitType=1,
-                    divisions=divisions,
-                    weight=weight,
-                    smoothingAngle=smoothing_angle,
-                )
-            nodes.append(node)
+        adjust_edge_flow = _validate_scalar(parameters.get("adjust_edge_flow", 0.0), "adjust_edge_flow")
+        cmds.select(edges, replace=True)
+        node = cmds.polyConnectComponents(
+            constructionHistory=construction_history,
+            insertWithEdgeFlow=insert_with_edge_flow,
+            adjustEdgeFlow=adjust_edge_flow,
+        )
         after_counts = _counts()
         if after_counts == before_counts:
             raise RuntimeError(
-                "insert_edge_loop did not change mesh topology. "
-                "Use insert_support_loop with axis and position for a plane-based support cut."
+                "insert_edge_loop did not change mesh topology. Try a different seed edge or selected edge set."
             )
         return {
             "success": True,
@@ -273,9 +293,11 @@ def mesh_component_operations(
             "operation": operation,
             "edge_count": len(edges),
             "edges_preview": edges[:50],
-            "divisions": divisions,
-            "weight": weight,
-            "nodes": nodes,
+            "edge_ids": edge_ids[:50],
+            "edge_id_count": len(edge_ids),
+            "node": node,
+            "insert_with_edge_flow": insert_with_edge_flow,
+            "adjust_edge_flow": adjust_edge_flow,
             "counts_before": before_counts,
             "counts_after": after_counts,
         }

--- a/src/mayatools/object/move_mesh_components.py
+++ b/src/mayatools/object/move_mesh_components.py
@@ -1,0 +1,205 @@
+from typing import Dict, List, Any, Union
+
+
+def move_mesh_components(
+    object_name: str,
+    component_type: str = "vertex",
+    indices: List[int] = None,
+    components: Union[str, List[str]] = None,
+    mode: str = "offset",
+    vector: List[float] = None,
+    positions_by_vertex: Dict[str, List[float]] = None,
+    space: str = "world",
+    along_normal_distance: float = None,
+    use_selection: bool = True,
+    max_preview: int = 20,
+) -> Dict[str, Any]:
+    """Move or set polygon mesh components at vertex level.
+
+    Vertices can be edited directly, while selected edges and faces are first
+    converted to their unique vertices. mode="offset" adds vector and/or normal
+    distance to each resolved vertex. mode="set" assigns explicit coordinates
+    from positions_by_vertex, keyed by vertex index. This supports Maya-style
+    localized point/edge/face alignment without global deformation.
+    """
+    import re
+    import maya.cmds as cmds
+    import maya.api.OpenMaya as om
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(value) for value in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(value) for value in values]
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return value
+
+    def _mesh_shape(node):
+        if not cmds.objExists(node):
+            raise ValueError(f"Object does not exist: {node}")
+        if cmds.objectType(node) == "mesh":
+            return node
+        shapes = cmds.listRelatives(node, shapes=True, fullPath=True) or []
+        mesh_shapes = []
+        for shape in shapes:
+            if cmds.objectType(shape) != "mesh":
+                continue
+            try:
+                if cmds.attributeQuery("intermediateObject", node=shape, exists=True) and cmds.getAttr(f"{shape}.intermediateObject"):
+                    continue
+            except Exception:
+                pass
+            mesh_shapes.append(shape)
+        if not mesh_shapes:
+            raise ValueError(f"{node} is not a polygon mesh transform or mesh shape.")
+        return mesh_shapes[0]
+
+    def _mesh_fn(shape):
+        selection = om.MSelectionList()
+        selection.add(shape)
+        return om.MFnMesh(selection.getDagPath(0))
+
+    def _component_prefix():
+        parents = cmds.listRelatives(shape_name, parent=True, fullPath=False) or []
+        return parents[0] if parents else object_name
+
+    def _flatten(value):
+        if value is None:
+            return []
+        if isinstance(value, str):
+            value = [value]
+        if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+            raise ValueError("components must be a string, a list of strings, or None.")
+        return cmds.ls(value, flatten=True) or []
+
+    def _components_from_indices(kind):
+        if indices is None:
+            return []
+        if not isinstance(indices, list) or not all(isinstance(index, int) and not isinstance(index, bool) for index in indices):
+            raise ValueError("indices must be a list of integers.")
+        return [f"{prefix}.{kind}[{index}]" for index in indices]
+
+    def _selected_components():
+        if not use_selection:
+            return []
+        selected = cmds.ls(selection=True, flatten=True) or []
+        if not selected:
+            return []
+        object_tokens = {object_name, prefix, shape_name}
+        filtered = []
+        for item in selected:
+            item_object = item.split(".", 1)[0]
+            if item_object in object_tokens:
+                filtered.append(item)
+        return filtered
+
+    def _vertex_indices_from_components(source_components):
+        if not source_components:
+            return []
+        if component_type == "vertex":
+            vertex_components = source_components
+        else:
+            vertex_components = cmds.polyListComponentConversion(source_components, toVertex=True) or []
+            vertex_components = cmds.ls(vertex_components, flatten=True) or []
+        vertex_ids = []
+        pattern = re.compile(r"\.vtx\[(\d+)\]$")
+        for component in vertex_components:
+            match = pattern.search(component)
+            if match:
+                vertex_ids.append(int(match.group(1)))
+        return sorted(set(vertex_ids))
+
+    def _point_preview(vertex_id, point):
+        return {"index": vertex_id, "position": [float(point.x), float(point.y), float(point.z)]}
+
+    if not object_name:
+        raise ValueError("object_name is required.")
+    component_type = component_type.lower().strip()
+    if component_type not in {"vertex", "edge", "face"}:
+        raise ValueError("component_type must be vertex, edge, or face.")
+    mode = mode.lower().strip()
+    if mode not in {"offset", "set"}:
+        raise ValueError("mode must be offset or set.")
+    space = space.lower().strip()
+    if space not in {"world", "object"}:
+        raise ValueError("space must be world or object.")
+    max_preview = _validate_int(max_preview, "max_preview", 0)
+
+    shape_name = _mesh_shape(object_name)
+    mesh_fn = _mesh_fn(shape_name)
+    prefix = _component_prefix()
+    om_space = om.MSpace.kWorld if space == "world" else om.MSpace.kObject
+
+    kind = {"vertex": "vtx", "edge": "e", "face": "f"}[component_type]
+    source_components = _flatten(components) or _components_from_indices(kind) or _selected_components()
+    vertex_ids = _vertex_indices_from_components(source_components)
+    if not vertex_ids:
+        raise ValueError("No vertices resolved from components, indices, or current selection.")
+
+    points = mesh_fn.getPoints(om_space)
+    before_preview = [_point_preview(vertex_id, points[vertex_id]) for vertex_id in vertex_ids[:max_preview]]
+
+    move_vector = None
+    if vector is not None:
+        move_vector = _validate_vector(vector, 3, "vector")
+    normal_distance = None
+    if along_normal_distance is not None:
+        normal_distance = _validate_scalar(along_normal_distance, "along_normal_distance")
+
+    if mode == "offset":
+        if move_vector is None and normal_distance is None:
+            raise ValueError("mode=offset requires vector and/or along_normal_distance.")
+        for vertex_id in vertex_ids:
+            delta = [0.0, 0.0, 0.0]
+            if move_vector is not None:
+                delta[0] += move_vector[0]
+                delta[1] += move_vector[1]
+                delta[2] += move_vector[2]
+            if normal_distance is not None:
+                normal = mesh_fn.getVertexNormal(vertex_id, True, om_space)
+                delta[0] += normal.x * normal_distance
+                delta[1] += normal.y * normal_distance
+                delta[2] += normal.z * normal_distance
+            point = points[vertex_id]
+            points[vertex_id] = om.MPoint(point.x + delta[0], point.y + delta[1], point.z + delta[2])
+    else:
+        if not isinstance(positions_by_vertex, dict) or not positions_by_vertex:
+            raise ValueError("mode=set requires positions_by_vertex keyed by vertex index.")
+        for key, value in positions_by_vertex.items():
+            vertex_id = int(key)
+            if vertex_id not in vertex_ids:
+                continue
+            position = _validate_vector(value, 3, f"positions_by_vertex[{key}]")
+            points[vertex_id] = om.MPoint(position[0], position[1], position[2])
+
+    mesh_fn.setPoints(points, om_space)
+    try:
+        mesh_fn.updateSurface()
+    except Exception:
+        pass
+    cmds.select([f"{prefix}.vtx[{vertex_id}]" for vertex_id in vertex_ids], replace=True)
+
+    updated_points = mesh_fn.getPoints(om_space)
+    after_preview = [_point_preview(vertex_id, updated_points[vertex_id]) for vertex_id in vertex_ids[:max_preview]]
+    return {
+        "success": True,
+        "object_name": object_name,
+        "shape_name": shape_name,
+        "component_type": component_type,
+        "mode": mode,
+        "space": space,
+        "resolved_vertex_count": len(vertex_ids),
+        "resolved_vertices_preview": vertex_ids[:max_preview],
+        "before_preview": before_preview,
+        "after_preview": after_preview,
+    }

--- a/src/mayatools/object/polar_mesh_deform.py
+++ b/src/mayatools/object/polar_mesh_deform.py
@@ -1,0 +1,220 @@
+from typing import Dict, List, Any
+
+
+def polar_mesh_deform(
+    object_name: str,
+    center: List[float] = [0.0, 0.0, 0.0],
+    axis: str = "y",
+    cycles: int = 5,
+    radial_amplitude: float = 0.0,
+    axis_amplitude: float = 0.0,
+    uniform_axis_amplitude: float = 0.0,
+    waveform: str = "ridge",
+    phase_degrees: float = 0.0,
+    sharpness: float = 2.0,
+    axis_range: List[float] = None,
+    axis_falloff: float = 0.0,
+    axis_profile: List[List[float]] = None,
+    radial_range: List[float] = None,
+    radial_falloff: float = 0.0,
+    radial_profile: List[List[float]] = None,
+    smooth: bool = True,
+) -> Dict[str, Any]:
+    """Apply coupled angular radial and axial deformation to a polygon mesh.
+
+    The deformation is evaluated in polar coordinates around an axis. It can
+    create generic petal bases, star-shaped supports, punted bottoms, lobed
+    feet, angular ribs, or other cyclic features that need both radial and
+    axis-direction displacement. UVs are not edited; only vertex positions move.
+    """
+    import math
+    import maya.cmds as cmds
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(v) for v in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(v) for v in values]
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _smoothstep(edge0, edge1, value):
+        if abs(edge1 - edge0) <= 1e-9:
+            return 1.0 if value >= edge1 else 0.0
+        t = max(0.0, min(1.0, (value - edge0) / (edge1 - edge0)))
+        return t * t * (3.0 - 2.0 * t)
+
+    def _range_weight(value, value_range, falloff):
+        if value_range is None:
+            return 1.0
+        start, end = value_range
+        if start > end:
+            start, end = end, start
+        if value < start or value > end:
+            return 0.0
+        if falloff <= 0.0:
+            return 1.0
+        weight = 1.0
+        if value < start + falloff:
+            weight *= _smoothstep(start, start + falloff, value)
+        if value > end - falloff:
+            weight *= 1.0 - _smoothstep(end - falloff, end, value)
+        return weight
+
+    def _profile_weight(value, profile):
+        if not profile:
+            return 1.0
+        if value <= profile[0][0]:
+            return profile[0][1]
+        if value >= profile[-1][0]:
+            return profile[-1][1]
+        for index in range(len(profile) - 1):
+            x0, y0 = profile[index]
+            x1, y1 = profile[index + 1]
+            if x0 <= value <= x1:
+                if abs(x1 - x0) <= 1e-9:
+                    return y1
+                t = (value - x0) / (x1 - x0)
+                return y0 + (y1 - y0) * t
+        return 1.0
+
+    def _validate_profile(profile, arg_name):
+        if profile is None:
+            return None
+        if not isinstance(profile, list) or len(profile) < 2:
+            raise ValueError(f"{arg_name} must contain at least two [value, weight] points.")
+        clean = []
+        previous_value = None
+        for point in profile:
+            value, weight = _validate_vector(point, 2, f"{arg_name} point")
+            if previous_value is not None and value <= previous_value:
+                raise ValueError(f"{arg_name} values must be strictly increasing.")
+            clean.append([value, weight])
+            previous_value = value
+        return clean
+
+    def _pattern(angle):
+        if waveform == "sin":
+            return math.sin(angle)
+        if waveform == "cosine":
+            return math.cos(angle)
+        value = max(0.0, 0.5 + 0.5 * math.cos(angle))
+        return value ** sharpness
+
+    if not cmds.objExists(object_name):
+        raise ValueError(f"Object does not exist: {object_name}")
+
+    center = _validate_vector(center, 3, "center")
+    axis = axis.lower()
+    axes = {
+        "x": (0, 1, 2),
+        "y": (1, 0, 2),
+        "z": (2, 0, 1),
+    }
+    if axis not in axes:
+        raise ValueError("axis must be one of x, y, or z.")
+    axis_index, radial_a, radial_b = axes[axis]
+
+    if not isinstance(cycles, int) or isinstance(cycles, bool) or cycles < 1:
+        raise ValueError("cycles must be an integer greater than or equal to 1.")
+    radial_amplitude = _validate_scalar(radial_amplitude, "radial_amplitude")
+    axis_amplitude = _validate_scalar(axis_amplitude, "axis_amplitude")
+    uniform_axis_amplitude = _validate_scalar(uniform_axis_amplitude, "uniform_axis_amplitude")
+    phase = math.radians(_validate_scalar(phase_degrees, "phase_degrees"))
+    sharpness = _validate_scalar(sharpness, "sharpness")
+    if sharpness <= 0.0:
+        raise ValueError("sharpness must be greater than zero.")
+
+    waveform = waveform.lower()
+    if waveform not in {"ridge", "groove", "sin", "cosine"}:
+        raise ValueError("waveform must be one of ridge, groove, sin, or cosine.")
+
+    clean_axis_range = _validate_vector(axis_range, 2, "axis_range") if axis_range is not None else None
+    clean_radial_range = _validate_vector(radial_range, 2, "radial_range") if radial_range is not None else None
+    axis_falloff = _validate_scalar(axis_falloff, "axis_falloff")
+    radial_falloff = _validate_scalar(radial_falloff, "radial_falloff")
+    if axis_falloff < 0.0 or radial_falloff < 0.0:
+        raise ValueError("falloff values must be non-negative.")
+    clean_axis_profile = _validate_profile(axis_profile, "axis_profile")
+    clean_radial_profile = _validate_profile(radial_profile, "radial_profile")
+
+    shapes = cmds.listRelatives(object_name, shapes=True, fullPath=True) or []
+    if cmds.objectType(object_name) == "mesh":
+        shapes = [object_name]
+    if not any(cmds.objectType(shape) == "mesh" for shape in shapes):
+        raise ValueError(f"{object_name} is not a polygon mesh transform or mesh shape.")
+
+    vertices = cmds.ls(f"{object_name}.vtx[*]", flatten=True) or []
+    if not vertices:
+        raise ValueError(f"No vertices found on {object_name}.")
+
+    radial_displacements = []
+    axis_displacements = []
+    deformed_vertices = 0
+
+    for vertex in vertices:
+        position = cmds.xform(vertex, query=True, worldSpace=True, translation=True)
+        local_axis = position[axis_index] - center[axis_index]
+        axis_weight = _range_weight(local_axis, clean_axis_range, axis_falloff)
+        axis_weight *= _profile_weight(local_axis, clean_axis_profile)
+        if axis_weight == 0.0:
+            continue
+
+        delta_a = position[radial_a] - center[radial_a]
+        delta_b = position[radial_b] - center[radial_b]
+        radius = math.sqrt(delta_a * delta_a + delta_b * delta_b)
+        radial_weight = _range_weight(radius, clean_radial_range, radial_falloff)
+        radial_weight *= _profile_weight(radius, clean_radial_profile)
+        weight = axis_weight * radial_weight
+        if weight == 0.0:
+            continue
+
+        angle = math.atan2(delta_a, delta_b)
+        feature = _pattern(cycles * angle + phase)
+        radial_displacement = radial_amplitude * feature * weight
+        axis_displacement = (axis_amplitude * feature + uniform_axis_amplitude) * weight
+
+        if radius > 1e-8 and radial_displacement != 0.0:
+            new_radius = max(0.0, radius + radial_displacement)
+            scale = new_radius / radius
+            position[radial_a] = center[radial_a] + delta_a * scale
+            position[radial_b] = center[radial_b] + delta_b * scale
+        position[axis_index] = position[axis_index] + axis_displacement
+        cmds.xform(vertex, worldSpace=True, translation=position)
+
+        radial_displacements.append(radial_displacement)
+        axis_displacements.append(axis_displacement)
+        deformed_vertices += 1
+
+    if smooth:
+        cmds.polySoftEdge(object_name, angle=180, constructionHistory=False)
+
+    return {
+        "success": True,
+        "object_name": object_name,
+        "deformed_vertices": deformed_vertices,
+        "cycles": cycles,
+        "radial_amplitude": radial_amplitude,
+        "axis_amplitude": axis_amplitude,
+        "uniform_axis_amplitude": uniform_axis_amplitude,
+        "waveform": waveform,
+        "phase_degrees": phase_degrees,
+        "sharpness": sharpness,
+        "axis": axis,
+        "axis_range": clean_axis_range,
+        "axis_falloff": axis_falloff,
+        "axis_profile": clean_axis_profile,
+        "radial_range": clean_radial_range,
+        "radial_falloff": radial_falloff,
+        "radial_profile": clean_radial_profile,
+        "min_radial_displacement": min(radial_displacements) if radial_displacements else 0.0,
+        "max_radial_displacement": max(radial_displacements) if radial_displacements else 0.0,
+        "min_axis_displacement": min(axis_displacements) if axis_displacements else 0.0,
+        "max_axis_displacement": max(axis_displacements) if axis_displacements else 0.0,
+        "bounding_box": cmds.exactWorldBoundingBox(object_name),
+    }

--- a/src/mayatools/object/radial_mesh_deform.py
+++ b/src/mayatools/object/radial_mesh_deform.py
@@ -1,0 +1,193 @@
+from typing import Dict, List, Any
+
+
+def radial_mesh_deform(
+    object_name: str,
+    center: List[float] = [0.0, 0.0, 0.0],
+    axis: str = "y",
+    cycles: int = 12,
+    amplitude: float = -0.05,
+    waveform: str = "groove",
+    phase_degrees: float = 0.0,
+    sharpness: float = 2.0,
+    axis_range: List[float] = None,
+    axis_falloff: float = 0.0,
+    axis_profile: List[List[float]] = None,
+    smooth: bool = True,
+) -> Dict[str, Any]:
+    """Apply a periodic radial deformation to a polygon mesh.
+
+    This is useful for generic lathed or cylindrical forms that need flutes,
+    grooves, ridges, corrugation, or other repeated radial detail. UVs are not
+    edited; only vertex positions are moved.
+
+    Waveforms:
+    - sin: signed sine wave in the range -1..1
+    - cosine: signed cosine wave in the range -1..1
+    - groove: repeated positive lobes in the range 0..1, usually with negative amplitude
+    - ridge: repeated positive lobes in the range 0..1, usually with positive amplitude
+    """
+    import math
+    import maya.cmds as cmds
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_vector(values, length, name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(v) for v in values):
+            raise ValueError(f"{name} must be a list of {length} numeric values.")
+        return [float(v) for v in values]
+
+    def _smoothstep(edge0, edge1, value):
+        if edge0 == edge1:
+            return 1.0 if value >= edge1 else 0.0
+        t = max(0.0, min(1.0, (value - edge0) / (edge1 - edge0)))
+        return t * t * (3.0 - 2.0 * t)
+
+    def _range_weight(value, value_range, falloff):
+        if value_range is None:
+            return 1.0
+        start, end = value_range
+        if start > end:
+            start, end = end, start
+        if value < start or value > end:
+            return 0.0
+        if falloff <= 0.0:
+            return 1.0
+        weight = 1.0
+        if value < start + falloff:
+            weight *= _smoothstep(start, start + falloff, value)
+        if value > end - falloff:
+            weight *= 1.0 - _smoothstep(end - falloff, end, value)
+        return weight
+
+    def _profile_weight(value, profile):
+        if not profile:
+            return 1.0
+        if value <= profile[0][0]:
+            return profile[0][1]
+        if value >= profile[-1][0]:
+            return profile[-1][1]
+        for index in range(len(profile) - 1):
+            x0, y0 = profile[index]
+            x1, y1 = profile[index + 1]
+            if x0 <= value <= x1:
+                if x0 == x1:
+                    return y1
+                t = (value - x0) / (x1 - x0)
+                return y0 + (y1 - y0) * t
+        return 1.0
+
+    if not cmds.objExists(object_name):
+        raise ValueError(f"Object does not exist: {object_name}")
+
+    center = _validate_vector(center, 3, "center")
+    axis = axis.lower()
+    axes = {
+        "x": (0, 1, 2),
+        "y": (1, 0, 2),
+        "z": (2, 0, 1),
+    }
+    if axis not in axes:
+        raise ValueError("axis must be one of x, y, or z.")
+    axis_index, radial_a, radial_b = axes[axis]
+
+    if cycles < 1:
+        raise ValueError("cycles must be at least 1.")
+    if not _is_number(amplitude):
+        raise ValueError("amplitude must be numeric.")
+    if not _is_number(phase_degrees):
+        raise ValueError("phase_degrees must be numeric.")
+    if not _is_number(sharpness) or sharpness <= 0:
+        raise ValueError("sharpness must be a number greater than zero.")
+
+    waveform = waveform.lower()
+    if waveform not in {"sin", "cosine", "groove", "ridge"}:
+        raise ValueError("waveform must be one of sin, cosine, groove, or ridge.")
+
+    clean_axis_range = None
+    if axis_range is not None:
+        clean_axis_range = _validate_vector(axis_range, 2, "axis_range")
+    if not _is_number(axis_falloff) or axis_falloff < 0:
+        raise ValueError("axis_falloff must be a non-negative number.")
+
+    clean_axis_profile = None
+    if axis_profile is not None:
+        if not isinstance(axis_profile, list) or len(axis_profile) < 2:
+            raise ValueError("axis_profile must contain at least two [axis_value, weight] points.")
+        clean_axis_profile = []
+        previous_value = None
+        for point in axis_profile:
+            axis_value, weight = _validate_vector(point, 2, "axis_profile point")
+            if previous_value is not None and axis_value <= previous_value:
+                raise ValueError("axis_profile axis values must be strictly increasing.")
+            clean_axis_profile.append([axis_value, weight])
+            previous_value = axis_value
+
+    shapes = cmds.listRelatives(object_name, shapes=True, fullPath=True) or []
+    if cmds.objectType(object_name) == "mesh":
+        shapes = [object_name]
+    if not any(cmds.objectType(shape) == "mesh" for shape in shapes):
+        raise ValueError(f"{object_name} is not a polygon mesh transform or mesh shape.")
+
+    vertices = cmds.ls(f"{object_name}.vtx[*]", flatten=True) or []
+    if not vertices:
+        raise ValueError(f"No vertices found on {object_name}.")
+
+    phase = math.radians(phase_degrees)
+    displacement_values = []
+    deformed_vertices = 0
+
+    for vertex in vertices:
+        position = cmds.xform(vertex, query=True, worldSpace=True, translation=True)
+        axis_value = position[axis_index] - center[axis_index]
+        weight = _range_weight(axis_value, clean_axis_range, float(axis_falloff))
+        weight *= _profile_weight(axis_value, clean_axis_profile)
+        if weight == 0.0:
+            continue
+
+        delta_a = position[radial_a] - center[radial_a]
+        delta_b = position[radial_b] - center[radial_b]
+        radius = math.sqrt(delta_a * delta_a + delta_b * delta_b)
+        if radius <= 1e-8:
+            continue
+
+        angle = math.atan2(delta_a, delta_b)
+        wave_angle = cycles * angle + phase
+        if waveform == "sin":
+            pattern = math.sin(wave_angle)
+        elif waveform == "cosine":
+            pattern = math.cos(wave_angle)
+        else:
+            pattern = max(0.0, 0.5 + 0.5 * math.cos(wave_angle))
+            pattern = pattern ** float(sharpness)
+
+        displacement = float(amplitude) * pattern * weight
+        new_radius = max(0.0, radius + displacement)
+        scale = new_radius / radius
+        position[radial_a] = center[radial_a] + delta_a * scale
+        position[radial_b] = center[radial_b] + delta_b * scale
+        cmds.xform(vertex, worldSpace=True, translation=position)
+
+        displacement_values.append(displacement)
+        deformed_vertices += 1
+
+    if smooth:
+        cmds.polySoftEdge(object_name, angle=180, constructionHistory=False)
+
+    bbox = cmds.exactWorldBoundingBox(object_name)
+    return {
+        "success": True,
+        "object_name": object_name,
+        "deformed_vertices": deformed_vertices,
+        "cycles": cycles,
+        "amplitude": float(amplitude),
+        "waveform": waveform,
+        "axis": axis,
+        "axis_range": clean_axis_range,
+        "axis_falloff": float(axis_falloff),
+        "axis_profile": clean_axis_profile,
+        "min_displacement": min(displacement_values) if displacement_values else 0.0,
+        "max_displacement": max(displacement_values) if displacement_values else 0.0,
+        "bounding_box": bbox,
+    }

--- a/src/mayatools/object/radial_profile_deform.py
+++ b/src/mayatools/object/radial_profile_deform.py
@@ -31,6 +31,7 @@ def radial_profile_deform(
     """
     import math
     import maya.cmds as cmds
+    import maya.api.OpenMaya as om
 
     def _is_number(value):
         return isinstance(value, (int, float)) and not isinstance(value, bool)
@@ -122,8 +123,14 @@ def radial_profile_deform(
     shapes = cmds.listRelatives(object_name, shapes=True, fullPath=True) or []
     if cmds.objectType(object_name) == "mesh":
         shapes = [object_name]
-    if not any(cmds.objectType(shape) == "mesh" for shape in shapes):
+    mesh_shapes = [shape for shape in shapes if cmds.objectType(shape) == "mesh"]
+    if not mesh_shapes:
         raise ValueError(f"{object_name} is not a polygon mesh transform or mesh shape.")
+
+    selection = om.MSelectionList()
+    selection.add(mesh_shapes[0])
+    dag_path = selection.getDagPath(0)
+    mesh_fn = om.MFnMesh(dag_path)
 
     bbox = cmds.exactWorldBoundingBox(object_name)
     if center is None:
@@ -145,16 +152,17 @@ def radial_profile_deform(
     if position_mode == "normalized" and abs(axis_span) <= 1e-9:
         raise ValueError("axis_range must have non-zero length when position_mode is normalized.")
 
-    vertices = cmds.ls(f"{object_name}.vtx[*]", flatten=True) or []
-    if not vertices:
+    points = mesh_fn.getPoints(om.MSpace.kWorld)
+    if not points:
         raise ValueError(f"No vertices found on {object_name}.")
 
     displacements = []
     deformed_vertices = 0
     skipped_vertices = 0
 
-    for vertex in vertices:
-        position = cmds.xform(vertex, query=True, worldSpace=True, translation=True)
+    for point_index in range(len(points)):
+        point = points[point_index]
+        position = [point.x, point.y, point.z]
         axis_value = position[axis_index]
         if axis_value < clean_axis_range[0] or axis_value > clean_axis_range[1]:
             skipped_vertices += 1
@@ -191,9 +199,12 @@ def radial_profile_deform(
         scale = new_radius / radius
         position[radial_a] = clean_center[radial_a] + delta_a * scale
         position[radial_b] = clean_center[radial_b] + delta_b * scale
-        cmds.xform(vertex, worldSpace=True, translation=position)
+        points[point_index] = om.MPoint(position[0], position[1], position[2])
         displacements.append(displacement)
         deformed_vertices += 1
+
+    if deformed_vertices:
+        mesh_fn.setPoints(points, om.MSpace.kWorld)
 
     if smooth:
         cmds.polySoftEdge(object_name, angle=180, constructionHistory=False)

--- a/src/mayatools/object/radial_profile_deform.py
+++ b/src/mayatools/object/radial_profile_deform.py
@@ -1,0 +1,222 @@
+from typing import Dict, List, Any
+
+
+def radial_profile_deform(
+    object_name: str,
+    profile_points: List[List[float]],
+    center: List[float] = None,
+    axis: str = "y",
+    position_mode: str = "normalized",
+    value_mode: str = "scale",
+    interpolation: str = "smooth",
+    axis_range: List[float] = None,
+    blend: float = 1.0,
+    max_abs_displacement: float = None,
+    min_radius: float = 1e-6,
+    smooth: bool = True,
+) -> Dict[str, Any]:
+    """Apply an axial radial profile deformation to a polygon mesh.
+
+    The tool samples a user-provided profile along a chosen axis and changes
+    each vertex radius around that axis. It is useful for generic silhouette
+    correction and shaping on lathed or cylindrical meshes: bottle shoulders,
+    can tapers, cup waists, vase bellies, tube bulges, neck transitions, and
+    other non-periodic profile adjustments. UVs are not edited.
+
+    profile_points are [position, value] pairs. With position_mode="normalized",
+    positions are 0..1 over axis_range or the object's bounding box. With
+    value_mode="scale", values multiply the current radius. With
+    value_mode="offset", values add to the current radius. With
+    value_mode="target_radius", values are absolute target radii.
+    """
+    import math
+    import maya.cmds as cmds
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(value) for value in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(value) for value in values]
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _clamp(value, lower, upper):
+        return max(lower, min(upper, value))
+
+    def _smoothstep(value):
+        value = _clamp(value, 0.0, 1.0)
+        return value * value * (3.0 - 2.0 * value)
+
+    def _validate_profile(points):
+        if not isinstance(points, list) or len(points) < 2:
+            raise ValueError("profile_points must contain at least two [position, value] points.")
+        clean = []
+        previous_position = None
+        for point in points:
+            position, value = _validate_vector(point, 2, "profile_points point")
+            if position_mode == "normalized" and (position < 0.0 or position > 1.0):
+                raise ValueError("Normalized profile point positions must be in the range 0..1.")
+            if previous_position is not None and position <= previous_position:
+                raise ValueError("profile_points positions must be strictly increasing.")
+            clean.append([position, value])
+            previous_position = position
+        return clean
+
+    def _sample_profile(position):
+        if position <= clean_profile[0][0]:
+            return clean_profile[0][1]
+        if position >= clean_profile[-1][0]:
+            return clean_profile[-1][1]
+        for index in range(len(clean_profile) - 1):
+            x0, y0 = clean_profile[index]
+            x1, y1 = clean_profile[index + 1]
+            if x0 <= position <= x1:
+                if abs(x1 - x0) <= 1e-9:
+                    return y1
+                t = (position - x0) / (x1 - x0)
+                if interpolation == "smooth":
+                    t = _smoothstep(t)
+                return y0 + (y1 - y0) * t
+        return clean_profile[-1][1]
+
+    if not cmds.objExists(object_name):
+        raise ValueError(f"Object does not exist: {object_name}")
+
+    axis = axis.lower().strip()
+    axes = {
+        "x": (0, 1, 2),
+        "y": (1, 0, 2),
+        "z": (2, 0, 1),
+    }
+    if axis not in axes:
+        raise ValueError("axis must be one of x, y, or z.")
+    axis_index, radial_a, radial_b = axes[axis]
+
+    position_mode = position_mode.lower().strip()
+    if position_mode not in {"normalized", "world"}:
+        raise ValueError("position_mode must be normalized or world.")
+    value_mode = value_mode.lower().strip()
+    if value_mode not in {"scale", "offset", "target_radius"}:
+        raise ValueError("value_mode must be scale, offset, or target_radius.")
+    interpolation = interpolation.lower().strip()
+    if interpolation not in {"linear", "smooth"}:
+        raise ValueError("interpolation must be linear or smooth.")
+
+    clean_profile = _validate_profile(profile_points)
+    blend = _validate_scalar(blend, "blend")
+    if blend < 0.0 or blend > 1.0:
+        raise ValueError("blend must be in the range 0..1.")
+    min_radius = _validate_scalar(min_radius, "min_radius")
+    if min_radius < 0.0:
+        raise ValueError("min_radius must be greater than or equal to zero.")
+    if max_abs_displacement is not None:
+        max_abs_displacement = _validate_scalar(max_abs_displacement, "max_abs_displacement")
+        if max_abs_displacement < 0.0:
+            raise ValueError("max_abs_displacement must be greater than or equal to zero.")
+
+    shapes = cmds.listRelatives(object_name, shapes=True, fullPath=True) or []
+    if cmds.objectType(object_name) == "mesh":
+        shapes = [object_name]
+    if not any(cmds.objectType(shape) == "mesh" for shape in shapes):
+        raise ValueError(f"{object_name} is not a polygon mesh transform or mesh shape.")
+
+    bbox = cmds.exactWorldBoundingBox(object_name)
+    if center is None:
+        clean_center = [
+            (bbox[0] + bbox[3]) * 0.5,
+            (bbox[1] + bbox[4]) * 0.5,
+            (bbox[2] + bbox[5]) * 0.5,
+        ]
+    else:
+        clean_center = _validate_vector(center, 3, "center")
+
+    if axis_range is None:
+        clean_axis_range = [bbox[axis_index], bbox[axis_index + 3]]
+    else:
+        clean_axis_range = _validate_vector(axis_range, 2, "axis_range")
+    if clean_axis_range[1] < clean_axis_range[0]:
+        clean_axis_range = [clean_axis_range[1], clean_axis_range[0]]
+    axis_span = clean_axis_range[1] - clean_axis_range[0]
+    if position_mode == "normalized" and abs(axis_span) <= 1e-9:
+        raise ValueError("axis_range must have non-zero length when position_mode is normalized.")
+
+    vertices = cmds.ls(f"{object_name}.vtx[*]", flatten=True) or []
+    if not vertices:
+        raise ValueError(f"No vertices found on {object_name}.")
+
+    displacements = []
+    deformed_vertices = 0
+    skipped_vertices = 0
+
+    for vertex in vertices:
+        position = cmds.xform(vertex, query=True, worldSpace=True, translation=True)
+        axis_value = position[axis_index]
+        if axis_value < clean_axis_range[0] or axis_value > clean_axis_range[1]:
+            skipped_vertices += 1
+            continue
+
+        if position_mode == "normalized":
+            profile_position = (axis_value - clean_axis_range[0]) / axis_span
+        else:
+            profile_position = axis_value
+
+        delta_a = position[radial_a] - clean_center[radial_a]
+        delta_b = position[radial_b] - clean_center[radial_b]
+        radius = math.sqrt(delta_a * delta_a + delta_b * delta_b)
+        if radius <= min_radius:
+            skipped_vertices += 1
+            continue
+
+        value = _sample_profile(profile_position)
+        if value_mode == "scale":
+            target_radius = radius * value
+        elif value_mode == "offset":
+            target_radius = radius + value
+        else:
+            target_radius = value
+        target_radius = max(0.0, target_radius)
+
+        displacement = (target_radius - radius) * blend
+        if max_abs_displacement is not None:
+            displacement = _clamp(displacement, -max_abs_displacement, max_abs_displacement)
+        if abs(displacement) <= 1e-12:
+            continue
+
+        new_radius = max(0.0, radius + displacement)
+        scale = new_radius / radius
+        position[radial_a] = clean_center[radial_a] + delta_a * scale
+        position[radial_b] = clean_center[radial_b] + delta_b * scale
+        cmds.xform(vertex, worldSpace=True, translation=position)
+        displacements.append(displacement)
+        deformed_vertices += 1
+
+    if smooth:
+        cmds.polySoftEdge(object_name, angle=180, constructionHistory=False)
+
+    return {
+        "success": True,
+        "object_name": object_name,
+        "axis": axis,
+        "center": clean_center,
+        "axis_range": clean_axis_range,
+        "position_mode": position_mode,
+        "value_mode": value_mode,
+        "interpolation": interpolation,
+        "profile_points": clean_profile,
+        "blend": blend,
+        "max_abs_displacement": max_abs_displacement,
+        "deformed_vertices": deformed_vertices,
+        "skipped_vertices": skipped_vertices,
+        "min_displacement": min(displacements) if displacements else 0.0,
+        "max_displacement": max(displacements) if displacements else 0.0,
+        "mean_abs_displacement": (
+            sum(abs(value) for value in displacements) / float(len(displacements))
+            if displacements else 0.0
+        ),
+        "bounding_box": cmds.exactWorldBoundingBox(object_name),
+    }

--- a/src/mayatools/object/sample_mesh_radial_profile.py
+++ b/src/mayatools/object/sample_mesh_radial_profile.py
@@ -1,0 +1,219 @@
+from typing import Dict, List, Any
+
+
+def sample_mesh_radial_profile(
+    object_name: str,
+    center: List[float] = None,
+    axis: str = "y",
+    axis_range: List[float] = None,
+    sample_count: int = 32,
+    radius_stat: str = "max",
+    percentile: float = 90.0,
+    position_mode: str = "world",
+    min_vertices_per_sample: int = 1,
+) -> Dict[str, Any]:
+    """Sample an axial radial profile from an existing polygon mesh.
+
+    The tool bins mesh vertices along an axis and reports representative radii
+    around a center point. It is useful for reverse-engineering approximate
+    revolve profiles from existing bottles, cups, vases, liquid volumes, shells,
+    pipes, and other near-axisymmetric meshes before rebuilding or comparing
+    them with generic profile-based tools.
+    """
+    import math
+    import maya.cmds as cmds
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(value) for value in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(value) for value in values]
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _percentile(values, pct):
+        if not values:
+            return 0.0
+        ordered = sorted(values)
+        if len(ordered) == 1:
+            return ordered[0]
+        position = (max(0.0, min(100.0, pct)) / 100.0) * (len(ordered) - 1)
+        lower = int(math.floor(position))
+        upper = int(math.ceil(position))
+        if lower == upper:
+            return ordered[lower]
+        t = position - lower
+        return ordered[lower] + (ordered[upper] - ordered[lower]) * t
+
+    if not cmds.objExists(object_name):
+        raise ValueError(f"Object does not exist: {object_name}")
+
+    axis = axis.lower().strip()
+    axes = {
+        "x": (0, 1, 2),
+        "y": (1, 0, 2),
+        "z": (2, 0, 1),
+    }
+    if axis not in axes:
+        raise ValueError("axis must be one of x, y, or z.")
+    axis_index, radial_a, radial_b = axes[axis]
+
+    if not isinstance(sample_count, int) or isinstance(sample_count, bool) or sample_count < 2:
+        raise ValueError("sample_count must be an integer greater than or equal to 2.")
+    if not isinstance(min_vertices_per_sample, int) or isinstance(min_vertices_per_sample, bool) or min_vertices_per_sample < 1:
+        raise ValueError("min_vertices_per_sample must be an integer greater than or equal to 1.")
+
+    radius_stat = radius_stat.lower().strip()
+    if radius_stat not in {"max", "mean", "min", "median", "percentile"}:
+        raise ValueError("radius_stat must be one of max, mean, min, median, or percentile.")
+    percentile = _validate_scalar(percentile, "percentile")
+    if percentile < 0.0 or percentile > 100.0:
+        raise ValueError("percentile must be in the range 0..100.")
+
+    position_mode = position_mode.lower().strip()
+    if position_mode not in {"world", "relative", "normalized"}:
+        raise ValueError("position_mode must be world, relative, or normalized.")
+
+    shapes = cmds.listRelatives(object_name, shapes=True, fullPath=True) or []
+    if cmds.objectType(object_name) == "mesh":
+        shapes = [object_name]
+    if not any(cmds.objectType(shape) == "mesh" for shape in shapes):
+        raise ValueError(f"{object_name} is not a polygon mesh transform or mesh shape.")
+
+    bbox = cmds.exactWorldBoundingBox(object_name)
+    if center is None:
+        clean_center = [
+            (bbox[0] + bbox[3]) * 0.5,
+            (bbox[1] + bbox[4]) * 0.5,
+            (bbox[2] + bbox[5]) * 0.5,
+        ]
+    else:
+        clean_center = _validate_vector(center, 3, "center")
+
+    if axis_range is None:
+        clean_axis_range = [bbox[axis_index], bbox[axis_index + 3]]
+    else:
+        clean_axis_range = _validate_vector(axis_range, 2, "axis_range")
+    if clean_axis_range[1] < clean_axis_range[0]:
+        clean_axis_range = [clean_axis_range[1], clean_axis_range[0]]
+    axis_span = clean_axis_range[1] - clean_axis_range[0]
+    if axis_span <= 1e-9:
+        raise ValueError("axis_range must have non-zero length.")
+
+    vertices = cmds.ls(f"{object_name}.vtx[*]", flatten=True) or []
+    if not vertices:
+        raise ValueError(f"No vertices found on {object_name}.")
+
+    samples = [
+        {
+            "axis_value_world": clean_axis_range[0] + axis_span * (index / float(sample_count - 1)),
+            "radii": [],
+        }
+        for index in range(sample_count)
+    ]
+
+    band_count = sample_count - 1
+    skipped_vertices = 0
+    for vertex in vertices:
+        position = cmds.xform(vertex, query=True, worldSpace=True, translation=True)
+        axis_value = position[axis_index]
+        if axis_value < clean_axis_range[0] or axis_value > clean_axis_range[1]:
+            skipped_vertices += 1
+            continue
+        t = (axis_value - clean_axis_range[0]) / axis_span
+        sample_index = int(round(t * band_count))
+        sample_index = max(0, min(sample_count - 1, sample_index))
+        delta_a = position[radial_a] - clean_center[radial_a]
+        delta_b = position[radial_b] - clean_center[radial_b]
+        samples[sample_index]["radii"].append(math.sqrt(delta_a * delta_a + delta_b * delta_b))
+
+    valid_samples = []
+    for index, sample in enumerate(samples):
+        radii = sample["radii"]
+        valid = len(radii) >= min_vertices_per_sample
+        if valid:
+            if radius_stat == "max":
+                radius = max(radii)
+            elif radius_stat == "min":
+                radius = min(radii)
+            elif radius_stat == "mean":
+                radius = sum(radii) / float(len(radii))
+            elif radius_stat == "median":
+                radius = _percentile(radii, 50.0)
+            else:
+                radius = _percentile(radii, percentile)
+            valid_samples.append((index, radius))
+        sample["vertex_count"] = len(radii)
+        sample["valid"] = valid
+        sample["radius"] = None
+
+    if not valid_samples:
+        raise ValueError("No samples had enough vertices. Lower min_vertices_per_sample or expand axis_range.")
+
+    for index, radius in valid_samples:
+        samples[index]["radius"] = radius
+
+    # Fill empty samples by nearest-neighbor interpolation so the returned
+    # profile is directly usable by profile-based modeling tools.
+    for index, sample in enumerate(samples):
+        if sample["radius"] is not None:
+            continue
+        previous_valid = None
+        next_valid = None
+        for valid_index, radius in reversed(valid_samples):
+            if valid_index < index:
+                previous_valid = (valid_index, radius)
+                break
+        for valid_index, radius in valid_samples:
+            if valid_index > index:
+                next_valid = (valid_index, radius)
+                break
+        if previous_valid and next_valid:
+            span = next_valid[0] - previous_valid[0]
+            t = (index - previous_valid[0]) / float(span)
+            sample["radius"] = previous_valid[1] + (next_valid[1] - previous_valid[1]) * t
+        elif previous_valid:
+            sample["radius"] = previous_valid[1]
+        else:
+            sample["radius"] = next_valid[1]
+
+    profile_points = []
+    for sample in samples:
+        world_value = sample["axis_value_world"]
+        if position_mode == "world":
+            profile_position = world_value
+        elif position_mode == "relative":
+            profile_position = world_value - clean_center[axis_index]
+        else:
+            profile_position = (world_value - clean_axis_range[0]) / axis_span
+        profile_points.append([profile_position, sample["radius"]])
+
+    return {
+        "success": True,
+        "object_name": object_name,
+        "axis": axis,
+        "center": clean_center,
+        "axis_range": clean_axis_range,
+        "sample_count": sample_count,
+        "radius_stat": radius_stat,
+        "percentile": percentile,
+        "position_mode": position_mode,
+        "min_vertices_per_sample": min_vertices_per_sample,
+        "skipped_vertices": skipped_vertices,
+        "profile_points": profile_points,
+        "samples": [
+            {
+                "axis_value_world": sample["axis_value_world"],
+                "profile_position": profile_points[index][0],
+                "radius": sample["radius"],
+                "vertex_count": sample["vertex_count"],
+                "valid": sample["valid"],
+            }
+            for index, sample in enumerate(samples)
+        ],
+    }

--- a/src/mayatools/object/sculpt_mesh_components.py
+++ b/src/mayatools/object/sculpt_mesh_components.py
@@ -1,0 +1,287 @@
+from typing import Dict, List, Union
+
+
+def sculpt_mesh_components(
+    object_name: str,
+    operation: str,
+    component_type: str = "vertex",
+    indices: List[int] = None,
+    components: Union[str, List[str]] = None,
+    iterations: int = 1,
+    strength: float = 1.0,
+    distance: float = 0.0,
+    preserve_boundary: bool = True,
+    space: str = "world",
+    use_selection: bool = True,
+    max_preview: int = 20,
+) -> Dict[str, object]:
+    """Locally smooth, relax, or inflate polygon mesh components.
+
+    Operations:
+    - average_vertices: move vertices toward the average of connected vertices
+    - relax_vertices: move vertices tangentially toward connected averages,
+      reducing irregular spacing while preserving local volume better
+    - shrink_fatten_vertices: move vertices along their averaged vertex normals
+
+    Components can be explicit, indexed, or taken from the current selection.
+    Edges and faces are converted to vertices. This supports Maya-style local
+    cleanup of uneven point spacing, soft sculpt-like surface relaxation, and
+    small inflate/deflate adjustments without global procedural deformation.
+    """
+    import math
+    import re
+    import maya.cmds as cmds
+    import maya.api.OpenMaya as om
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return int(value)
+
+    def _mesh_shape(node):
+        if not cmds.objExists(node):
+            raise ValueError(f"Object does not exist: {node}")
+        if cmds.objectType(node) == "mesh":
+            return node
+        shapes = cmds.listRelatives(node, shapes=True, fullPath=True) or []
+        mesh_shapes = []
+        for shape in shapes:
+            if cmds.objectType(shape) != "mesh":
+                continue
+            try:
+                if cmds.attributeQuery("intermediateObject", node=shape, exists=True) and cmds.getAttr(f"{shape}.intermediateObject"):
+                    continue
+            except Exception:
+                pass
+            mesh_shapes.append(shape)
+        if not mesh_shapes:
+            raise ValueError(f"{node} is not a polygon mesh transform or mesh shape.")
+        return mesh_shapes[0]
+
+    def _dag_path(shape):
+        selection = om.MSelectionList()
+        selection.add(shape)
+        return selection.getDagPath(0)
+
+    def _mesh_fn(shape):
+        return om.MFnMesh(_dag_path(shape))
+
+    def _prefix(shape):
+        parents = cmds.listRelatives(shape, parent=True, fullPath=False) or []
+        return parents[0] if parents else object_name
+
+    def _flatten(value):
+        if value is None:
+            return []
+        if isinstance(value, str):
+            value = [value]
+        if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+            raise ValueError("components must be a string, a list of strings, or None.")
+        return cmds.ls(value, flatten=True) or []
+
+    def _components_from_indices(kind):
+        if indices is None:
+            return []
+        if not isinstance(indices, list) or not all(isinstance(index, int) and not isinstance(index, bool) for index in indices):
+            raise ValueError("indices must be a list of integers.")
+        return [f"{prefix_name}.{kind}[{index}]" for index in indices]
+
+    def _selected_components():
+        if not use_selection:
+            return []
+        selected = cmds.ls(selection=True, flatten=True) or []
+        object_tokens = {object_name, prefix_name, shape_name}
+        return [item for item in selected if item.split(".", 1)[0] in object_tokens]
+
+    def _resolve_components():
+        clean_type = component_type.lower().strip()
+        kind_map = {"vertex": "vtx", "edge": "e", "face": "f", "uv": "map", "vertex_face": "vtxFace"}
+        if components is not None:
+            resolved = _flatten(components)
+        elif clean_type in kind_map and indices is not None:
+            resolved = _components_from_indices(kind_map[clean_type])
+        else:
+            resolved = _selected_components()
+        if not resolved:
+            raise ValueError("No components resolved from components, indices, or current selection.")
+        return resolved
+
+    def _vertex_ids_from_components(items):
+        converted = cmds.polyListComponentConversion(items, toVertex=True) or []
+        vertices = cmds.ls(converted, flatten=True) or []
+        pattern = re.compile(r"\.vtx\[(\d+)\]$")
+        ids = []
+        for vertex in vertices:
+            match = pattern.search(vertex)
+            if match:
+                ids.append(int(match.group(1)))
+        return sorted(set(ids))
+
+    def _edge_adjacency_and_boundary():
+        adjacency = {vertex_id: set() for vertex_id in range(mesh_fn.numVertices)}
+        boundary_vertices = set()
+        edge_it = om.MItMeshEdge(dag)
+        while not edge_it.isDone():
+            v0 = int(edge_it.vertexId(0))
+            v1 = int(edge_it.vertexId(1))
+            adjacency[v0].add(v1)
+            adjacency[v1].add(v0)
+            try:
+                connected_faces = edge_it.getConnectedFaces()
+            except Exception:
+                connected_faces = []
+            if len(connected_faces) < 2:
+                boundary_vertices.add(v0)
+                boundary_vertices.add(v1)
+            edge_it.next()
+        return adjacency, boundary_vertices
+
+    def _point_list(point):
+        return [float(point.x), float(point.y), float(point.z)]
+
+    def _distance(a, b):
+        return math.sqrt((a.x - b.x) ** 2 + (a.y - b.y) ** 2 + (a.z - b.z) ** 2)
+
+    def _average_point(points, neighbor_ids):
+        center = om.MPoint()
+        for neighbor_id in neighbor_ids:
+            center += points[neighbor_id]
+        return center / float(len(neighbor_ids))
+
+    def _normal(vertex_id):
+        normal = mesh_fn.getVertexNormal(vertex_id, True, om_space)
+        vector = om.MVector(normal.x, normal.y, normal.z)
+        if vector.length() <= 1e-9:
+            return om.MVector(0.0, 1.0, 0.0)
+        vector.normalize()
+        return vector
+
+    def _preview(vertex_ids, before_points, after_points):
+        items = []
+        for vertex_id in vertex_ids[:max_preview]:
+            before = before_points[vertex_id]
+            after = after_points[vertex_id]
+            items.append({
+                "index": vertex_id,
+                "component": f"{prefix_name}.vtx[{vertex_id}]",
+                "before": _point_list(before),
+                "after": _point_list(after),
+                "movement": _distance(before, after),
+            })
+        return items
+
+    if not object_name:
+        raise ValueError("object_name is required.")
+    if not operation:
+        raise ValueError("operation is required.")
+    operation = operation.lower().strip()
+    if operation not in {"average_vertices", "relax_vertices", "shrink_fatten_vertices"}:
+        raise ValueError("operation must be average_vertices, relax_vertices, or shrink_fatten_vertices.")
+    component_type = component_type.lower().strip()
+    if component_type not in {"vertex", "edge", "face", "uv", "vertex_face"}:
+        raise ValueError("component_type must be vertex, edge, face, uv, or vertex_face.")
+    clean_iterations = _validate_int(iterations, "iterations", 1)
+    clean_strength = _validate_scalar(strength, "strength")
+    if clean_strength < 0.0:
+        raise ValueError("strength must be greater than or equal to 0.")
+    clean_distance = _validate_scalar(distance, "distance")
+    space = space.lower().strip()
+    if space not in {"world", "object"}:
+        raise ValueError("space must be world or object.")
+    max_preview = _validate_int(max_preview, "max_preview", 0)
+
+    shape_name = _mesh_shape(object_name)
+    dag = _dag_path(shape_name)
+    mesh_fn = _mesh_fn(shape_name)
+    prefix_name = _prefix(shape_name)
+    om_space = om.MSpace.kWorld if space == "world" else om.MSpace.kObject
+
+    resolved_components = _resolve_components()
+    vertex_ids = _vertex_ids_from_components(resolved_components)
+    if not vertex_ids:
+        raise ValueError("No vertices resolved from components, indices, or current selection.")
+
+    adjacency, boundary_vertices = _edge_adjacency_and_boundary()
+    points = mesh_fn.getPoints(om_space)
+    before_points = {vertex_id: om.MPoint(points[vertex_id]) for vertex_id in vertex_ids}
+    skipped = []
+
+    if operation in {"average_vertices", "relax_vertices"}:
+        for _ in range(clean_iterations):
+            next_points = om.MPointArray(points)
+            for vertex_id in vertex_ids:
+                if preserve_boundary and vertex_id in boundary_vertices:
+                    skipped.append({"index": vertex_id, "reason": "boundary"})
+                    continue
+                neighbors = sorted(adjacency.get(vertex_id, []))
+                if not neighbors:
+                    skipped.append({"index": vertex_id, "reason": "no_connected_vertices"})
+                    continue
+                average = _average_point(points, neighbors)
+                displacement = om.MVector(average.x - points[vertex_id].x, average.y - points[vertex_id].y, average.z - points[vertex_id].z)
+                if operation == "relax_vertices":
+                    normal = _normal(vertex_id)
+                    displacement = displacement - normal * (displacement * normal)
+                next_points[vertex_id] = om.MPoint(
+                    points[vertex_id].x + displacement.x * clean_strength,
+                    points[vertex_id].y + displacement.y * clean_strength,
+                    points[vertex_id].z + displacement.z * clean_strength,
+                )
+            points = next_points
+
+    if operation == "shrink_fatten_vertices":
+        for _ in range(clean_iterations):
+            next_points = om.MPointArray(points)
+            for vertex_id in vertex_ids:
+                if preserve_boundary and vertex_id in boundary_vertices:
+                    skipped.append({"index": vertex_id, "reason": "boundary"})
+                    continue
+                normal = _normal(vertex_id)
+                offset = clean_distance * clean_strength
+                next_points[vertex_id] = om.MPoint(
+                    points[vertex_id].x + normal.x * offset,
+                    points[vertex_id].y + normal.y * offset,
+                    points[vertex_id].z + normal.z * offset,
+                )
+            points = next_points
+
+    mesh_fn.setPoints(points, om_space)
+    try:
+        mesh_fn.updateSurface()
+    except Exception:
+        pass
+    updated_points = mesh_fn.getPoints(om_space)
+    after_points = {vertex_id: om.MPoint(updated_points[vertex_id]) for vertex_id in vertex_ids}
+    movements = [_distance(before_points[vertex_id], after_points[vertex_id]) for vertex_id in vertex_ids]
+    moved_count = sum(1 for movement in movements if movement > 1e-9)
+    if moved_count == 0:
+        raise RuntimeError(f"{operation} did not move any vertices.")
+    cmds.select([f"{prefix_name}.vtx[{vertex_id}]" for vertex_id in vertex_ids], replace=True)
+
+    return {
+        "success": True,
+        "object_name": object_name,
+        "shape_name": shape_name,
+        "operation": operation,
+        "component_type": component_type,
+        "space": space,
+        "iterations": clean_iterations,
+        "strength": clean_strength,
+        "distance": clean_distance,
+        "preserve_boundary": bool(preserve_boundary),
+        "resolved_vertex_count": len(vertex_ids),
+        "moved_vertex_count": moved_count,
+        "skipped_count": len(skipped),
+        "skipped_preview": skipped[:max_preview],
+        "total_movement": float(sum(movements)),
+        "max_movement": float(max(movements) if movements else 0.0),
+        "preview": _preview(vertex_ids, before_points, after_points),
+    }

--- a/src/mayatools/object/sculpt_mesh_components.py
+++ b/src/mayatools/object/sculpt_mesh_components.py
@@ -13,6 +13,7 @@ def sculpt_mesh_components(
     preserve_boundary: bool = True,
     space: str = "world",
     use_selection: bool = True,
+    select_result: bool = True,
     max_preview: int = 20,
 ) -> Dict[str, object]:
     """Locally smooth, relax, or inflate polygon mesh components.
@@ -27,6 +28,8 @@ def sculpt_mesh_components(
     Edges and faces are converted to vertices. This supports Maya-style local
     cleanup of uneven point spacing, soft sculpt-like surface relaxation, and
     small inflate/deflate adjustments without global procedural deformation.
+    Set select_result=False for scripted sculpt passes where the next operation
+    should not inherit the edited vertex selection.
     """
     import math
     import re
@@ -264,7 +267,8 @@ def sculpt_mesh_components(
     moved_count = sum(1 for movement in movements if movement > 1e-9)
     if moved_count == 0:
         raise RuntimeError(f"{operation} did not move any vertices.")
-    cmds.select([f"{prefix_name}.vtx[{vertex_id}]" for vertex_id in vertex_ids], replace=True)
+    if select_result:
+        cmds.select([f"{prefix_name}.vtx[{vertex_id}]" for vertex_id in vertex_ids], replace=True)
 
     return {
         "success": True,
@@ -277,6 +281,7 @@ def sculpt_mesh_components(
         "strength": clean_strength,
         "distance": clean_distance,
         "preserve_boundary": bool(preserve_boundary),
+        "select_result": bool(select_result),
         "resolved_vertex_count": len(vertex_ids),
         "moved_vertex_count": moved_count,
         "skipped_count": len(skipped),

--- a/src/mayatools/object/select_mesh_by_cylindrical_pattern.py
+++ b/src/mayatools/object/select_mesh_by_cylindrical_pattern.py
@@ -1,0 +1,365 @@
+from typing import Dict, List, Any, Union
+
+
+def select_mesh_by_cylindrical_pattern(
+    object_name: str,
+    result_type: str = "face",
+    component_type: str = None,
+    indices: List[int] = None,
+    components: Union[str, List[str]] = None,
+    center: List[float] = None,
+    axis: str = "y",
+    axis_range: List[float] = None,
+    angle_range_degrees: List[float] = None,
+    angular_count: int = 8,
+    angular_duty_cycle: float = 0.5,
+    angular_phase_degrees: float = 0.0,
+    axis_count: int = 0,
+    axis_duty_cycle: float = 1.0,
+    axis_phase: float = 0.0,
+    invert: bool = False,
+    sample_mode: str = "center",
+    space: str = "world",
+    selection_mode: str = "replace",
+    select_result: bool = True,
+    use_selection: bool = True,
+    max_preview: int = 200,
+) -> Dict[str, Any]:
+    """Select mesh components by repeated cylindrical coordinate bands.
+
+    The angular pattern divides angle_range_degrees into angular_count repeated
+    cells and selects the duty-cycle portion of each cell. Optionally, axis_count
+    applies the same repeated pattern along the cylinder axis. This is useful
+    for Maya-style component work on cap knurling, grooves, flutes, corrugated
+    surfaces, vents, gear teeth, grip ridges, and other repeated cylindrical
+    details before transform, material, normal, crease, or extraction edits.
+    """
+    import math
+    import re
+    import maya.cmds as cmds
+    import maya.api.OpenMaya as om
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return int(value)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(item) for item in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(item) for item in values]
+
+    def _validate_range(values, arg_name):
+        clean = _validate_vector(values, 2, arg_name)
+        if clean[1] < clean[0]:
+            clean = [clean[1], clean[0]]
+        if clean[1] == clean[0]:
+            raise ValueError(f"{arg_name} must have non-zero span.")
+        return clean
+
+    def _positive_span(start_degrees, end_degrees):
+        span = (end_degrees - start_degrees) % 360.0
+        return 360.0 if abs(span) < 1.0e-8 else span
+
+    def _axis_tuple(axis_name):
+        clean_axis = (axis_name or "").lower().strip()
+        axes = {
+            "x": (0, 1, 2),
+            "y": (1, 0, 2),
+            "z": (2, 0, 1),
+        }
+        if clean_axis not in axes:
+            raise ValueError("axis must be x, y, or z.")
+        return clean_axis, axes[clean_axis]
+
+    def _mesh_shape(node):
+        if not cmds.objExists(node):
+            raise ValueError(f"Object does not exist: {node}")
+        if cmds.objectType(node) == "mesh":
+            return node
+        shapes = cmds.listRelatives(node, shapes=True, fullPath=True) or []
+        mesh_shapes = []
+        for shape in shapes:
+            if cmds.objectType(shape) != "mesh":
+                continue
+            try:
+                if cmds.attributeQuery("intermediateObject", node=shape, exists=True) and cmds.getAttr(f"{shape}.intermediateObject"):
+                    continue
+            except Exception:
+                pass
+            mesh_shapes.append(shape)
+        if not mesh_shapes:
+            raise ValueError(f"{node} is not a polygon mesh transform or mesh shape.")
+        return mesh_shapes[0]
+
+    def _dag_path(shape):
+        selection = om.MSelectionList()
+        selection.add(shape)
+        return selection.getDagPath(0)
+
+    def _prefix(shape):
+        parents = cmds.listRelatives(shape, parent=True, fullPath=False) or []
+        return parents[0] if parents else object_name
+
+    def _flatten(value):
+        if value is None:
+            return []
+        if isinstance(value, str):
+            value = [value]
+        if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+            raise ValueError("components must be a string, a list of strings, or None.")
+        return cmds.ls(value, flatten=True) or []
+
+    def _selected_components():
+        if not use_selection:
+            return []
+        selected = cmds.ls(selection=True, flatten=True) or []
+        object_tokens = {object_name, prefix_name, shape_name}
+        return [item for item in selected if item.split(".", 1)[0] in object_tokens]
+
+    def _components_from_indices(kind):
+        if indices is None:
+            return []
+        if not isinstance(indices, list) or not all(isinstance(index, int) and not isinstance(index, bool) for index in indices):
+            raise ValueError("indices must be a list of integers.")
+        return [f"{prefix_name}.{kind}[{index}]" for index in indices]
+
+    def _resolve_components():
+        clean_type = (component_type or clean_result_type).lower().strip()
+        kind_map = {"vertex": "vtx", "edge": "e", "face": "f", "uv": "map", "vertex_face": "vtxFace"}
+        if components is not None:
+            return _flatten(components)
+        if clean_type in kind_map and indices is not None:
+            return _components_from_indices(kind_map[clean_type])
+        return _selected_components()
+
+    def _unique(items):
+        seen = set()
+        result = []
+        for item in cmds.ls(items, flatten=True) or []:
+            if item in seen:
+                continue
+            seen.add(item)
+            result.append(item)
+        return result
+
+    def _component_ids(items, kind):
+        pattern = re.compile(rf"\.{kind}\[(\d+)\]$")
+        ids = []
+        for item in cmds.ls(items, flatten=True) or []:
+            match = pattern.search(item)
+            if match:
+                ids.append(int(match.group(1)))
+        return list(dict.fromkeys(ids))
+
+    def _convert(items, target):
+        flags = {
+            "vertex": {"toVertex": True},
+            "edge": {"toEdge": True},
+            "face": {"toFace": True},
+        }[target]
+        return _unique(cmds.polyListComponentConversion(items, **flags) or [])
+
+    def _candidate_ids():
+        source = _resolve_components()
+        if source:
+            kind = {"vertex": "vtx", "edge": "e", "face": "f"}[clean_result_type]
+            return _component_ids(_convert(source, clean_result_type), kind)
+        total = {
+            "vertex": int(mesh_fn.numVertices),
+            "edge": int(mesh_fn.numEdges),
+            "face": int(mesh_fn.numPolygons),
+        }[clean_result_type]
+        return list(range(total))
+
+    def _point_values(point):
+        return [float(point.x), float(point.y), float(point.z)]
+
+    def _average(points_to_average):
+        values = [0.0, 0.0, 0.0]
+        for point in points_to_average:
+            point_values = _point_values(point)
+            values[0] += point_values[0]
+            values[1] += point_values[1]
+            values[2] += point_values[2]
+        count = float(max(1, len(points_to_average)))
+        return [values[0] / count, values[1] / count, values[2] / count]
+
+    def _edge_points(edge_id):
+        vertex_a, vertex_b = mesh_fn.getEdgeVertices(edge_id)
+        return [points[int(vertex_a)], points[int(vertex_b)]]
+
+    def _face_points(face_id):
+        return [points[int(vertex_id)] for vertex_id in mesh_fn.getPolygonVertices(face_id)]
+
+    def _sample_points(component_id):
+        if clean_result_type == "vertex":
+            return [points[component_id]]
+        if clean_result_type == "edge":
+            edge_points = _edge_points(component_id)
+            if clean_sample_mode == "center":
+                return [om.MPoint(*_average(edge_points))]
+            return edge_points
+        face_points = _face_points(component_id)
+        if clean_sample_mode == "center":
+            return [om.MPoint(*_average(face_points))]
+        return face_points
+
+    def _coordinate_record(point):
+        values = _point_values(point)
+        local_axis = values[axis_index] - clean_center[axis_index]
+        delta_a = values[radial_a] - clean_center[radial_a]
+        delta_b = values[radial_b] - clean_center[radial_b]
+        angle = math.degrees(math.atan2(delta_a, delta_b))
+        radius = math.sqrt(delta_a * delta_a + delta_b * delta_b)
+        return {"axis_value": local_axis, "angle_degrees": angle, "radius": radius}
+
+    def _angle_match(angle_degrees):
+        delta = (angle_degrees - clean_angle_start - clean_angular_phase) % 360.0
+        if delta > clean_angle_span + 1.0e-8 and clean_angle_span < 360.0 - 1.0e-8:
+            return False, None
+        if clean_angle_span >= 360.0 - 1.0e-8:
+            range_t = (delta % 360.0) / 360.0
+        else:
+            range_t = max(0.0, min(1.0, delta / clean_angle_span))
+        cell_position = (range_t * clean_angular_count) % 1.0
+        return cell_position <= clean_angular_duty + 1.0e-8, cell_position
+
+    def _axis_match(axis_value):
+        if clean_axis_range is None:
+            return True, None
+        if axis_value < clean_axis_range[0] - 1.0e-8 or axis_value > clean_axis_range[1] + 1.0e-8:
+            return False, None
+        if clean_axis_count <= 0:
+            return True, None
+        axis_t = (axis_value - clean_axis_range[0]) / (clean_axis_range[1] - clean_axis_range[0])
+        cell_position = ((axis_t * clean_axis_count) + clean_axis_phase) % 1.0
+        return cell_position <= clean_axis_duty + 1.0e-8, cell_position
+
+    def _point_matches(point):
+        record = _coordinate_record(point)
+        angle_ok, angle_cell = _angle_match(record["angle_degrees"])
+        axis_ok, axis_cell = _axis_match(record["axis_value"])
+        matched = angle_ok and axis_ok
+        if invert:
+            matched = not matched
+        record["angle_cell_position"] = angle_cell
+        record["axis_cell_position"] = axis_cell
+        record["matched"] = matched
+        return matched, record
+
+    def _component_matches(component_id):
+        sample_points = _sample_points(component_id)
+        matches = []
+        records = []
+        for point in sample_points:
+            matched, record = _point_matches(point)
+            matches.append(matched)
+            records.append(record)
+        if clean_sample_mode in {"center", "any"}:
+            return any(matches), records
+        return all(matches), records
+
+    def _component(kind, index):
+        return f"{prefix_name}.{kind}[{index}]"
+
+    def _apply_selection(items):
+        mode_name = selection_mode.lower().strip()
+        if mode_name not in {"replace", "add", "toggle", "deselect"}:
+            raise ValueError("selection_mode must be replace, add, toggle, or deselect.")
+        if items:
+            cmds.select(items, **{mode_name: True})
+        elif mode_name == "replace":
+            cmds.select(clear=True)
+
+    if not object_name:
+        raise ValueError("object_name is required.")
+    clean_result_type = result_type.lower().strip()
+    if clean_result_type not in {"vertex", "edge", "face"}:
+        raise ValueError("result_type must be vertex, edge, or face.")
+    clean_sample_mode = sample_mode.lower().strip()
+    if clean_sample_mode not in {"center", "any", "all"}:
+        raise ValueError("sample_mode must be center, any, or all.")
+    space = space.lower().strip()
+    if space not in {"world", "object"}:
+        raise ValueError("space must be world or object.")
+    clean_axis_name, (axis_index, radial_a, radial_b) = _axis_tuple(axis)
+    clean_center = _validate_vector(center, 3, "center") if center is not None else [0.0, 0.0, 0.0]
+    clean_axis_range = _validate_range(axis_range, "axis_range") if axis_range is not None else None
+    clean_angle_range = _validate_vector(angle_range_degrees if angle_range_degrees is not None else [0.0, 360.0], 2, "angle_range_degrees")
+    clean_angle_start = clean_angle_range[0]
+    clean_angle_span = _positive_span(clean_angle_range[0], clean_angle_range[1])
+    clean_angular_count = _validate_int(angular_count, "angular_count", 1)
+    clean_axis_count = _validate_int(axis_count, "axis_count", 0)
+    clean_angular_duty = _validate_scalar(angular_duty_cycle, "angular_duty_cycle")
+    clean_axis_duty = _validate_scalar(axis_duty_cycle, "axis_duty_cycle")
+    clean_angular_phase = _validate_scalar(angular_phase_degrees, "angular_phase_degrees")
+    clean_axis_phase = _validate_scalar(axis_phase, "axis_phase")
+    if clean_angular_duty < 0.0 or clean_angular_duty > 1.0:
+        raise ValueError("angular_duty_cycle must be between 0 and 1.")
+    if clean_axis_duty < 0.0 or clean_axis_duty > 1.0:
+        raise ValueError("axis_duty_cycle must be between 0 and 1.")
+    max_preview = _validate_int(max_preview, "max_preview", 1)
+
+    shape_name = _mesh_shape(object_name)
+    prefix_name = _prefix(shape_name)
+    mesh_fn = om.MFnMesh(_dag_path(shape_name))
+    om_space = om.MSpace.kWorld if space == "world" else om.MSpace.kObject
+    points = mesh_fn.getPoints(om_space)
+
+    matched_ids = []
+    records = []
+    for component_id in _candidate_ids():
+        matched, sample_records = _component_matches(component_id)
+        if not matched:
+            continue
+        matched_ids.append(component_id)
+        records.append(
+            {
+                "component": _component({"vertex": "vtx", "edge": "e", "face": "f"}[clean_result_type], component_id),
+                "index": component_id,
+                "samples": sample_records[:max_preview],
+            }
+        )
+
+    kind = {"vertex": "vtx", "edge": "e", "face": "f"}[clean_result_type]
+    matched_components = [_component(kind, component_id) for component_id in matched_ids]
+    if select_result:
+        _apply_selection(matched_components)
+
+    return {
+        "success": True,
+        "object_name": object_name,
+        "shape_name": shape_name,
+        "operation": "select_mesh_by_cylindrical_pattern",
+        "result_type": clean_result_type,
+        "sample_mode": clean_sample_mode,
+        "space": space,
+        "center": clean_center,
+        "axis": clean_axis_name,
+        "axis_range": clean_axis_range,
+        "angle_range_degrees": clean_angle_range,
+        "angle_span_degrees": clean_angle_span,
+        "angular_count": clean_angular_count,
+        "angular_duty_cycle": clean_angular_duty,
+        "angular_phase_degrees": clean_angular_phase,
+        "axis_count": clean_axis_count,
+        "axis_duty_cycle": clean_axis_duty,
+        "axis_phase": clean_axis_phase,
+        "invert": bool(invert),
+        "matched_count": len(matched_components),
+        "components": matched_components[:max_preview],
+        "truncated": len(matched_components) > max_preview,
+        "selected": bool(select_result),
+        "selection_mode": selection_mode if select_result else None,
+        "records": records[:max_preview],
+        "records_truncated": len(records) > max_preview,
+    }

--- a/src/mayatools/object/select_mesh_by_cylindrical_pattern.py
+++ b/src/mayatools/object/select_mesh_by_cylindrical_pattern.py
@@ -307,7 +307,7 @@ def select_mesh_by_cylindrical_pattern(
         raise ValueError("angular_duty_cycle must be between 0 and 1.")
     if clean_axis_duty < 0.0 or clean_axis_duty > 1.0:
         raise ValueError("axis_duty_cycle must be between 0 and 1.")
-    max_preview = _validate_int(max_preview, "max_preview", 1)
+    max_preview = _validate_int(max_preview, "max_preview", 0)
 
     shape_name = _mesh_shape(object_name)
     prefix_name = _prefix(shape_name)

--- a/src/mayatools/object/select_mesh_by_region.py
+++ b/src/mayatools/object/select_mesh_by_region.py
@@ -318,7 +318,7 @@ def select_mesh_by_region(
     space = space.lower().strip()
     if space not in {"world", "object"}:
         raise ValueError("space must be world or object.")
-    max_preview = _validate_int(max_preview, "max_preview", 1)
+    max_preview = _validate_int(max_preview, "max_preview", 0)
 
     shape_name = _mesh_shape(object_name)
     prefix_name = _prefix(shape_name)

--- a/src/mayatools/object/select_mesh_by_region.py
+++ b/src/mayatools/object/select_mesh_by_region.py
@@ -1,0 +1,402 @@
+from typing import Dict, List, Any, Union
+
+
+def select_mesh_by_region(
+    object_name: str,
+    result_type: str = "face",
+    component_type: str = None,
+    indices: List[int] = None,
+    components: Union[str, List[str]] = None,
+    axis: str = None,
+    axis_range: List[float] = None,
+    box_min: List[float] = None,
+    box_max: List[float] = None,
+    center: List[float] = None,
+    radial_axis: str = "y",
+    radial_range: List[float] = None,
+    angle_range_degrees: List[float] = None,
+    normal: List[float] = None,
+    normal_angle_degrees: float = None,
+    sample_mode: str = "center",
+    space: str = "world",
+    selection_mode: str = "replace",
+    select_result: bool = True,
+    use_selection: bool = True,
+    max_preview: int = 200,
+) -> Dict[str, Any]:
+    """Filter mesh vertices, edges, or faces by spatial and normal criteria.
+
+    Supported criteria:
+    - axis_range on x, y, or z, measured relative to center
+    - box_min/box_max absolute bounding box limits
+    - radial_range and angle_range_degrees around radial_axis and center
+    - normal plus normal_angle_degrees for face normals or vertex normals
+
+    This is a Maya-style component selection constraint for reliably targeting
+    local bands, panels, caps, front/back regions, and normal-facing areas before
+    transform, material, UV, or topology edits.
+    """
+    import math
+    import re
+    import maya.cmds as cmds
+    import maya.api.OpenMaya as om
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return int(value)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(item) for item in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(item) for item in values]
+
+    def _validate_range(values, arg_name):
+        clean = _validate_vector(values, 2, arg_name)
+        if clean[0] > clean[1]:
+            clean = [clean[1], clean[0]]
+        return clean
+
+    def _normalize(values, arg_name):
+        vector = _validate_vector(values, 3, arg_name)
+        length = math.sqrt(sum(item * item for item in vector))
+        if length <= 1.0e-12:
+            raise ValueError(f"{arg_name} must not be a zero vector.")
+        return [item / length for item in vector]
+
+    def _axis_index(axis_name, arg_name):
+        clean_axis = (axis_name or "").lower().strip()
+        if clean_axis not in {"x", "y", "z"}:
+            raise ValueError(f"{arg_name} must be x, y, or z.")
+        return {"x": 0, "y": 1, "z": 2}[clean_axis]
+
+    def _positive_span(start_degrees, end_degrees):
+        span = (end_degrees - start_degrees) % 360.0
+        return 360.0 if abs(span) < 1.0e-8 else span
+
+    def _angle_in_range(angle, start_degrees, span_degrees):
+        delta = (angle - start_degrees) % 360.0
+        return delta <= span_degrees + 1.0e-8
+
+    def _mesh_shape(node):
+        if not cmds.objExists(node):
+            raise ValueError(f"Object does not exist: {node}")
+        if cmds.objectType(node) == "mesh":
+            return node
+        shapes = cmds.listRelatives(node, shapes=True, fullPath=True) or []
+        mesh_shapes = []
+        for shape in shapes:
+            if cmds.objectType(shape) != "mesh":
+                continue
+            try:
+                if cmds.attributeQuery("intermediateObject", node=shape, exists=True) and cmds.getAttr(f"{shape}.intermediateObject"):
+                    continue
+            except Exception:
+                pass
+            mesh_shapes.append(shape)
+        if not mesh_shapes:
+            raise ValueError(f"{node} is not a polygon mesh transform or mesh shape.")
+        return mesh_shapes[0]
+
+    def _dag_path(shape):
+        selection = om.MSelectionList()
+        selection.add(shape)
+        return selection.getDagPath(0)
+
+    def _mesh_fn(shape):
+        return om.MFnMesh(_dag_path(shape))
+
+    def _prefix(shape):
+        parents = cmds.listRelatives(shape, parent=True, fullPath=False) or []
+        return parents[0] if parents else object_name
+
+    def _flatten(value):
+        if value is None:
+            return []
+        if isinstance(value, str):
+            value = [value]
+        if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+            raise ValueError("components must be a string, a list of strings, or None.")
+        return cmds.ls(value, flatten=True) or []
+
+    def _unique(items):
+        seen = set()
+        result = []
+        for item in cmds.ls(items, flatten=True) or []:
+            if item in seen:
+                continue
+            seen.add(item)
+            result.append(item)
+        return result
+
+    def _selected_components():
+        if not use_selection:
+            return []
+        selected = cmds.ls(selection=True, flatten=True) or []
+        object_tokens = {object_name, prefix_name, shape_name}
+        return [item for item in selected if item.split(".", 1)[0] in object_tokens]
+
+    def _components_from_indices(kind):
+        if indices is None:
+            return []
+        if not isinstance(indices, list) or not all(isinstance(index, int) and not isinstance(index, bool) for index in indices):
+            raise ValueError("indices must be a list of integers.")
+        return [f"{prefix_name}.{kind}[{index}]" for index in indices]
+
+    def _resolve_seed_components():
+        clean_type = (component_type or result_type).lower().strip()
+        kind_map = {"vertex": "vtx", "edge": "e", "face": "f", "uv": "map", "vertex_face": "vtxFace"}
+        if components is not None:
+            return _flatten(components)
+        if clean_type in kind_map and indices is not None:
+            return _components_from_indices(kind_map[clean_type])
+        selected = _selected_components()
+        return selected
+
+    def _convert(items, target):
+        flags = {
+            "vertex": {"toVertex": True},
+            "edge": {"toEdge": True},
+            "face": {"toFace": True},
+        }[target]
+        return _unique(cmds.polyListComponentConversion(items, **flags) or [])
+
+    def _component_ids(items, kind):
+        pattern = re.compile(rf"\.{kind}\[(\d+)\]$")
+        ids = []
+        for item in cmds.ls(items, flatten=True) or []:
+            match = pattern.search(item)
+            if match:
+                ids.append(int(match.group(1)))
+        return list(dict.fromkeys(ids))
+
+    def _candidate_ids():
+        seeds = _resolve_seed_components()
+        kind = {"vertex": "vtx", "edge": "e", "face": "f"}[clean_result_type]
+        if seeds:
+            return _component_ids(_convert(seeds, clean_result_type), kind)
+        total = {
+            "vertex": int(mesh_fn.numVertices),
+            "edge": int(mesh_fn.numEdges),
+            "face": int(mesh_fn.numPolygons),
+        }[clean_result_type]
+        return list(range(total))
+
+    def _point_values(point):
+        return [float(point.x), float(point.y), float(point.z)]
+
+    def _average_point(points):
+        result = om.MPoint()
+        for point in points:
+            result += point
+        return result / float(max(1, len(points)))
+
+    def _edge_points(edge_id):
+        iterator = om.MItMeshEdge(dag_path)
+        iterator.setIndex(edge_id)
+        return [points[int(iterator.vertexId(0))], points[int(iterator.vertexId(1))]]
+
+    def _face_points(face_id):
+        vertex_ids = mesh_fn.getPolygonVertices(face_id)
+        return [points[int(vertex_id)] for vertex_id in vertex_ids]
+
+    def _sample_points(component_id):
+        if clean_result_type == "vertex":
+            return [points[component_id]]
+        if clean_result_type == "edge":
+            edge_points = _edge_points(component_id)
+            if clean_sample_mode == "center":
+                return [_average_point(edge_points)]
+            return edge_points
+        face_points = _face_points(component_id)
+        if clean_sample_mode == "center":
+            return [_average_point(face_points)]
+        return face_points
+
+    def _point_matches(point):
+        values = _point_values(point)
+        if clean_box_min is not None:
+            for index in range(3):
+                if values[index] < clean_box_min[index] - 1.0e-9 or values[index] > clean_box_max[index] + 1.0e-9:
+                    return False
+        if clean_axis_range is not None:
+            axis_value = values[axis_idx] - clean_center[axis_idx]
+            if axis_value < clean_axis_range[0] - 1.0e-9 or axis_value > clean_axis_range[1] + 1.0e-9:
+                return False
+        if clean_radial_range is not None or clean_angle_range is not None:
+            delta_a = values[radial_a] - clean_center[radial_a]
+            delta_b = values[radial_b] - clean_center[radial_b]
+            radius = math.sqrt(delta_a * delta_a + delta_b * delta_b)
+            if clean_radial_range is not None and (radius < clean_radial_range[0] - 1.0e-9 or radius > clean_radial_range[1] + 1.0e-9):
+                return False
+            if clean_angle_range is not None:
+                angle = math.degrees(math.atan2(delta_a, delta_b))
+                if not _angle_in_range(angle, clean_angle_range[0], angle_span):
+                    return False
+        return True
+
+    def _component_position_match(component_id):
+        sample_points = _sample_points(component_id)
+        if clean_sample_mode in {"center", "any"}:
+            return any(_point_matches(point) for point in sample_points)
+        if clean_sample_mode == "all":
+            return all(_point_matches(point) for point in sample_points)
+        raise ValueError("sample_mode must be center, any, or all.")
+
+    def _vertex_normal(vertex_id):
+        vector = mesh_fn.getVertexNormal(vertex_id, True, om_space)
+        length = math.sqrt(vector.x * vector.x + vector.y * vector.y + vector.z * vector.z)
+        if length <= 1.0e-12:
+            return None
+        return [float(vector.x / length), float(vector.y / length), float(vector.z / length)]
+
+    def _edge_normal(edge_id):
+        vertices = _edge_points(edge_id)
+        vertex_ids = []
+        iterator = om.MItMeshEdge(dag_path)
+        iterator.setIndex(edge_id)
+        vertex_ids.append(int(iterator.vertexId(0)))
+        vertex_ids.append(int(iterator.vertexId(1)))
+        normals = [_vertex_normal(vertex_id) for vertex_id in vertex_ids]
+        normals = [item for item in normals if item is not None]
+        if not normals:
+            return None
+        summed = [sum(item[index] for item in normals) / float(len(normals)) for index in range(3)]
+        return _normalize(summed, "edge normal")
+
+    def _face_normal(face_id):
+        vector = mesh_fn.getPolygonNormal(face_id, om_space)
+        length = math.sqrt(vector.x * vector.x + vector.y * vector.y + vector.z * vector.z)
+        if length <= 1.0e-12:
+            return None
+        return [float(vector.x / length), float(vector.y / length), float(vector.z / length)]
+
+    def _normal_for_component(component_id):
+        if clean_normal is None:
+            return None
+        if clean_result_type == "vertex":
+            return _vertex_normal(component_id)
+        if clean_result_type == "edge":
+            return _edge_normal(component_id)
+        return _face_normal(component_id)
+
+    def _normal_matches(component_id):
+        if clean_normal is None:
+            return True
+        component_normal = _normal_for_component(component_id)
+        if component_normal is None:
+            return False
+        dot = max(-1.0, min(1.0, sum(component_normal[index] * clean_normal[index] for index in range(3))))
+        angle = math.degrees(math.acos(dot))
+        return angle <= clean_normal_angle + 1.0e-8
+
+    def _component(kind, index):
+        return f"{prefix_name}.{kind}[{index}]"
+
+    def _apply_selection(items):
+        mode = selection_mode.lower().strip()
+        if mode not in {"replace", "add", "toggle", "deselect"}:
+            raise ValueError("selection_mode must be replace, add, toggle, or deselect.")
+        cmds.select(items, **{mode: True})
+
+    if not object_name:
+        raise ValueError("object_name is required.")
+    clean_result_type = result_type.lower().strip()
+    if clean_result_type not in {"vertex", "edge", "face"}:
+        raise ValueError("result_type must be vertex, edge, or face.")
+    clean_sample_mode = sample_mode.lower().strip()
+    if clean_sample_mode not in {"center", "any", "all"}:
+        raise ValueError("sample_mode must be center, any, or all.")
+    space = space.lower().strip()
+    if space not in {"world", "object"}:
+        raise ValueError("space must be world or object.")
+    max_preview = _validate_int(max_preview, "max_preview", 1)
+
+    shape_name = _mesh_shape(object_name)
+    prefix_name = _prefix(shape_name)
+    dag_path = _dag_path(shape_name)
+    mesh_fn = _mesh_fn(shape_name)
+    om_space = om.MSpace.kWorld if space == "world" else om.MSpace.kObject
+    points = mesh_fn.getPoints(om_space)
+
+    clean_center = _validate_vector(center, 3, "center") if center is not None else [0.0, 0.0, 0.0]
+    axis_idx = _axis_index(axis, "axis") if axis is not None else None
+    clean_axis_range = _validate_range(axis_range, "axis_range") if axis_range is not None else None
+    if clean_axis_range is not None and axis_idx is None:
+        raise ValueError("axis is required when axis_range is provided.")
+    if box_min is None and box_max is None:
+        clean_box_min = None
+        clean_box_max = None
+    elif box_min is not None and box_max is not None:
+        clean_box_min = _validate_vector(box_min, 3, "box_min")
+        clean_box_max = _validate_vector(box_max, 3, "box_max")
+        for index in range(3):
+            if clean_box_min[index] > clean_box_max[index]:
+                clean_box_min[index], clean_box_max[index] = clean_box_max[index], clean_box_min[index]
+    else:
+        raise ValueError("box_min and box_max must be provided together.")
+
+    radial_axis_idx = _axis_index(radial_axis, "radial_axis")
+    radial_axes = [index for index in range(3) if index != radial_axis_idx]
+    radial_a, radial_b = radial_axes[0], radial_axes[1]
+    clean_radial_range = _validate_range(radial_range, "radial_range") if radial_range is not None else None
+    clean_angle_range = _validate_vector(angle_range_degrees, 2, "angle_range_degrees") if angle_range_degrees is not None else None
+    angle_span = _positive_span(clean_angle_range[0], clean_angle_range[1]) if clean_angle_range is not None else None
+    clean_normal = _normalize(normal, "normal") if normal is not None else None
+    clean_normal_angle = _validate_scalar(normal_angle_degrees if normal_angle_degrees is not None else 15.0, "normal_angle_degrees")
+    if clean_normal_angle < 0.0 or clean_normal_angle > 180.0:
+        raise ValueError("normal_angle_degrees must be between 0 and 180.")
+    if (
+        clean_axis_range is None
+        and clean_box_min is None
+        and clean_radial_range is None
+        and clean_angle_range is None
+        and clean_normal is None
+    ):
+        raise ValueError("At least one filter criterion is required.")
+
+    candidate_ids = _candidate_ids()
+    matched_ids = []
+    for component_id in candidate_ids:
+        if _component_position_match(component_id) and _normal_matches(component_id):
+            matched_ids.append(component_id)
+
+    kind = {"vertex": "vtx", "edge": "e", "face": "f"}[clean_result_type]
+    matched_components = [_component(kind, component_id) for component_id in matched_ids]
+    if select_result:
+        _apply_selection(matched_components)
+
+    return {
+        "success": True,
+        "object_name": object_name,
+        "shape_name": shape_name,
+        "result_type": clean_result_type,
+        "space": space,
+        "sample_mode": clean_sample_mode,
+        "criteria": {
+            "axis": axis.lower().strip() if axis else None,
+            "axis_range": clean_axis_range,
+            "box_min": clean_box_min,
+            "box_max": clean_box_max,
+            "center": clean_center,
+            "radial_axis": radial_axis.lower().strip(),
+            "radial_range": clean_radial_range,
+            "angle_range_degrees": clean_angle_range,
+            "normal": clean_normal,
+            "normal_angle_degrees": clean_normal_angle if clean_normal is not None else None,
+        },
+        "candidate_count": len(candidate_ids),
+        "matched_count": len(matched_components),
+        "components": matched_components[:max_preview],
+        "truncated": len(matched_components) > max_preview,
+        "selected": bool(select_result),
+        "selection_mode": selection_mode if select_result else None,
+    }

--- a/src/mayatools/object/select_mesh_by_uv_region.py
+++ b/src/mayatools/object/select_mesh_by_uv_region.py
@@ -1,0 +1,303 @@
+from typing import Dict, List, Any, Union
+
+
+def select_mesh_by_uv_region(
+    object_name: str,
+    uv_box: List[float],
+    result_type: str = "face",
+    component_type: str = None,
+    indices: List[int] = None,
+    components: Union[str, List[str]] = None,
+    sample_mode: str = "center",
+    keep_inside: bool = True,
+    uv_set: str = None,
+    selection_mode: str = "replace",
+    select_result: bool = True,
+    use_selection: bool = True,
+    max_preview: int = 200,
+) -> Dict[str, Any]:
+    """Filter mesh components by UV coordinates inside a rectangular region.
+
+    Result types:
+    - uv: select UVs whose coordinates are inside or outside uv_box
+    - face: select faces by UV center, any UV, or all UVs
+    - edge, vertex: convert matched faces or UVs to mesh edges or vertices
+
+    This is a UV-editor style selection constraint for labels, decals, trim
+    sheets, texture masks, material regions, and cleanup tasks where component
+    ownership is clearer in UV space than in world space.
+    """
+    import re
+    import maya.cmds as cmds
+    import maya.api.OpenMaya as om
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_box(value):
+        if not isinstance(value, list) or len(value) != 4 or not all(_is_number(item) for item in value):
+            raise ValueError("uv_box must be [min_u, min_v, max_u, max_v].")
+        clean = [float(item) for item in value]
+        if clean[2] < clean[0]:
+            clean[0], clean[2] = clean[2], clean[0]
+        if clean[3] < clean[1]:
+            clean[1], clean[3] = clean[3], clean[1]
+        if clean[2] == clean[0] or clean[3] == clean[1]:
+            raise ValueError("uv_box must have non-zero width and height.")
+        return clean
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return int(value)
+
+    def _mesh_shape(node):
+        if not cmds.objExists(node):
+            raise ValueError(f"Object does not exist: {node}")
+        if cmds.objectType(node) == "mesh":
+            return node
+        shapes = cmds.listRelatives(node, shapes=True, fullPath=True) or []
+        mesh_shapes = []
+        for shape in shapes:
+            if cmds.objectType(shape) != "mesh":
+                continue
+            try:
+                if cmds.attributeQuery("intermediateObject", node=shape, exists=True) and cmds.getAttr(f"{shape}.intermediateObject"):
+                    continue
+            except Exception:
+                pass
+            mesh_shapes.append(shape)
+        if not mesh_shapes:
+            raise ValueError(f"{node} is not a polygon mesh transform or mesh shape.")
+        return mesh_shapes[0]
+
+    def _dag_path(shape):
+        selection = om.MSelectionList()
+        selection.add(shape)
+        return selection.getDagPath(0)
+
+    def _mesh_fn(shape):
+        return om.MFnMesh(_dag_path(shape))
+
+    def _prefix(shape):
+        parents = cmds.listRelatives(shape, parent=True, fullPath=False) or []
+        return parents[0] if parents else object_name
+
+    def _flatten(value):
+        if value is None:
+            return []
+        if isinstance(value, str):
+            value = [value]
+        if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+            raise ValueError("components must be a string, a list of strings, or None.")
+        return cmds.ls(value, flatten=True) or []
+
+    def _selected_components():
+        if not use_selection:
+            return []
+        selected = cmds.ls(selection=True, flatten=True) or []
+        object_tokens = {object_name, prefix_name, shape_name}
+        return [item for item in selected if item.split(".", 1)[0] in object_tokens]
+
+    def _components_from_indices(kind):
+        if indices is None:
+            return []
+        if not isinstance(indices, list) or not all(isinstance(index, int) and not isinstance(index, bool) for index in indices):
+            raise ValueError("indices must be a list of integers.")
+        return [f"{prefix_name}.{kind}[{index}]" for index in indices]
+
+    def _resolve_components(default_type=None):
+        clean_type = (component_type or default_type or "").lower().strip()
+        kind_map = {"vertex": "vtx", "edge": "e", "face": "f", "uv": "map", "vertex_face": "vtxFace"}
+        if components is not None:
+            return _flatten(components)
+        if clean_type in kind_map and indices is not None:
+            return _components_from_indices(kind_map[clean_type])
+        return _selected_components()
+
+    def _unique(items):
+        seen = set()
+        result = []
+        for item in cmds.ls(items, flatten=True) or []:
+            if item in seen:
+                continue
+            seen.add(item)
+            result.append(item)
+        return result
+
+    def _component_ids(items, kind):
+        pattern = re.compile(rf"\.{kind}\[(\d+)\]$")
+        ids = []
+        for item in cmds.ls(items, flatten=True) or []:
+            match = pattern.search(item)
+            if match:
+                ids.append(int(match.group(1)))
+        return list(dict.fromkeys(ids))
+
+    def _convert(items, target):
+        flags = {
+            "vertex": {"toVertex": True},
+            "edge": {"toEdge": True},
+            "face": {"toFace": True},
+            "uv": {"toUV": True},
+        }[target]
+        return _unique(cmds.polyListComponentConversion(items, **flags) or [])
+
+    def _uv_component(uv_id):
+        return f"{prefix_name}.map[{uv_id}]"
+
+    def _face_component(face_id):
+        return f"{prefix_name}.f[{face_id}]"
+
+    def _inside(uv):
+        u_value, v_value = uv
+        return clean_box[0] <= u_value <= clean_box[2] and clean_box[1] <= v_value <= clean_box[3]
+
+    def _uv_value(uv_id):
+        u_value, v_value = mesh_fn.getUV(int(uv_id), active_uv_set)
+        return [float(u_value), float(v_value)]
+
+    def _candidate_face_ids():
+        source = _resolve_components("face")
+        if not source:
+            return list(range(int(mesh_fn.numPolygons)))
+        return _component_ids(_convert(source, "face"), "f")
+
+    def _candidate_uv_ids():
+        source = _resolve_components("uv")
+        if not source:
+            return list(range(int(mesh_fn.numUVs(active_uv_set))))
+        return _component_ids(_convert(source, "uv"), "map")
+
+    def _face_uv_records(face_id):
+        polygon_it.setIndex(int(face_id))
+        records = []
+        for local_index in range(int(polygon_it.polygonVertexCount())):
+            try:
+                uv_id = int(polygon_it.getUVIndex(local_index, active_uv_set))
+                uv = _uv_value(uv_id)
+            except Exception:
+                continue
+            records.append({"uv_id": uv_id, "uv": uv})
+        return records
+
+    def _face_matches(face_id):
+        records = _face_uv_records(face_id)
+        if not records:
+            return False, []
+        if clean_sample_mode == "center":
+            center = [
+                sum(record["uv"][0] for record in records) / float(len(records)),
+                sum(record["uv"][1] for record in records) / float(len(records)),
+            ]
+            inside = _inside(center)
+        elif clean_sample_mode == "any":
+            inside = any(_inside(record["uv"]) for record in records)
+        else:
+            inside = all(_inside(record["uv"]) for record in records)
+        return inside == bool(keep_inside), records
+
+    def _selection_items():
+        if clean_result_type == "uv":
+            matched_uv_ids = []
+            uv_records = []
+            for uv_id in _candidate_uv_ids():
+                uv = _uv_value(uv_id)
+                matched = _inside(uv) == bool(keep_inside)
+                if matched:
+                    matched_uv_ids.append(uv_id)
+                    uv_records.append({"component": _uv_component(uv_id), "index": uv_id, "uv": uv})
+            return [_uv_component(uv_id) for uv_id in matched_uv_ids], uv_records, []
+
+        matched_face_ids = []
+        face_records = []
+        for face_id in _candidate_face_ids():
+            matched, uv_records = _face_matches(face_id)
+            if not matched:
+                continue
+            matched_face_ids.append(face_id)
+            center = None
+            if uv_records:
+                center = [
+                    sum(record["uv"][0] for record in uv_records) / float(len(uv_records)),
+                    sum(record["uv"][1] for record in uv_records) / float(len(uv_records)),
+                ]
+            face_records.append(
+                {
+                    "component": _face_component(face_id),
+                    "index": face_id,
+                    "uv_center": center,
+                    "uv_count": len(uv_records),
+                    "uvs": uv_records[:max_preview],
+                }
+            )
+        face_components = [_face_component(face_id) for face_id in matched_face_ids]
+        if clean_result_type == "face":
+            return face_components, [], face_records
+        converted = _convert(face_components, clean_result_type) if face_components else []
+        return converted, [], face_records
+
+    def _apply_selection(items):
+        mode_name = selection_mode.lower().strip()
+        if mode_name not in {"replace", "add", "toggle", "deselect"}:
+            raise ValueError("selection_mode must be replace, add, toggle, or deselect.")
+        if items:
+            cmds.select(items, **{mode_name: True})
+        elif mode_name == "replace":
+            cmds.select(clear=True)
+
+    if not object_name:
+        raise ValueError("object_name is required.")
+    clean_box = _validate_box(uv_box)
+    clean_result_type = result_type.lower().strip()
+    if clean_result_type not in {"uv", "face", "edge", "vertex"}:
+        raise ValueError("result_type must be uv, face, edge, or vertex.")
+    clean_sample_mode = sample_mode.lower().strip()
+    if clean_sample_mode not in {"center", "any", "all"}:
+        raise ValueError("sample_mode must be center, any, or all.")
+    max_preview = _validate_int(max_preview, "max_preview", 1)
+
+    shape_name = _mesh_shape(object_name)
+    prefix_name = _prefix(shape_name)
+    mesh_fn = _mesh_fn(shape_name)
+    polygon_it = om.MItMeshPolygon(_dag_path(shape_name))
+
+    all_uv_sets = cmds.polyUVSet(object_name, query=True, allUVSets=True) or []
+    previous_uv_set = (cmds.polyUVSet(object_name, query=True, currentUVSet=True) or [None])[0]
+    if uv_set:
+        if uv_set not in all_uv_sets:
+            raise ValueError(f"UV set {uv_set} does not exist on {object_name}.")
+        cmds.polyUVSet(object_name, currentUVSet=True, uvSet=uv_set)
+    active_uv_set = uv_set or previous_uv_set
+    if not active_uv_set:
+        raise ValueError(f"{object_name} has no active UV set.")
+
+    try:
+        matched_components, uv_records, face_records = _selection_items()
+        if select_result:
+            _apply_selection(matched_components)
+        return {
+            "success": True,
+            "object_name": object_name,
+            "shape_name": shape_name,
+            "operation": "select_mesh_by_uv_region",
+            "uv_set": active_uv_set,
+            "uv_box": clean_box,
+            "result_type": clean_result_type,
+            "sample_mode": clean_sample_mode,
+            "keep_inside": bool(keep_inside),
+            "matched_count": len(matched_components),
+            "components": matched_components[:max_preview],
+            "truncated": len(matched_components) > max_preview,
+            "selected": bool(select_result),
+            "selection_mode": selection_mode if select_result else None,
+            "uv_records": uv_records[:max_preview],
+            "face_records": face_records[:max_preview],
+            "records_truncated": len(uv_records) > max_preview or len(face_records) > max_preview,
+        }
+    finally:
+        if uv_set and previous_uv_set and previous_uv_set in all_uv_sets and cmds.objExists(object_name):
+            try:
+                cmds.polyUVSet(object_name, currentUVSet=True, uvSet=previous_uv_set)
+            except Exception:
+                pass

--- a/src/mayatools/object/select_mesh_components.py
+++ b/src/mayatools/object/select_mesh_components.py
@@ -1,0 +1,288 @@
+from typing import Dict, List, Any, Union
+
+
+def select_mesh_components(
+    object_name: str,
+    operation: str = "query",
+    component_type: str = None,
+    indices: List[int] = None,
+    components: Union[str, List[str]] = None,
+    target_type: str = None,
+    path_indices: List[int] = None,
+    selection_mode: str = "replace",
+    select_result: bool = True,
+    use_selection: bool = True,
+    options: Dict[str, Any] = None,
+    max_components: int = 1000,
+) -> Dict[str, Any]:
+    """Resolve, convert, and select Maya polygon components.
+
+    Operations:
+    - query: report explicit, indexed, or currently selected components
+    - select: select resolved components with replace/add/toggle/deselect mode
+    - convert: convert components to vertex, edge, face, uv, or vertex_face
+    - edge_loop, edge_ring, edge_border, edge_loop_or_border: select from seed edges
+    - edge_loop_path, edge_ring_path: select a loop/ring path between two seed edges
+    - extend_to_shell: select the connected polygon shell from seed faces
+    - uv_shell: select the full UV shell from seed components
+    - boundary: convert to border edges around the resolved component region
+
+    This is a component selection/navigation tool for Maya-style polygon
+    modeling. Use it to reliably target edge loops, rings, face shells, UV
+    shells, or converted component sets before localized edits.
+    """
+    import re
+    import maya.cmds as cmds
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return int(value)
+
+    def _mesh_shape(node):
+        if not cmds.objExists(node):
+            raise ValueError(f"Object does not exist: {node}")
+        if cmds.objectType(node) == "mesh":
+            return node
+        shapes = cmds.listRelatives(node, shapes=True, fullPath=True) or []
+        mesh_shapes = []
+        for shape in shapes:
+            if cmds.objectType(shape) != "mesh":
+                continue
+            try:
+                if cmds.attributeQuery("intermediateObject", node=shape, exists=True) and cmds.getAttr(f"{shape}.intermediateObject"):
+                    continue
+            except Exception:
+                pass
+            mesh_shapes.append(shape)
+        if not mesh_shapes:
+            raise ValueError(f"{node} is not a polygon mesh transform or mesh shape.")
+        return mesh_shapes[0]
+
+    def _prefix(shape):
+        parents = cmds.listRelatives(shape, parent=True, fullPath=False) or []
+        return parents[0] if parents else object_name
+
+    def _flatten(value):
+        if value is None:
+            return []
+        if isinstance(value, str):
+            value = [value]
+        if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+            raise ValueError("components must be a string, a list of strings, or None.")
+        return cmds.ls(value, flatten=True) or []
+
+    def _unique(items):
+        seen = set()
+        result = []
+        for item in cmds.ls(items, flatten=True) or []:
+            if item not in seen:
+                seen.add(item)
+                result.append(item)
+        return result
+
+    def _selected_components():
+        if not use_selection:
+            return []
+        selected = cmds.ls(selection=True, flatten=True) or []
+        object_tokens = {object_name, prefix_name, shape_name}
+        return [item for item in selected if item.split(".", 1)[0] in object_tokens]
+
+    def _components_from_indices(kind):
+        if indices is None:
+            return []
+        if not isinstance(indices, list) or not all(isinstance(index, int) and not isinstance(index, bool) for index in indices):
+            raise ValueError("indices must be a list of integers.")
+        return [f"{prefix_name}.{kind}[{index}]" for index in indices]
+
+    def _resolve_components(default_type=None):
+        clean_type = (component_type or default_type or "").lower().strip()
+        kind_map = {
+            "vertex": "vtx",
+            "edge": "e",
+            "face": "f",
+            "uv": "map",
+            "vertex_face": "vtxFace",
+        }
+        if components is not None:
+            resolved = _flatten(components)
+        elif clean_type in kind_map and indices is not None:
+            resolved = _components_from_indices(kind_map[clean_type])
+        else:
+            resolved = _selected_components()
+        if not resolved:
+            raise ValueError("No components resolved from components, indices, or current selection.")
+        return _unique(resolved)
+
+    def _component_ids(items, kind):
+        pattern = re.compile(rf"\.{kind}\[(\d+)\]$")
+        ids = []
+        for item in cmds.ls(items, flatten=True) or []:
+            match = pattern.search(item)
+            if match:
+                ids.append(int(match.group(1)))
+        return list(dict.fromkeys(ids))
+
+    def _edge_ids():
+        resolved = _resolve_components("edge")
+        edges = cmds.polyListComponentConversion(resolved, toEdge=True) or []
+        edge_ids = _component_ids(edges, "e")
+        if not edge_ids:
+            raise ValueError("Operation requires edge components.")
+        return edge_ids
+
+    def _face_ids():
+        resolved = _resolve_components("face")
+        faces = cmds.polyListComponentConversion(resolved, toFace=True) or []
+        face_ids = _component_ids(faces, "f")
+        if not face_ids:
+            raise ValueError("Operation requires face components.")
+        return face_ids
+
+    def _poly_select(flag_name, seed_ids, result_kind):
+        results = []
+        for seed_id in seed_ids:
+            output = cmds.polySelect(
+                object_name,
+                asSelectString=True,
+                noSelection=True,
+                **{flag_name: int(seed_id)},
+            ) or []
+            for item in output:
+                if isinstance(item, int):
+                    results.append(f"{prefix_name}.{result_kind}[{item}]")
+                else:
+                    results.extend(_flatten(item))
+        return _unique(results)
+
+    def _poly_select_path(flag_name, seed_ids, result_kind):
+        if len(seed_ids) != 2:
+            raise ValueError(f"{flag_name} requires exactly two seed component indices.")
+        output = cmds.polySelect(
+            object_name,
+            asSelectString=True,
+            noSelection=True,
+            **{flag_name: [int(seed_ids[0]), int(seed_ids[1])]},
+        ) or []
+        results = []
+        for item in output:
+            if isinstance(item, int):
+                results.append(f"{prefix_name}.{result_kind}[{item}]")
+            else:
+                results.extend(_flatten(item))
+        return _unique(results)
+
+    def _convert(items, clean_target, convert_options):
+        target_flags = {
+            "vertex": {"toVertex": True},
+            "edge": {"toEdge": True},
+            "face": {"toFace": True},
+            "uv": {"toUV": True},
+            "vertex_face": {"toVertexFace": True},
+        }
+        if clean_target not in target_flags:
+            raise ValueError("target_type must be vertex, edge, face, uv, or vertex_face.")
+        kwargs = dict(target_flags[clean_target])
+        if convert_options.get("border"):
+            kwargs["border"] = True
+        if convert_options.get("internal"):
+            kwargs["internal"] = True
+        if convert_options.get("uv_shell"):
+            kwargs["uvShell"] = True
+        if convert_options.get("vertex_face_all_edges"):
+            kwargs["vertexFaceAllEdges"] = True
+        converted = cmds.polyListComponentConversion(items, **kwargs) or []
+        return _unique(converted)
+
+    def _apply_selection(items):
+        mode = selection_mode.lower().strip()
+        if mode not in {"replace", "add", "toggle", "deselect"}:
+            raise ValueError("selection_mode must be replace, add, toggle, or deselect.")
+        kwargs = {mode: True}
+        cmds.select(items, **kwargs)
+
+    def _result(clean_operation, items, selected=False):
+        truncated = len(items) > max_components
+        preview = items[:max_components]
+        return {
+            "success": True,
+            "object_name": object_name,
+            "operation": clean_operation,
+            "component_count": len(items),
+            "components": preview,
+            "truncated": truncated,
+            "selected": bool(selected),
+            "selection_mode": selection_mode if selected else None,
+        }
+
+    if not object_name:
+        raise ValueError("object_name is required.")
+    operation = operation.lower().strip()
+    options = options or {}
+    max_components = _validate_int(max_components, "max_components", 1)
+    shape_name = _mesh_shape(object_name)
+    prefix_name = _prefix(shape_name)
+
+    if operation == "query":
+        resolved = _resolve_components()
+        return _result(operation, resolved, selected=False)
+
+    if operation == "select":
+        resolved = _resolve_components()
+        _apply_selection(resolved)
+        return _result(operation, resolved, selected=True)
+
+    if operation == "convert":
+        resolved = _resolve_components()
+        converted = _convert(resolved, (target_type or "").lower().strip(), options)
+        if select_result:
+            _apply_selection(converted)
+        return _result(operation, converted, selected=select_result)
+
+    if operation == "boundary":
+        resolved = _resolve_components()
+        boundary_edges = _convert(resolved, "edge", {"border": True})
+        if select_result:
+            _apply_selection(boundary_edges)
+        return _result(operation, boundary_edges, selected=select_result)
+
+    if operation in {"edge_loop", "edge_ring", "edge_border", "edge_loop_or_border"}:
+        flag_map = {
+            "edge_loop": "edgeLoop",
+            "edge_ring": "edgeRing",
+            "edge_border": "edgeBorder",
+            "edge_loop_or_border": "edgeLoopOrBorder",
+        }
+        selected = _poly_select(flag_map[operation], _edge_ids(), "e")
+        if select_result:
+            _apply_selection(selected)
+        return _result(operation, selected, selected=select_result)
+
+    if operation in {"edge_loop_path", "edge_ring_path"}:
+        clean_path = path_indices if path_indices is not None else _edge_ids()[:2]
+        if not isinstance(clean_path, list) or not all(isinstance(index, int) and not isinstance(index, bool) for index in clean_path):
+            raise ValueError("path_indices must be a list of two edge indices.")
+        flag_name = "edgeLoopPath" if operation == "edge_loop_path" else "edgeRingPath"
+        selected = _poly_select_path(flag_name, clean_path, "e")
+        if select_result:
+            _apply_selection(selected)
+        return _result(operation, selected, selected=select_result)
+
+    if operation == "extend_to_shell":
+        selected = _poly_select("extendToShell", _face_ids(), "f")
+        if select_result:
+            _apply_selection(selected)
+        return _result(operation, selected, selected=select_result)
+
+    if operation == "uv_shell":
+        resolved = _resolve_components()
+        uv_items = _convert(resolved, "uv", {"uv_shell": True})
+        if select_result:
+            _apply_selection(uv_items)
+        return _result(operation, uv_items, selected=select_result)
+
+    raise ValueError(
+        "Unknown operation. Use query, select, convert, edge_loop, edge_ring, "
+        "edge_border, edge_loop_or_border, edge_loop_path, edge_ring_path, "
+        "extend_to_shell, uv_shell, or boundary."
+    )

--- a/src/mayatools/object/select_mesh_rings_by_axis.py
+++ b/src/mayatools/object/select_mesh_rings_by_axis.py
@@ -1,0 +1,275 @@
+from typing import Dict, List, Any
+
+
+def select_mesh_rings_by_axis(
+    object_name: str,
+    result_type: str = "vertex",
+    axis: str = "y",
+    targets: List[float] = None,
+    mode: str = "nearest",
+    group_tolerance: float = 0.001,
+    target_tolerance: float = None,
+    min_components_per_group: int = 1,
+    space: str = "world",
+    selection_mode: str = "replace",
+    select_result: bool = True,
+    max_groups: int = 20,
+    max_preview: int = 100,
+) -> Dict[str, Any]:
+    """Select coordinate-clustered mesh rows or component bands along an axis.
+
+    Modes:
+    - nearest: find the closest coordinate group for each target value
+    - within: find all coordinate groups within target_tolerance of each target
+    - all: report all coordinate groups, limited by max_groups
+
+    This is a generic Maya-style component navigation tool for meshes with
+    repeated rows or bands, such as bottles, cans, vases, characters, props, and
+    gridded hard-surface models. It makes component rings explicit before
+    localized transforms, edge sliding, normal edits, material assignment, or UV
+    work.
+    """
+    import maya.cmds as cmds
+    import maya.api.OpenMaya as om
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return int(value)
+
+    def _axis_index(axis_name):
+        clean_axis = (axis_name or "").lower().strip()
+        if clean_axis not in {"x", "y", "z"}:
+            raise ValueError("axis must be x, y, or z.")
+        return {"x": 0, "y": 1, "z": 2}[clean_axis]
+
+    def _mesh_shape(node):
+        if not cmds.objExists(node):
+            raise ValueError(f"Object does not exist: {node}")
+        if cmds.objectType(node) == "mesh":
+            return node
+        shapes = cmds.listRelatives(node, shapes=True, fullPath=True) or []
+        mesh_shapes = []
+        for shape in shapes:
+            if cmds.objectType(shape) != "mesh":
+                continue
+            try:
+                if cmds.attributeQuery("intermediateObject", node=shape, exists=True) and cmds.getAttr(f"{shape}.intermediateObject"):
+                    continue
+            except Exception:
+                pass
+            mesh_shapes.append(shape)
+        if not mesh_shapes:
+            raise ValueError(f"{node} is not a polygon mesh transform or mesh shape.")
+        return mesh_shapes[0]
+
+    def _dag_path(shape):
+        selection = om.MSelectionList()
+        selection.add(shape)
+        return selection.getDagPath(0)
+
+    def _prefix(shape):
+        parents = cmds.listRelatives(shape, parent=True, fullPath=False) or []
+        return parents[0] if parents else object_name
+
+    def _point_values(point):
+        return [float(point.x), float(point.y), float(point.z)]
+
+    def _component_center(component_id):
+        if clean_result_type == "vertex":
+            return _point_values(points[component_id])
+        if clean_result_type == "edge":
+            vertex_ids = list(mesh_fn.getEdgeVertices(component_id))
+        else:
+            vertex_ids = list(mesh_fn.getPolygonVertices(component_id))
+        center = [0.0, 0.0, 0.0]
+        for vertex_id in vertex_ids:
+            values = _point_values(points[int(vertex_id)])
+            center[0] += values[0]
+            center[1] += values[1]
+            center[2] += values[2]
+        scale = 1.0 / float(max(1, len(vertex_ids)))
+        return [center[0] * scale, center[1] * scale, center[2] * scale]
+
+    def _component_name(component_id):
+        kind = {"vertex": "vtx", "edge": "e", "face": "f"}[clean_result_type]
+        return f"{prefix_name}.{kind}[{component_id}]"
+
+    def _build_groups():
+        total = {
+            "vertex": int(mesh_fn.numVertices),
+            "edge": int(mesh_fn.numEdges),
+            "face": int(mesh_fn.numPolygons),
+        }[clean_result_type]
+        records = []
+        for component_id in range(total):
+            center = _component_center(component_id)
+            records.append(
+                {
+                    "id": component_id,
+                    "axis_value": center[axis_idx],
+                    "center": center,
+                }
+            )
+        records.sort(key=lambda item: (item["axis_value"], item["id"]))
+
+        groups = []
+        current = []
+        group_start = None
+        for record in records:
+            if not current or record["axis_value"] - group_start <= clean_group_tolerance:
+                current.append(record)
+                if group_start is None:
+                    group_start = record["axis_value"]
+                continue
+            groups.append(current)
+            current = [record]
+            group_start = record["axis_value"]
+        if current:
+            groups.append(current)
+
+        result = []
+        for group_index, group in enumerate(groups):
+            if len(group) < clean_min_components:
+                continue
+            values = [item["axis_value"] for item in group]
+            ids = sorted(item["id"] for item in group)
+            result.append(
+                {
+                    "group_index": group_index,
+                    "axis_value": sum(values) / float(len(values)),
+                    "axis_min": min(values),
+                    "axis_max": max(values),
+                    "component_count": len(group),
+                    "component_ids": ids,
+                }
+            )
+        return result
+
+    def _pick_groups(groups):
+        if clean_mode == "all":
+            return groups[:clean_max_groups]
+        if not clean_targets:
+            raise ValueError("targets are required for nearest and within modes.")
+        picked = []
+        seen = set()
+        tolerance = clean_target_tolerance
+        for target in clean_targets:
+            if clean_mode == "nearest":
+                candidates = sorted(groups, key=lambda group: (abs(group["axis_value"] - target), group["axis_value"]))
+                if not candidates:
+                    continue
+                group = candidates[0]
+                distance = abs(group["axis_value"] - target)
+                if tolerance is not None and distance > tolerance:
+                    continue
+                records = [dict(group)]
+                records[0]["target"] = target
+                records[0]["target_distance"] = distance
+            else:
+                records = []
+                for group in groups:
+                    distance = abs(group["axis_value"] - target)
+                    if distance <= tolerance:
+                        record = dict(group)
+                        record["target"] = target
+                        record["target_distance"] = distance
+                        records.append(record)
+            for record in records:
+                key = record["group_index"]
+                if key in seen:
+                    continue
+                seen.add(key)
+                picked.append(record)
+        picked.sort(key=lambda item: item["axis_value"])
+        return picked[:clean_max_groups]
+
+    def _apply_selection(items):
+        mode_name = selection_mode.lower().strip()
+        if mode_name not in {"replace", "add", "toggle", "deselect"}:
+            raise ValueError("selection_mode must be replace, add, toggle, or deselect.")
+        cmds.select(items, **{mode_name: True})
+
+    if not object_name:
+        raise ValueError("object_name is required.")
+    clean_result_type = result_type.lower().strip()
+    if clean_result_type not in {"vertex", "edge", "face"}:
+        raise ValueError("result_type must be vertex, edge, or face.")
+    clean_mode = mode.lower().strip()
+    if clean_mode not in {"nearest", "within", "all"}:
+        raise ValueError("mode must be nearest, within, or all.")
+    clean_group_tolerance = _validate_scalar(group_tolerance, "group_tolerance")
+    if clean_group_tolerance < 0.0:
+        raise ValueError("group_tolerance must be greater than or equal to zero.")
+    if target_tolerance is None:
+        clean_target_tolerance = None if clean_mode == "nearest" else clean_group_tolerance
+    else:
+        clean_target_tolerance = _validate_scalar(target_tolerance, "target_tolerance")
+        if clean_target_tolerance < 0.0:
+            raise ValueError("target_tolerance must be greater than or equal to zero.")
+    clean_min_components = _validate_int(min_components_per_group, "min_components_per_group", 1)
+    clean_max_groups = _validate_int(max_groups, "max_groups", 1)
+    max_preview = _validate_int(max_preview, "max_preview", 1)
+    space = space.lower().strip()
+    if space not in {"world", "object"}:
+        raise ValueError("space must be world or object.")
+    clean_targets = []
+    if targets is not None:
+        if not isinstance(targets, list) or not all(_is_number(item) for item in targets):
+            raise ValueError("targets must be a list of numeric values.")
+        clean_targets = [float(item) for item in targets]
+
+    axis_idx = _axis_index(axis)
+    shape_name = _mesh_shape(object_name)
+    prefix_name = _prefix(shape_name)
+    dag_path = _dag_path(shape_name)
+    mesh_fn = om.MFnMesh(dag_path)
+    om_space = om.MSpace.kWorld if space == "world" else om.MSpace.kObject
+    points = mesh_fn.getPoints(om_space)
+
+    all_groups = _build_groups()
+    picked_groups = _pick_groups(all_groups)
+    selected_components = []
+    for group in picked_groups:
+        components = [_component_name(component_id) for component_id in group["component_ids"]]
+        selected_components.extend(components)
+        group["components"] = components[:max_preview]
+        group["truncated"] = len(components) > max_preview
+        group["component_ids_preview"] = group["component_ids"][:max_preview]
+        if len(group["component_ids"]) > max_preview:
+            group["component_ids"] = group["component_ids"][:max_preview]
+
+    if select_result and selected_components:
+        _apply_selection(selected_components)
+    elif select_result and selection_mode.lower().strip() == "replace":
+        cmds.select(clear=True)
+
+    return {
+        "success": True,
+        "object_name": object_name,
+        "shape_name": shape_name,
+        "result_type": clean_result_type,
+        "axis": axis.lower().strip(),
+        "space": space,
+        "mode": clean_mode,
+        "targets": clean_targets,
+        "group_tolerance": clean_group_tolerance,
+        "target_tolerance": clean_target_tolerance,
+        "min_components_per_group": clean_min_components,
+        "available_group_count": len(all_groups),
+        "returned_group_count": len(picked_groups),
+        "selected_component_count": len(selected_components),
+        "selected_components": selected_components[:max_preview],
+        "selected_components_truncated": len(selected_components) > max_preview,
+        "selected": bool(select_result and selected_components),
+        "selection_mode": selection_mode if select_result and selected_components else None,
+        "groups": picked_groups,
+    }

--- a/src/mayatools/object/select_mesh_silhouette_components.py
+++ b/src/mayatools/object/select_mesh_silhouette_components.py
@@ -1,0 +1,409 @@
+from typing import Dict, List, Any
+
+
+def select_mesh_silhouette_components(
+    object_name: str,
+    result_type: str = "vertex",
+    method: str = "projected_extremes",
+    view_direction: List[float] = None,
+    camera_name: str = None,
+    up_axis: List[float] = None,
+    axis: str = None,
+    axis_range: List[float] = None,
+    box_min: List[float] = None,
+    box_max: List[float] = None,
+    center: List[float] = None,
+    screen_y_range: List[float] = None,
+    bin_count: int = 32,
+    extreme_sides: List[str] = None,
+    extreme_count: int = 1,
+    normal_dot_tolerance: float = 0.02,
+    include_boundary_edges: bool = True,
+    space: str = "world",
+    selection_mode: str = "replace",
+    select_result: bool = True,
+    max_preview: int = 200,
+) -> Dict[str, Any]:
+    """Select mesh components that define a view-dependent silhouette.
+
+    Methods:
+    - projected_extremes: project components into a view plane, split them into
+      vertical bins, and select the left/right projected extremes in each bin.
+      This matches the common Maya modeling workflow of checking front/side
+      outline and moving the visible profile components.
+    - normal_edges: select edges whose adjacent face normals cross the view
+      direction, optionally including border edges.
+
+    The tool is generic for props, characters, bottles, cars, hard-surface
+    panels, icons, and any mesh where view silhouette control matters. It does
+    not modify geometry.
+    """
+    import math
+    import re
+    import maya.cmds as cmds
+    import maya.api.OpenMaya as om
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return int(value)
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(item) for item in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(item) for item in values]
+
+    def _validate_range(values, arg_name):
+        clean = _validate_vector(values, 2, arg_name)
+        if clean[0] > clean[1]:
+            clean = [clean[1], clean[0]]
+        if abs(clean[1] - clean[0]) <= 1.0e-12:
+            raise ValueError(f"{arg_name} must have non-zero span.")
+        return clean
+
+    def _axis_index(axis_name):
+        clean_axis = (axis_name or "").lower().strip()
+        if clean_axis not in {"x", "y", "z"}:
+            raise ValueError("axis must be x, y, or z.")
+        return {"x": 0, "y": 1, "z": 2}[clean_axis]
+
+    def _mesh_shape(node):
+        if not cmds.objExists(node):
+            raise ValueError(f"Object does not exist: {node}")
+        if cmds.objectType(node) == "mesh":
+            return node
+        shapes = cmds.listRelatives(node, shapes=True, fullPath=True) or []
+        mesh_shapes = []
+        for shape in shapes:
+            if cmds.objectType(shape) != "mesh":
+                continue
+            try:
+                if cmds.attributeQuery("intermediateObject", node=shape, exists=True) and cmds.getAttr(f"{shape}.intermediateObject"):
+                    continue
+            except Exception:
+                pass
+            mesh_shapes.append(shape)
+        if not mesh_shapes:
+            raise ValueError(f"{node} is not a polygon mesh transform or mesh shape.")
+        return mesh_shapes[0]
+
+    def _dag_path(node):
+        selection = om.MSelectionList()
+        selection.add(node)
+        return selection.getDagPath(0)
+
+    def _mesh_fn(shape):
+        return om.MFnMesh(_dag_path(shape))
+
+    def _prefix(shape):
+        parents = cmds.listRelatives(shape, parent=True, fullPath=False) or []
+        return parents[0] if parents else object_name
+
+    def _normalize_vector(values, arg_name):
+        vector = om.MVector(*_validate_vector(values, 3, arg_name))
+        length = vector.length()
+        if length <= 1.0e-12:
+            raise ValueError(f"{arg_name} must not be a zero vector.")
+        return vector / length
+
+    def _camera_view_direction(name):
+        if not name or not cmds.objExists(name):
+            raise ValueError(f"Camera does not exist: {name}")
+        node = name
+        if cmds.objectType(node) == "camera":
+            parents = cmds.listRelatives(node, parent=True, fullPath=True) or []
+            if not parents:
+                raise ValueError(f"Camera shape has no transform: {name}")
+            node = parents[0]
+        matrix = _dag_path(node).inclusiveMatrix()
+        direction = om.MVector(0.0, 0.0, -1.0) * matrix
+        length = direction.length()
+        if length <= 1.0e-12:
+            raise ValueError(f"Unable to derive view direction from camera: {name}")
+        return direction / length
+
+    def _projection_basis():
+        view = _camera_view_direction(camera_name) if camera_name else _normalize_vector(clean_view_direction, "view_direction")
+        up = _normalize_vector(clean_up_axis, "up_axis")
+        up = up - view * (up * view)
+        if up.length() <= 1.0e-12:
+            raise ValueError("up_axis must not be parallel to view_direction.")
+        up.normalize()
+        right = view ^ up
+        if right.length() <= 1.0e-12:
+            raise ValueError("Unable to build a projection basis.")
+        right.normalize()
+        return view, right, up
+
+    def _point_values(point):
+        return [float(point.x), float(point.y), float(point.z)]
+
+    def _point_from_values(values):
+        return om.MPoint(float(values[0]), float(values[1]), float(values[2]))
+
+    def _average_points(point_items):
+        result = om.MPoint()
+        for point in point_items:
+            result += point
+        return result / float(max(1, len(point_items)))
+
+    def _edge_vertices(edge_id):
+        vertices = mesh_fn.getEdgeVertices(int(edge_id))
+        return int(vertices[0]), int(vertices[1])
+
+    def _component_center(component_id):
+        if clean_result_type == "vertex":
+            return points[int(component_id)]
+        if clean_result_type == "edge":
+            a, b = _edge_vertices(component_id)
+            return _average_points([points[a], points[b]])
+        vertex_ids = mesh_fn.getPolygonVertices(int(component_id))
+        return _average_points([points[int(vertex_id)] for vertex_id in vertex_ids])
+
+    def _component_name(component_id, result_type_name=None):
+        kind = {"vertex": "vtx", "edge": "e", "face": "f"}[result_type_name or clean_result_type]
+        return f"{prefix_name}.{kind}[{int(component_id)}]"
+
+    def _passes_filters(point):
+        values = _point_values(point)
+        if clean_box_min is not None:
+            for index in range(3):
+                if values[index] < clean_box_min[index] - 1.0e-9 or values[index] > clean_box_max[index] + 1.0e-9:
+                    return False
+        if axis_idx is not None:
+            axis_value = values[axis_idx] - clean_center[axis_idx]
+            if axis_value < clean_axis_range[0] - 1.0e-9 or axis_value > clean_axis_range[1] + 1.0e-9:
+                return False
+        return True
+
+    def _component_ids(items, kind):
+        pattern = re.compile(rf"\.{kind}\[(\d+)\]$")
+        ids = []
+        for item in cmds.ls(items, flatten=True) or []:
+            match = pattern.search(item)
+            if match:
+                ids.append(int(match.group(1)))
+        return sorted(set(ids))
+
+    def _convert_components(source_items, target_type):
+        flags = {
+            "vertex": {"toVertex": True},
+            "edge": {"toEdge": True},
+            "face": {"toFace": True},
+        }[target_type]
+        converted = cmds.polyListComponentConversion(source_items, **flags) or []
+        kind = {"vertex": "vtx", "edge": "e", "face": "f"}[target_type]
+        return _component_ids(converted, kind)
+
+    def _candidate_ids_for_result_type():
+        total = {
+            "vertex": int(mesh_fn.numVertices),
+            "edge": int(mesh_fn.numEdges),
+            "face": int(mesh_fn.numPolygons),
+        }[clean_result_type]
+        ids = []
+        for component_id in range(total):
+            center_point = _component_center(component_id)
+            if _passes_filters(center_point):
+                ids.append(component_id)
+        return ids
+
+    def _projected_extreme_ids():
+        candidate_ids = _candidate_ids_for_result_type()
+        records = []
+        for component_id in candidate_ids:
+            point = _component_center(component_id)
+            vector = om.MVector(point.x, point.y, point.z)
+            screen_x = float(vector * right_axis)
+            screen_y = float(vector * up_vector)
+            records.append({"id": component_id, "screen_x": screen_x, "screen_y": screen_y})
+        if not records:
+            return [], []
+
+        if clean_screen_y_range is None:
+            y_min = min(record["screen_y"] for record in records)
+            y_max = max(record["screen_y"] for record in records)
+            if abs(y_max - y_min) <= 1.0e-12:
+                y_max = y_min + 1.0
+            y_range = [y_min, y_max]
+        else:
+            y_range = clean_screen_y_range
+            records = [record for record in records if y_range[0] - 1.0e-9 <= record["screen_y"] <= y_range[1] + 1.0e-9]
+        if not records:
+            return [], []
+
+        span = y_range[1] - y_range[0]
+        bins = [[] for _ in range(clean_bin_count)]
+        for record in records:
+            t = (record["screen_y"] - y_range[0]) / span
+            index = int(math.floor(t * clean_bin_count))
+            index = max(0, min(clean_bin_count - 1, index))
+            bins[index].append(record)
+
+        selected = []
+        bin_reports = []
+        for bin_index, bin_records in enumerate(bins):
+            if not bin_records:
+                continue
+            bin_report = {
+                "bin_index": bin_index,
+                "screen_y_min": y_range[0] + span * (bin_index / float(clean_bin_count)),
+                "screen_y_max": y_range[0] + span * ((bin_index + 1) / float(clean_bin_count)),
+                "candidate_count": len(bin_records),
+                "selected": [],
+            }
+            if "left" in clean_extreme_sides:
+                for record in sorted(bin_records, key=lambda item: (item["screen_x"], item["id"]))[:clean_extreme_count]:
+                    selected.append(record["id"])
+                    bin_report["selected"].append({"side": "left", "index": record["id"], "screen_x": record["screen_x"], "screen_y": record["screen_y"]})
+            if "right" in clean_extreme_sides:
+                for record in sorted(bin_records, key=lambda item: (-item["screen_x"], item["id"]))[:clean_extreme_count]:
+                    selected.append(record["id"])
+                    bin_report["selected"].append({"side": "right", "index": record["id"], "screen_x": record["screen_x"], "screen_y": record["screen_y"]})
+            bin_reports.append(bin_report)
+        return sorted(set(selected)), bin_reports
+
+    def _normal_edge_ids():
+        edge_ids = []
+        edge_reports = []
+        edge_iterator = om.MItMeshEdge(_dag_path(shape_name))
+        while not edge_iterator.isDone():
+            edge_id = int(edge_iterator.index())
+            a, b = int(edge_iterator.vertexId(0)), int(edge_iterator.vertexId(1))
+            center_point = _average_points([points[a], points[b]])
+            if not _passes_filters(center_point):
+                edge_iterator.next()
+                continue
+            try:
+                face_ids = [int(face_id) for face_id in edge_iterator.getConnectedFaces()]
+            except Exception:
+                face_ids = []
+            selected = False
+            dots = []
+            if len(face_ids) < 2:
+                selected = bool(include_boundary_edges)
+            else:
+                for face_id in face_ids[:2]:
+                    normal = mesh_fn.getPolygonNormal(face_id, om_space)
+                    normal.normalize()
+                    dots.append(float(normal * view_vector))
+                if dots[0] * dots[1] <= 0.0:
+                    selected = True
+                elif min(abs(dots[0]), abs(dots[1])) <= clean_normal_dot_tolerance:
+                    selected = True
+            if selected:
+                edge_ids.append(edge_id)
+                edge_reports.append({"edge": edge_id, "faces": face_ids, "normal_dots": dots})
+            edge_iterator.next()
+        if clean_result_type == "edge":
+            return edge_ids, edge_reports
+        edge_components = [_component_name(edge_id, "edge") for edge_id in edge_ids]
+        converted_ids = _convert_components(edge_components, clean_result_type) if edge_components else []
+        return converted_ids, edge_reports
+
+    def _apply_selection(component_ids):
+        mode = selection_mode.lower().strip()
+        if mode not in {"replace", "add", "toggle", "deselect"}:
+            raise ValueError("selection_mode must be replace, add, toggle, or deselect.")
+        items = [_component_name(component_id) for component_id in component_ids]
+        if items:
+            cmds.select(items, **{mode: True})
+        elif mode == "replace":
+            cmds.select(clear=True)
+
+    if not object_name:
+        raise ValueError("object_name is required.")
+    clean_result_type = (result_type or "").lower().strip()
+    if clean_result_type not in {"vertex", "edge", "face"}:
+        raise ValueError("result_type must be vertex, edge, or face.")
+    clean_method = (method or "").lower().strip()
+    if clean_method not in {"projected_extremes", "normal_edges"}:
+        raise ValueError("method must be projected_extremes or normal_edges.")
+    space = (space or "").lower().strip()
+    if space not in {"world", "object"}:
+        raise ValueError("space must be world or object.")
+    om_space = om.MSpace.kWorld if space == "world" else om.MSpace.kObject
+    clean_view_direction = view_direction if view_direction is not None else [0.0, 0.0, -1.0]
+    clean_up_axis = up_axis if up_axis is not None else [0.0, 1.0, 0.0]
+    clean_center = _validate_vector(center, 3, "center") if center is not None else [0.0, 0.0, 0.0]
+    axis_idx = _axis_index(axis) if axis is not None else None
+    clean_axis_range = _validate_range(axis_range, "axis_range") if axis_range is not None else None
+    if axis_idx is not None and clean_axis_range is None:
+        raise ValueError("axis_range is required when axis is provided.")
+    if axis_idx is None and clean_axis_range is not None:
+        raise ValueError("axis is required when axis_range is provided.")
+    clean_box_min = clean_box_max = None
+    if box_min is not None or box_max is not None:
+        clean_box_min = _validate_vector(box_min, 3, "box_min")
+        clean_box_max = _validate_vector(box_max, 3, "box_max")
+        for index in range(3):
+            if clean_box_min[index] > clean_box_max[index]:
+                clean_box_min[index], clean_box_max[index] = clean_box_max[index], clean_box_min[index]
+    clean_screen_y_range = _validate_range(screen_y_range, "screen_y_range") if screen_y_range is not None else None
+    clean_bin_count = _validate_int(bin_count, "bin_count", 1)
+    clean_extreme_count = _validate_int(extreme_count, "extreme_count", 1)
+    clean_extreme_sides = [str(item).lower().strip() for item in (extreme_sides or ["left", "right"])]
+    if not clean_extreme_sides or any(item not in {"left", "right"} for item in clean_extreme_sides):
+        raise ValueError("extreme_sides must contain left and/or right.")
+    clean_normal_dot_tolerance = _validate_scalar(normal_dot_tolerance, "normal_dot_tolerance")
+    if clean_normal_dot_tolerance < 0.0:
+        raise ValueError("normal_dot_tolerance must be greater than or equal to zero.")
+    max_preview = _validate_int(max_preview, "max_preview", 0)
+
+    shape_name = _mesh_shape(object_name)
+    prefix_name = _prefix(shape_name)
+    mesh_fn = _mesh_fn(shape_name)
+    points = mesh_fn.getPoints(om_space)
+    view_vector, right_axis, up_vector = _projection_basis()
+
+    if clean_method == "projected_extremes":
+        result_ids, detail_records = _projected_extreme_ids()
+        detail_key = "bins"
+    else:
+        result_ids, detail_records = _normal_edge_ids()
+        detail_key = "edges"
+
+    if select_result:
+        _apply_selection(result_ids)
+
+    components = [_component_name(component_id) for component_id in result_ids]
+    return {
+        "success": True,
+        "object_name": object_name,
+        "shape_name": shape_name,
+        "operation": "select_mesh_silhouette_components",
+        "method": clean_method,
+        "result_type": clean_result_type,
+        "space": space,
+        "view_direction": [float(view_vector.x), float(view_vector.y), float(view_vector.z)],
+        "up_axis": [float(up_vector.x), float(up_vector.y), float(up_vector.z)],
+        "right_axis": [float(right_axis.x), float(right_axis.y), float(right_axis.z)],
+        "filters": {
+            "axis": axis,
+            "axis_range": clean_axis_range,
+            "box_min": clean_box_min,
+            "box_max": clean_box_max,
+            "screen_y_range": clean_screen_y_range,
+        },
+        "bin_count": clean_bin_count if clean_method == "projected_extremes" else None,
+        "extreme_sides": clean_extreme_sides if clean_method == "projected_extremes" else None,
+        "extreme_count": clean_extreme_count if clean_method == "projected_extremes" else None,
+        "normal_dot_tolerance": clean_normal_dot_tolerance if clean_method == "normal_edges" else None,
+        "include_boundary_edges": bool(include_boundary_edges) if clean_method == "normal_edges" else None,
+        "component_count": len(components),
+        "components": components[:max_preview],
+        "indices": result_ids[:max_preview],
+        "truncated": len(components) > max_preview,
+        "selected": bool(select_result),
+        "selection_mode": selection_mode if select_result else None,
+        detail_key: detail_records[:max_preview],
+        f"{detail_key}_truncated": len(detail_records) > max_preview,
+    }

--- a/src/mayatools/object/set_object_attribute.py
+++ b/src/mayatools/object/set_object_attribute.py
@@ -6,12 +6,22 @@
 from typing import Dict, Any, List
 
 
-def set_object_attribute(object_name:str, attribute_name:str, attribute_value:Any) -> Dict[str, Any]:
-    """ Set an object's attribute with a specific value. """
+def set_object_attribute(
+    object_name: str,
+    attribute_name: str,
+    attribute_value: Any,
+    disconnect_existing: bool = False,
+) -> Dict[str, Any]:
+    """Set an object's attribute with a specific value.
+
+    When disconnect_existing is true, incoming connections to the target
+    attribute are disconnected before setting the value. This is useful for
+    intentionally overriding shader or utility-node driven attributes.
+    """
     import maya.cmds as cmds
 
     def _validate_vector3d(vec:List[float]):
-        return isinstance(vec, list) and len(vec) == 3 and all([isinstance(v, float) for v in vec])
+        return isinstance(vec, list) and len(vec) == 3 and all([isinstance(v, (int, float)) and not isinstance(v, bool) for v in vec])
 
     if not cmds.objExists(object_name):
         raise ValueError(f"Error: {object_name} doesn't exist in the scene")
@@ -30,20 +40,49 @@ def set_object_attribute(object_name:str, attribute_name:str, attribute_value:An
 
     attr_type = cmds.getAttr(f'{object_name}.{attribute_name}', type=True)
      
-    if attr_type == 'double3':
+    vector_types = {"double3", "float3"}
+    if attr_type in vector_types:
         if not _validate_vector3d(attribute_value):
-            raise ValueError(f"{attribute_name} is a 3d vector and needs to be list of 3 floats.")
+            raise ValueError(f"{attribute_name} is a 3d vector and needs to be a list of 3 numeric values.")
+        attribute_value = [float(attribute_value[0]), float(attribute_value[1]), float(attribute_value[2])]
+
+    def _disconnect_inputs(node, attr, attr_type_value):
+        plugs = [f"{node}.{attr}"]
+        if attr_type_value in vector_types:
+            for child in cmds.attributeQuery(attr, node=node, listChildren=True) or []:
+                plugs.append(f"{node}.{child}")
+        disconnected = []
+        for plug in plugs:
+            for source in cmds.listConnections(plug, source=True, destination=False, plugs=True) or []:
+                try:
+                    cmds.disconnectAttr(source, plug)
+                    disconnected.append({"source": source, "destination": plug})
+                except Exception:
+                    pass
+        return disconnected
+
+    disconnected_connections = []
+    if disconnect_existing:
+        disconnected_connections = _disconnect_inputs(object_name, attribute_name, attr_type)
 
     try:
-        if attr_type == 'double3':
+        if attr_type in vector_types:
             cmds.setAttr(f'{object_name}.{attribute_name}', attribute_value[0], attribute_value[1], attribute_value[2], type=attr_type)
         elif attr_type == 'bool':
             cmds.setAttr(f'{object_name}.{attribute_name}', 1 if attribute_value else 0)
+        elif attr_type == "string":
+            cmds.setAttr(f'{object_name}.{attribute_name}', str(attribute_value), type="string")
         else:
             cmds.setAttr(f'{object_name}.{attribute_name}', attribute_value)
-        results = { "success": True }
+        results = {
+            "success": True,
+            "object_name": object_name,
+            "attribute_name": attribute_name,
+            "disconnect_existing": bool(disconnect_existing),
+            "disconnected_connections": disconnected_connections,
+        }
     except Exception as e:
-        raise RuntimeError(f"Error: Unable to update attribute {attribute_name} on object {object_name}")
+        raise RuntimeError(f"Error: Unable to update attribute {attribute_name} on object {object_name}: {e}")
 
     return results
     

--- a/src/mayatools/object/slide_mesh_components.py
+++ b/src/mayatools/object/slide_mesh_components.py
@@ -1,0 +1,348 @@
+from typing import Dict, List, Any, Union
+
+
+def slide_mesh_components(
+    object_name: str,
+    component_type: str = "vertex",
+    indices: List[int] = None,
+    components: Union[str, List[str]] = None,
+    direction: str = "positive_axis",
+    axis: str = "y",
+    factor: float = 0.25,
+    distance: float = None,
+    target_point: List[float] = None,
+    prefer_unselected_neighbors: bool = True,
+    preserve_boundary: bool = False,
+    space: str = "world",
+    use_selection: bool = True,
+    select_result: bool = True,
+    max_preview: int = 50,
+) -> Dict[str, Any]:
+    """Slide resolved mesh vertices along their connected topology.
+
+    Operations like Insert Edge Loop often create a centered loop. This tool
+    moves the resolved vertices along neighboring mesh edges instead of through
+    arbitrary world-space translation, which matches the common Maya artist
+    workflow of sliding support loops, edge loops, or local vertex rows while
+    keeping them on the existing surface flow.
+
+    Directions:
+    - positive_axis / negative_axis: choose the connected neighbor in the
+      requested x, y, or z direction
+    - toward_point / away_from_point: choose the connected neighbor closest to
+      or farthest from target_point
+    - closest_neighbor / farthest_neighbor: choose by edge length
+
+    Edges, faces, UVs, and vertex-faces are converted to unique vertices before
+    sliding. When prefer_unselected_neighbors is true, selected vertices slide
+    toward neighbors outside the resolved set when possible, which is useful for
+    moving a whole selected loop toward one side of its surrounding quad strip.
+    """
+    import math
+    import re
+    import maya.cmds as cmds
+    import maya.api.OpenMaya as om
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return int(value)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(item) for item in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(item) for item in values]
+
+    def _axis_index(axis_name):
+        clean_axis = (axis_name or "").lower().strip()
+        if clean_axis not in {"x", "y", "z"}:
+            raise ValueError("axis must be x, y, or z.")
+        return {"x": 0, "y": 1, "z": 2}[clean_axis]
+
+    def _mesh_shape(node):
+        if not cmds.objExists(node):
+            raise ValueError(f"Object does not exist: {node}")
+        if cmds.objectType(node) == "mesh":
+            return node
+        shapes = cmds.listRelatives(node, shapes=True, fullPath=True) or []
+        mesh_shapes = []
+        for shape in shapes:
+            if cmds.objectType(shape) != "mesh":
+                continue
+            try:
+                if cmds.attributeQuery("intermediateObject", node=shape, exists=True) and cmds.getAttr(f"{shape}.intermediateObject"):
+                    continue
+            except Exception:
+                pass
+            mesh_shapes.append(shape)
+        if not mesh_shapes:
+            raise ValueError(f"{node} is not a polygon mesh transform or mesh shape.")
+        return mesh_shapes[0]
+
+    def _dag_path(shape):
+        selection = om.MSelectionList()
+        selection.add(shape)
+        return selection.getDagPath(0)
+
+    def _mesh_fn(shape):
+        return om.MFnMesh(_dag_path(shape))
+
+    def _prefix(shape):
+        parents = cmds.listRelatives(shape, parent=True, fullPath=False) or []
+        return parents[0] if parents else object_name
+
+    def _flatten(value):
+        if value is None:
+            return []
+        if isinstance(value, str):
+            value = [value]
+        if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+            raise ValueError("components must be a string, a list of strings, or None.")
+        return cmds.ls(value, flatten=True) or []
+
+    def _components_from_indices(kind):
+        if indices is None:
+            return []
+        if not isinstance(indices, list) or not all(isinstance(index, int) and not isinstance(index, bool) for index in indices):
+            raise ValueError("indices must be a list of integers.")
+        return [f"{prefix_name}.{kind}[{index}]" for index in indices]
+
+    def _selected_components():
+        if not use_selection:
+            return []
+        selected = cmds.ls(selection=True, flatten=True) or []
+        object_tokens = {object_name, prefix_name, shape_name}
+        return [item for item in selected if item.split(".", 1)[0] in object_tokens]
+
+    def _resolve_components():
+        clean_type = component_type.lower().strip()
+        kind_map = {
+            "vertex": "vtx",
+            "edge": "e",
+            "face": "f",
+            "uv": "map",
+            "vertex_face": "vtxFace",
+        }
+        if components is not None:
+            resolved = _flatten(components)
+        elif clean_type in kind_map and indices is not None:
+            resolved = _components_from_indices(kind_map[clean_type])
+        else:
+            resolved = _selected_components()
+        if not resolved:
+            raise ValueError("No components resolved from components, indices, or current selection.")
+        return resolved
+
+    def _vertex_ids_from_components(items):
+        converted = cmds.polyListComponentConversion(items, toVertex=True) or []
+        vertices = cmds.ls(converted, flatten=True) or []
+        pattern = re.compile(r"\.vtx\[(\d+)\]$")
+        ids = []
+        for vertex in vertices:
+            match = pattern.search(vertex)
+            if match:
+                ids.append(int(match.group(1)))
+        return sorted(set(ids))
+
+    def _point_values(point):
+        return [float(point.x), float(point.y), float(point.z)]
+
+    def _distance(a, b):
+        return math.sqrt((a.x - b.x) ** 2 + (a.y - b.y) ** 2 + (a.z - b.z) ** 2)
+
+    def _distance_to_values(point, values):
+        return math.sqrt((point.x - values[0]) ** 2 + (point.y - values[1]) ** 2 + (point.z - values[2]) ** 2)
+
+    def _adjacency_and_boundary():
+        adjacency = {vertex_id: set() for vertex_id in range(mesh_fn.numVertices)}
+        boundary = set()
+        edge_it = om.MItMeshEdge(dag)
+        while not edge_it.isDone():
+            v0 = int(edge_it.vertexId(0))
+            v1 = int(edge_it.vertexId(1))
+            adjacency[v0].add(v1)
+            adjacency[v1].add(v0)
+            try:
+                connected_faces = edge_it.getConnectedFaces()
+            except Exception:
+                connected_faces = []
+            if len(connected_faces) < 2:
+                boundary.add(v0)
+                boundary.add(v1)
+            edge_it.next()
+        return adjacency, boundary
+
+    def _candidate_neighbors(vertex_id):
+        neighbors = sorted(adjacency.get(vertex_id, []))
+        if prefer_unselected_neighbors:
+            outside = [neighbor for neighbor in neighbors if neighbor not in seed_vertex_set]
+            if outside:
+                return outside
+        return neighbors
+
+    def _choose_neighbor(vertex_id, neighbor_ids, current_points):
+        point = current_points[vertex_id]
+        if clean_direction == "positive_axis":
+            directional = [neighbor_id for neighbor_id in neighbor_ids if _point_values(current_points[neighbor_id])[axis_idx] > _point_values(point)[axis_idx] + 1.0e-10]
+            if not directional:
+                return None, "no_positive_axis_neighbor"
+            return max(directional, key=lambda neighbor_id: _point_values(current_points[neighbor_id])[axis_idx]), None
+        if clean_direction == "negative_axis":
+            directional = [neighbor_id for neighbor_id in neighbor_ids if _point_values(current_points[neighbor_id])[axis_idx] < _point_values(point)[axis_idx] - 1.0e-10]
+            if not directional:
+                return None, "no_negative_axis_neighbor"
+            return min(directional, key=lambda neighbor_id: _point_values(current_points[neighbor_id])[axis_idx]), None
+        if clean_direction == "toward_point":
+            return min(neighbor_ids, key=lambda neighbor_id: _distance_to_values(current_points[neighbor_id], clean_target_point)), None
+        if clean_direction == "away_from_point":
+            return max(neighbor_ids, key=lambda neighbor_id: _distance_to_values(current_points[neighbor_id], clean_target_point)), None
+        if clean_direction == "closest_neighbor":
+            return min(neighbor_ids, key=lambda neighbor_id: _distance(point, current_points[neighbor_id])), None
+        if clean_direction == "farthest_neighbor":
+            return max(neighbor_ids, key=lambda neighbor_id: _distance(point, current_points[neighbor_id])), None
+        raise ValueError("Unsupported direction.")
+
+    def _slide_point(source, target):
+        vector = om.MVector(target.x - source.x, target.y - source.y, target.z - source.z)
+        length = vector.length()
+        if length <= 1.0e-12:
+            return om.MPoint(source), 0.0
+        if clean_distance is None:
+            amount = clean_factor
+        else:
+            amount = min(1.0, clean_distance / length)
+        return om.MPoint(
+            source.x + vector.x * amount,
+            source.y + vector.y * amount,
+            source.z + vector.z * amount,
+        ), amount
+
+    def _preview(vertex_ids, before_points, after_points, records):
+        items = []
+        for vertex_id in vertex_ids[:max_preview]:
+            before = before_points[vertex_id]
+            after = after_points[vertex_id]
+            record = records.get(vertex_id, {})
+            items.append(
+                {
+                    "index": vertex_id,
+                    "component": f"{prefix_name}.vtx[{vertex_id}]",
+                    "before": _point_values(before),
+                    "after": _point_values(after),
+                    "movement": _distance(before, after),
+                    "chosen_neighbor": record.get("chosen_neighbor"),
+                    "slide_amount": record.get("slide_amount"),
+                }
+            )
+        return items
+
+    if not object_name:
+        raise ValueError("object_name is required.")
+    component_type = component_type.lower().strip()
+    if component_type not in {"vertex", "edge", "face", "uv", "vertex_face"}:
+        raise ValueError("component_type must be vertex, edge, face, uv, or vertex_face.")
+    clean_direction = direction.lower().strip()
+    if clean_direction not in {"positive_axis", "negative_axis", "toward_point", "away_from_point", "closest_neighbor", "farthest_neighbor"}:
+        raise ValueError("direction must be positive_axis, negative_axis, toward_point, away_from_point, closest_neighbor, or farthest_neighbor.")
+    axis_idx = _axis_index(axis)
+    clean_factor = _validate_scalar(factor, "factor")
+    if clean_factor < 0.0 or clean_factor > 1.0:
+        raise ValueError("factor must be between 0 and 1.")
+    clean_distance = None if distance is None else _validate_scalar(distance, "distance")
+    if clean_distance is not None and clean_distance < 0.0:
+        raise ValueError("distance must be greater than or equal to zero.")
+    if clean_direction in {"toward_point", "away_from_point"}:
+        clean_target_point = _validate_vector(target_point, 3, "target_point")
+    else:
+        clean_target_point = None
+    space = space.lower().strip()
+    if space not in {"world", "object"}:
+        raise ValueError("space must be world or object.")
+    max_preview = _validate_int(max_preview, "max_preview", 0)
+
+    shape_name = _mesh_shape(object_name)
+    dag = _dag_path(shape_name)
+    mesh_fn = _mesh_fn(shape_name)
+    prefix_name = _prefix(shape_name)
+    om_space = om.MSpace.kWorld if space == "world" else om.MSpace.kObject
+
+    resolved_components = _resolve_components()
+    seed_vertex_ids = _vertex_ids_from_components(resolved_components)
+    if not seed_vertex_ids:
+        raise ValueError("No vertices resolved from components, indices, or current selection.")
+    seed_vertex_set = set(seed_vertex_ids)
+
+    adjacency, boundary_vertices = _adjacency_and_boundary()
+    points = mesh_fn.getPoints(om_space)
+    before_points = {vertex_id: om.MPoint(points[vertex_id]) for vertex_id in seed_vertex_ids}
+    next_points = om.MPointArray(points)
+    skipped = []
+    records = {}
+
+    for vertex_id in seed_vertex_ids:
+        if preserve_boundary and vertex_id in boundary_vertices:
+            skipped.append({"index": vertex_id, "reason": "boundary"})
+            continue
+        neighbor_ids = _candidate_neighbors(vertex_id)
+        if not neighbor_ids:
+            skipped.append({"index": vertex_id, "reason": "no_connected_neighbors"})
+            continue
+        chosen_neighbor, reason = _choose_neighbor(vertex_id, neighbor_ids, points)
+        if chosen_neighbor is None:
+            skipped.append({"index": vertex_id, "reason": reason})
+            continue
+        target_point = points[chosen_neighbor]
+        new_point, amount = _slide_point(points[vertex_id], target_point)
+        next_points[vertex_id] = new_point
+        records[vertex_id] = {
+            "chosen_neighbor": int(chosen_neighbor),
+            "slide_amount": float(amount),
+        }
+
+    mesh_fn.setPoints(next_points, om_space)
+    try:
+        mesh_fn.updateSurface()
+    except Exception:
+        pass
+
+    updated_points = mesh_fn.getPoints(om_space)
+    moved_ids = [
+        vertex_id
+        for vertex_id in seed_vertex_ids
+        if _distance(before_points[vertex_id], updated_points[vertex_id]) > 1.0e-9
+    ]
+    if not moved_ids:
+        raise RuntimeError(f"{clean_direction} slide did not move any vertices.")
+
+    if select_result:
+        cmds.select([f"{prefix_name}.vtx[{vertex_id}]" for vertex_id in seed_vertex_ids], replace=True)
+
+    return {
+        "success": True,
+        "object_name": object_name,
+        "shape_name": shape_name,
+        "component_type": component_type,
+        "space": space,
+        "direction": clean_direction,
+        "axis": axis.lower().strip(),
+        "factor": clean_factor,
+        "distance": clean_distance,
+        "target_point": clean_target_point,
+        "prefer_unselected_neighbors": bool(prefer_unselected_neighbors),
+        "preserve_boundary": bool(preserve_boundary),
+        "resolved_vertex_count": len(seed_vertex_ids),
+        "moved_vertex_count": len(moved_ids),
+        "skipped_count": len(skipped),
+        "resolved_vertices_preview": seed_vertex_ids[:max_preview],
+        "moved_vertices_preview": moved_ids[:max_preview],
+        "skipped_preview": skipped[:max_preview],
+        "preview": _preview(seed_vertex_ids, before_points, updated_points, records),
+    }

--- a/src/mayatools/object/snap_mesh_components_to_surface.py
+++ b/src/mayatools/object/snap_mesh_components_to_surface.py
@@ -1,0 +1,311 @@
+from typing import Dict, List, Any, Union
+
+
+def snap_mesh_components_to_surface(
+    object_name: str,
+    target_object_name: str,
+    component_type: str = "vertex",
+    indices: List[int] = None,
+    components: Union[str, List[str]] = None,
+    projection_mode: str = "closest_point",
+    ray_direction: List[float] = None,
+    ray_both_directions: bool = False,
+    max_distance: float = None,
+    fallback_to_closest: bool = True,
+    offset: float = 0.0,
+    offset_direction: str = "target_normal",
+    space: str = "world",
+    use_selection: bool = True,
+    max_preview: int = 20,
+) -> Dict[str, Any]:
+    """Snap source mesh components onto a target mesh surface.
+
+    projection_mode:
+    - closest_point: move each resolved source vertex to the closest point on
+      target_object_name
+    - ray: project each resolved source vertex along ray_direction and use the
+      ray hit on target_object_name, optionally falling back to closest_point
+
+    Edges and faces are converted to their unique vertices before snapping.
+    offset can then move the snapped vertex along the target surface normal or
+    along the source-to-hit direction. This is useful for shrinkwrap-style
+    label, decal, panel, patch, retopology, and contact cleanup workflows.
+    """
+    import math
+    import re
+    import maya.cmds as cmds
+    import maya.api.OpenMaya as om
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return int(value)
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(item) for item in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(item) for item in values]
+
+    def _normalize(values, arg_name):
+        vector = _validate_vector(values, 3, arg_name)
+        length = math.sqrt(vector[0] * vector[0] + vector[1] * vector[1] + vector[2] * vector[2])
+        if length <= 1e-9:
+            raise ValueError(f"{arg_name} must not be a zero vector.")
+        return [vector[0] / length, vector[1] / length, vector[2] / length]
+
+    def _mesh_shape(node):
+        if not cmds.objExists(node):
+            raise ValueError(f"Object does not exist: {node}")
+        if cmds.objectType(node) == "mesh":
+            return node
+        shapes = cmds.listRelatives(node, shapes=True, fullPath=True) or []
+        mesh_shapes = []
+        for shape in shapes:
+            if cmds.objectType(shape) != "mesh":
+                continue
+            try:
+                if cmds.attributeQuery("intermediateObject", node=shape, exists=True) and cmds.getAttr(f"{shape}.intermediateObject"):
+                    continue
+            except Exception:
+                pass
+            mesh_shapes.append(shape)
+        if not mesh_shapes:
+            raise ValueError(f"{node} is not a polygon mesh transform or mesh shape.")
+        return mesh_shapes[0]
+
+    def _mesh_fn(shape):
+        selection = om.MSelectionList()
+        selection.add(shape)
+        return om.MFnMesh(selection.getDagPath(0))
+
+    def _prefix(shape, fallback):
+        parents = cmds.listRelatives(shape, parent=True, fullPath=False) or []
+        return parents[0] if parents else fallback
+
+    def _flatten(value):
+        if value is None:
+            return []
+        if isinstance(value, str):
+            value = [value]
+        if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+            raise ValueError("components must be a string, a list of strings, or None.")
+        return cmds.ls(value, flatten=True) or []
+
+    def _components_from_indices(kind):
+        if indices is None:
+            return []
+        if not isinstance(indices, list) or not all(isinstance(index, int) and not isinstance(index, bool) for index in indices):
+            raise ValueError("indices must be a list of integers.")
+        return [f"{source_prefix}.{kind}[{index}]" for index in indices]
+
+    def _selected_components():
+        if not use_selection:
+            return []
+        selected = cmds.ls(selection=True, flatten=True) or []
+        object_tokens = {object_name, source_prefix, source_shape}
+        return [item for item in selected if item.split(".", 1)[0] in object_tokens]
+
+    def _resolve_components():
+        clean_type = component_type.lower().strip()
+        kind_map = {"vertex": "vtx", "edge": "e", "face": "f", "uv": "map", "vertex_face": "vtxFace"}
+        if components is not None:
+            resolved = _flatten(components)
+        elif clean_type in kind_map and indices is not None:
+            resolved = _components_from_indices(kind_map[clean_type])
+        else:
+            resolved = _selected_components()
+        if not resolved:
+            raise ValueError("No components resolved from components, indices, or current selection.")
+        return resolved
+
+    def _vertex_ids_from_components(items):
+        converted = cmds.polyListComponentConversion(items, toVertex=True) or []
+        vertices = cmds.ls(converted, flatten=True) or []
+        ids = []
+        pattern = re.compile(r"\.vtx\[(\d+)\]$")
+        for vertex in vertices:
+            match = pattern.search(vertex)
+            if match:
+                ids.append(int(match.group(1)))
+        return sorted(set(ids))
+
+    def _point_list(point):
+        return [float(point.x), float(point.y), float(point.z)]
+
+    def _vector_list(vector):
+        return [float(vector.x), float(vector.y), float(vector.z)]
+
+    def _distance(a, b):
+        return math.sqrt((a.x - b.x) ** 2 + (a.y - b.y) ** 2 + (a.z - b.z) ** 2)
+
+    def _offset_point(source_point, hit_point, normal_vector):
+        if abs(clean_offset) <= 1e-12:
+            return om.MPoint(hit_point.x, hit_point.y, hit_point.z)
+        if clean_offset_direction == "none":
+            return om.MPoint(hit_point.x, hit_point.y, hit_point.z)
+        if clean_offset_direction == "target_normal":
+            direction = normal_vector.normal()
+        elif clean_offset_direction == "source_to_hit":
+            direction = om.MVector(hit_point.x - source_point.x, hit_point.y - source_point.y, hit_point.z - source_point.z)
+            if direction.length() <= 1e-9:
+                direction = normal_vector.normal()
+            else:
+                direction.normalize()
+        elif clean_offset_direction == "hit_to_source":
+            direction = om.MVector(source_point.x - hit_point.x, source_point.y - hit_point.y, source_point.z - hit_point.z)
+            if direction.length() <= 1e-9:
+                direction = normal_vector.normal()
+            else:
+                direction.normalize()
+        else:
+            raise ValueError("offset_direction must be none, target_normal, source_to_hit, or hit_to_source.")
+        return om.MPoint(
+            hit_point.x + direction.x * clean_offset,
+            hit_point.y + direction.y * clean_offset,
+            hit_point.z + direction.z * clean_offset,
+        )
+
+    def _closest_match(source_point):
+        hit_point, hit_normal, face_id = target_fn.getClosestPointAndNormal(source_point, om_space)
+        return {
+            "mode": "closest_point",
+            "hit_point": hit_point,
+            "normal": hit_normal,
+            "face_id": int(face_id),
+            "distance": _distance(source_point, hit_point),
+        }
+
+    def _ray_match(source_point):
+        hit = target_fn.closestIntersection(
+            om.MFloatPoint(source_point.x, source_point.y, source_point.z),
+            om.MFloatVector(clean_ray_direction[0], clean_ray_direction[1], clean_ray_direction[2]),
+            om_space,
+            clean_max_distance,
+            bool(ray_both_directions),
+        )
+        if hit is None:
+            return None
+        hit_point = om.MPoint(hit[0])
+        closest_point, hit_normal, face_id = target_fn.getClosestPointAndNormal(hit_point, om_space)
+        return {
+            "mode": "ray",
+            "hit_point": hit_point,
+            "normal": hit_normal,
+            "face_id": int(face_id),
+            "ray_param": float(hit[1]),
+            "distance": _distance(source_point, hit_point),
+            "closest_point_error": _distance(hit_point, closest_point),
+        }
+
+    def _preview_record(vertex_id, before_point, after_point, match):
+        return {
+            "index": vertex_id,
+            "component": f"{source_prefix}.vtx[{vertex_id}]",
+            "before": _point_list(before_point),
+            "after": _point_list(after_point),
+            "target_point": _point_list(match["hit_point"]),
+            "target_normal": _vector_list(match["normal"]),
+            "target_face": match["face_id"],
+            "match_mode": match["mode"],
+            "distance": match["distance"],
+        }
+
+    if not object_name:
+        raise ValueError("object_name is required.")
+    if not target_object_name:
+        raise ValueError("target_object_name is required.")
+    projection_mode = projection_mode.lower().strip()
+    if projection_mode not in {"closest_point", "ray"}:
+        raise ValueError("projection_mode must be closest_point or ray.")
+    component_type = component_type.lower().strip()
+    if component_type not in {"vertex", "edge", "face", "uv", "vertex_face"}:
+        raise ValueError("component_type must be vertex, edge, face, uv, or vertex_face.")
+    space = space.lower().strip()
+    if space not in {"world", "object"}:
+        raise ValueError("space must be world or object.")
+    clean_offset = _validate_scalar(offset, "offset")
+    clean_offset_direction = offset_direction.lower().strip()
+    if clean_offset_direction not in {"none", "target_normal", "source_to_hit", "hit_to_source"}:
+        raise ValueError("offset_direction must be none, target_normal, source_to_hit, or hit_to_source.")
+    max_preview = _validate_int(max_preview, "max_preview", 0)
+    clean_max_distance = float(max_distance) if max_distance is not None else 1.0e12
+    if clean_max_distance <= 0.0:
+        raise ValueError("max_distance must be greater than zero when provided.")
+    clean_ray_direction = None
+    if projection_mode == "ray":
+        clean_ray_direction = _normalize(ray_direction, "ray_direction")
+
+    source_shape = _mesh_shape(object_name)
+    target_shape = _mesh_shape(target_object_name)
+    source_prefix = _prefix(source_shape, object_name)
+    source_fn = _mesh_fn(source_shape)
+    target_fn = _mesh_fn(target_shape)
+    om_space = om.MSpace.kWorld if space == "world" else om.MSpace.kObject
+
+    resolved_components = _resolve_components()
+    vertex_ids = _vertex_ids_from_components(resolved_components)
+    if not vertex_ids:
+        raise ValueError("No vertices resolved from components, indices, or current selection.")
+
+    points = source_fn.getPoints(om_space)
+    before_points = {vertex_id: om.MPoint(points[vertex_id]) for vertex_id in vertex_ids}
+    preview = []
+    skipped = []
+    moved_count = 0
+
+    for vertex_id in vertex_ids:
+        source_point = points[vertex_id]
+        match = None
+        if projection_mode == "ray":
+            match = _ray_match(source_point)
+        if match is None and (projection_mode == "closest_point" or fallback_to_closest):
+            match = _closest_match(source_point)
+        if match is None:
+            skipped.append({"index": vertex_id, "reason": "no_intersection"})
+            continue
+        if match["distance"] > clean_max_distance:
+            skipped.append({"index": vertex_id, "reason": "beyond_max_distance", "distance": match["distance"]})
+            continue
+        snapped_point = _offset_point(source_point, match["hit_point"], match["normal"])
+        points[vertex_id] = snapped_point
+        moved_count += 1
+        if len(preview) < max_preview:
+            preview.append(_preview_record(vertex_id, before_points[vertex_id], snapped_point, match))
+
+    if moved_count == 0:
+        raise RuntimeError("No vertices were snapped to the target surface.")
+
+    source_fn.setPoints(points, om_space)
+    try:
+        source_fn.updateSurface()
+    except Exception:
+        pass
+    cmds.select([f"{source_prefix}.vtx[{vertex_id}]" for vertex_id in vertex_ids], replace=True)
+
+    return {
+        "success": True,
+        "object_name": object_name,
+        "target_object_name": target_object_name,
+        "operation": "snap_mesh_components_to_surface",
+        "projection_mode": projection_mode,
+        "space": space,
+        "resolved_vertex_count": len(vertex_ids),
+        "moved_vertex_count": moved_count,
+        "skipped_count": len(skipped),
+        "skipped_preview": skipped[:max_preview],
+        "offset": clean_offset,
+        "offset_direction": clean_offset_direction,
+        "ray_direction": clean_ray_direction,
+        "ray_both_directions": bool(ray_both_directions),
+        "max_distance": None if max_distance is None else clean_max_distance,
+        "fallback_to_closest": bool(fallback_to_closest),
+        "preview": preview,
+    }

--- a/src/mayatools/object/soft_transform_mesh_components.py
+++ b/src/mayatools/object/soft_transform_mesh_components.py
@@ -1,0 +1,500 @@
+from typing import Dict, List, Any, Union
+
+
+def soft_transform_mesh_components(
+    object_name: str,
+    operation: str = "translate",
+    component_type: str = "vertex",
+    indices: List[int] = None,
+    components: Union[str, List[str]] = None,
+    vector: List[float] = None,
+    scale: List[float] = None,
+    rotation: List[float] = None,
+    axis: str = None,
+    value: float = None,
+    offset: float = 0.0,
+    pivot: List[float] = None,
+    pivot_mode: str = "selection_center",
+    center: List[float] = None,
+    center_mode: str = "origin",
+    radius_mode: str = "explicit",
+    falloff_radius: float = 1.0,
+    falloff_curve: str = "smooth",
+    strength: float = 1.0,
+    affect_all_vertices: bool = True,
+    preserve_boundary: bool = False,
+    space: str = "world",
+    use_selection: bool = True,
+    select_result: bool = True,
+    max_preview: int = 50,
+) -> Dict[str, Any]:
+    """Apply soft-selection style transforms around resolved mesh components.
+
+    Operations:
+    - translate: move vertices by vector scaled by falloff weight
+    - scale: scale vertices around a pivot with falloff
+    - rotate: rotate vertices around a pivot with falloff
+    - align_axis: move vertices toward one x, y, or z value with falloff
+    - align_radial: move vertices toward a cylinder radius around an axis
+    - radial_offset: add a radial offset around an axis
+
+    Seed components can be explicit, indexed, or current selection. Edges,
+    faces, UVs, and vertex-faces are converted to seed vertices. When
+    affect_all_vertices is true, nearby mesh vertices are included according to
+    falloff_radius, matching Maya's soft selection workflow for hand shaping
+    shoulders, waists, lips, dents, and other local form changes without hard
+    ring artifacts.
+    """
+    import math
+    import re
+    import maya.cmds as cmds
+    import maya.api.OpenMaya as om
+
+    def _is_number(value_to_check):
+        return isinstance(value_to_check, (int, float)) and not isinstance(value_to_check, bool)
+
+    def _validate_scalar(value_to_check, arg_name):
+        if not _is_number(value_to_check):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value_to_check)
+
+    def _validate_int(value_to_check, arg_name, minimum):
+        if not isinstance(value_to_check, int) or isinstance(value_to_check, bool) or value_to_check < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return int(value_to_check)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(item) for item in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(item) for item in values]
+
+    def _axis_index(axis_name):
+        clean_axis = (axis_name or "").lower().strip()
+        if clean_axis not in {"x", "y", "z"}:
+            raise ValueError("axis must be x, y, or z.")
+        return {"x": 0, "y": 1, "z": 2}[clean_axis]
+
+    def _mesh_shape(node):
+        if not cmds.objExists(node):
+            raise ValueError(f"Object does not exist: {node}")
+        if cmds.objectType(node) == "mesh":
+            return node
+        shapes = cmds.listRelatives(node, shapes=True, fullPath=True) or []
+        mesh_shapes = []
+        for shape in shapes:
+            if cmds.objectType(shape) != "mesh":
+                continue
+            try:
+                if cmds.attributeQuery("intermediateObject", node=shape, exists=True) and cmds.getAttr(f"{shape}.intermediateObject"):
+                    continue
+            except Exception:
+                pass
+            mesh_shapes.append(shape)
+        if not mesh_shapes:
+            raise ValueError(f"{node} is not a polygon mesh transform or mesh shape.")
+        return mesh_shapes[0]
+
+    def _dag_path(shape):
+        selection = om.MSelectionList()
+        selection.add(shape)
+        return selection.getDagPath(0)
+
+    def _mesh_fn(shape):
+        return om.MFnMesh(_dag_path(shape))
+
+    def _prefix(shape):
+        parents = cmds.listRelatives(shape, parent=True, fullPath=False) or []
+        return parents[0] if parents else object_name
+
+    def _flatten(value_to_flatten):
+        if value_to_flatten is None:
+            return []
+        if isinstance(value_to_flatten, str):
+            value_to_flatten = [value_to_flatten]
+        if not isinstance(value_to_flatten, list) or not all(isinstance(item, str) for item in value_to_flatten):
+            raise ValueError("components must be a string, a list of strings, or None.")
+        return cmds.ls(value_to_flatten, flatten=True) or []
+
+    def _components_from_indices(kind):
+        if indices is None:
+            return []
+        if not isinstance(indices, list) or not all(isinstance(index, int) and not isinstance(index, bool) for index in indices):
+            raise ValueError("indices must be a list of integers.")
+        return [f"{prefix_name}.{kind}[{index}]" for index in indices]
+
+    def _selected_components():
+        if not use_selection:
+            return []
+        selected = cmds.ls(selection=True, flatten=True) or []
+        object_tokens = {object_name, prefix_name, shape_name}
+        return [item for item in selected if item.split(".", 1)[0] in object_tokens]
+
+    def _resolve_components():
+        clean_type = component_type.lower().strip()
+        kind_map = {
+            "vertex": "vtx",
+            "edge": "e",
+            "face": "f",
+            "uv": "map",
+            "vertex_face": "vtxFace",
+        }
+        if components is not None:
+            resolved = _flatten(components)
+        elif clean_type in kind_map and indices is not None:
+            resolved = _components_from_indices(kind_map[clean_type])
+        else:
+            resolved = _selected_components()
+        if not resolved:
+            raise ValueError("No components resolved from components, indices, or current selection.")
+        return resolved
+
+    def _vertex_ids_from_components(items):
+        converted = cmds.polyListComponentConversion(items, toVertex=True) or []
+        vertices = cmds.ls(converted, flatten=True) or []
+        pattern = re.compile(r"\.vtx\[(\d+)\]$")
+        ids = []
+        for vertex in vertices:
+            match = pattern.search(vertex)
+            if match:
+                ids.append(int(match.group(1)))
+        return sorted(set(ids))
+
+    def _point_values(point):
+        return [float(point.x), float(point.y), float(point.z)]
+
+    def _point_from_values(values):
+        return om.MPoint(float(values[0]), float(values[1]), float(values[2]))
+
+    def _distance(a, b):
+        return math.sqrt((a.x - b.x) ** 2 + (a.y - b.y) ** 2 + (a.z - b.z) ** 2)
+
+    def _bounds(vertex_ids_to_check, current_points):
+        mins = [float("inf"), float("inf"), float("inf")]
+        maxs = [float("-inf"), float("-inf"), float("-inf")]
+        for vertex_id in vertex_ids_to_check:
+            values = _point_values(current_points[vertex_id])
+            for index in range(3):
+                mins[index] = min(mins[index], values[index])
+                maxs[index] = max(maxs[index], values[index])
+        center_value = [(mins[index] + maxs[index]) * 0.5 for index in range(3)]
+        return mins, maxs, center_value
+
+    def _boundary_vertices():
+        if not preserve_boundary:
+            return set()
+        boundary = set()
+        edge_it = om.MItMeshEdge(dag)
+        while not edge_it.isDone():
+            try:
+                connected_faces = edge_it.getConnectedFaces()
+            except Exception:
+                connected_faces = []
+            if len(connected_faces) < 2:
+                boundary.add(int(edge_it.vertexId(0)))
+                boundary.add(int(edge_it.vertexId(1)))
+            edge_it.next()
+        return boundary
+
+    def _falloff_weight(distance, radius):
+        if distance <= 1.0e-9:
+            return clean_strength
+        if radius <= 1.0e-9 or distance > radius:
+            return 0.0
+        t = max(0.0, min(1.0, distance / radius))
+        if clean_falloff_curve == "linear":
+            weight = 1.0 - t
+        elif clean_falloff_curve == "gaussian":
+            weight = math.exp(-4.0 * t * t)
+        elif clean_falloff_curve == "hard":
+            weight = 1.0
+        else:
+            weight = 1.0 - (t * t * (3.0 - 2.0 * t))
+        return weight * clean_strength
+
+    def _candidate_weights(current_points):
+        candidates = list(range(mesh_fn.numVertices)) if affect_all_vertices else seed_vertex_ids[:]
+        seed_points = [current_points[vertex_id] for vertex_id in seed_vertex_ids]
+        weights = {}
+        for vertex_id in candidates:
+            if vertex_id in boundary_vertices:
+                continue
+            point = current_points[vertex_id]
+            minimum_distance = min(_distance(point, seed_point) for seed_point in seed_points)
+            weight = _falloff_weight(minimum_distance, clean_falloff_radius)
+            if weight > 1.0e-9:
+                weights[vertex_id] = {
+                    "weight": weight,
+                    "distance": float(minimum_distance),
+                }
+        return weights
+
+    def _pivot(current_points):
+        if pivot is not None:
+            return _validate_vector(pivot, 3, "pivot")
+        mode = pivot_mode.lower().strip()
+        if mode == "origin":
+            return [0.0, 0.0, 0.0]
+        if mode == "selection_center":
+            return selection_center[:]
+        if mode == "object_center":
+            return object_center[:]
+        if mode == "selection_min":
+            return selection_min[:]
+        if mode == "selection_max":
+            return selection_max[:]
+        if mode == "object_min":
+            return object_min[:]
+        if mode == "object_max":
+            return object_max[:]
+        raise ValueError("pivot_mode must be origin, selection_center, selection_min, selection_max, object_center, object_min, or object_max.")
+
+    def _center(current_points):
+        if center is not None:
+            return _validate_vector(center, 3, "center")
+        mode = center_mode.lower().strip()
+        if mode == "origin":
+            return [0.0, 0.0, 0.0]
+        if mode == "selection_center":
+            return selection_center[:]
+        if mode == "object_center":
+            return object_center[:]
+        raise ValueError("center_mode must be origin, selection_center, or object_center.")
+
+    def _target_radius(current_points, center_value, axis_idx):
+        mode = radius_mode.lower().strip()
+        radial_axes = [index for index in range(3) if index != axis_idx]
+        radii = []
+        for vertex_id in seed_vertex_ids:
+            values = _point_values(current_points[vertex_id])
+            da = values[radial_axes[0]] - center_value[radial_axes[0]]
+            db = values[radial_axes[1]] - center_value[radial_axes[1]]
+            radii.append(math.sqrt(da * da + db * db))
+        if mode == "explicit":
+            radius = _validate_scalar(value, "value")
+        elif mode == "selection_min":
+            radius = min(radii)
+        elif mode == "selection_max":
+            radius = max(radii)
+        elif mode in {"selection_mean", "selection_center"}:
+            radius = sum(radii) / float(len(radii))
+        elif mode == "selection_median":
+            ordered = sorted(radii)
+            mid = len(ordered) // 2
+            radius = ordered[mid] if len(ordered) % 2 else (ordered[mid - 1] + ordered[mid]) * 0.5
+        else:
+            raise ValueError("radius_mode must be explicit, selection_min, selection_max, selection_mean, selection_center, or selection_median.")
+        if radius < 0.0:
+            raise ValueError("target radius must be greater than or equal to zero.")
+        return radius
+
+    def _rotate_point(point, pivot_value, rotation_value):
+        rx, ry, rz = [math.radians(item) for item in rotation_value]
+        x = point.x - pivot_value[0]
+        y = point.y - pivot_value[1]
+        z = point.z - pivot_value[2]
+
+        cos_x, sin_x = math.cos(rx), math.sin(rx)
+        y, z = y * cos_x - z * sin_x, y * sin_x + z * cos_x
+
+        cos_y, sin_y = math.cos(ry), math.sin(ry)
+        x, z = x * cos_y + z * sin_y, -x * sin_y + z * cos_y
+
+        cos_z, sin_z = math.cos(rz), math.sin(rz)
+        x, y = x * cos_z - y * sin_z, x * sin_z + y * cos_z
+
+        return om.MPoint(x + pivot_value[0], y + pivot_value[1], z + pivot_value[2])
+
+    def _lerp_point(source, target, weight):
+        return om.MPoint(
+            source.x + (target.x - source.x) * weight,
+            source.y + (target.y - source.y) * weight,
+            source.z + (target.z - source.z) * weight,
+        )
+
+    def _preview(vertex_ids_to_preview, before_points, after_points, weights):
+        items = []
+        for vertex_id in vertex_ids_to_preview[:max_preview]:
+            before = before_points[vertex_id]
+            after = after_points[vertex_id]
+            weight_record = weights.get(vertex_id, {"weight": 0.0, "distance": None})
+            items.append(
+                {
+                    "index": vertex_id,
+                    "component": f"{prefix_name}.vtx[{vertex_id}]",
+                    "before": _point_values(before),
+                    "after": _point_values(after),
+                    "weight": float(weight_record["weight"]),
+                    "distance_to_seed": weight_record["distance"],
+                    "movement": _distance(before, after),
+                }
+            )
+        return items
+
+    if not object_name:
+        raise ValueError("object_name is required.")
+    operation = operation.lower().strip()
+    allowed = {"translate", "scale", "rotate", "align_axis", "align_radial", "radial_offset"}
+    if operation not in allowed:
+        raise ValueError(f"operation must be one of: {', '.join(sorted(allowed))}.")
+    component_type = component_type.lower().strip()
+    if component_type not in {"vertex", "edge", "face", "uv", "vertex_face"}:
+        raise ValueError("component_type must be vertex, edge, face, uv, or vertex_face.")
+    space = space.lower().strip()
+    if space not in {"world", "object"}:
+        raise ValueError("space must be world or object.")
+    clean_falloff_radius = _validate_scalar(falloff_radius, "falloff_radius")
+    if clean_falloff_radius < 0.0:
+        raise ValueError("falloff_radius must be greater than or equal to zero.")
+    clean_strength = _validate_scalar(strength, "strength")
+    if clean_strength < 0.0 or clean_strength > 1.0:
+        raise ValueError("strength must be between 0 and 1.")
+    clean_falloff_curve = falloff_curve.lower().strip()
+    if clean_falloff_curve not in {"smooth", "linear", "gaussian", "hard"}:
+        raise ValueError("falloff_curve must be smooth, linear, gaussian, or hard.")
+    max_preview = _validate_int(max_preview, "max_preview", 0)
+
+    shape_name = _mesh_shape(object_name)
+    dag = _dag_path(shape_name)
+    mesh_fn = _mesh_fn(shape_name)
+    prefix_name = _prefix(shape_name)
+    om_space = om.MSpace.kWorld if space == "world" else om.MSpace.kObject
+
+    resolved_components = _resolve_components()
+    seed_vertex_ids = _vertex_ids_from_components(resolved_components)
+    if not seed_vertex_ids:
+        raise ValueError("No seed vertices resolved from components, indices, or current selection.")
+
+    points = mesh_fn.getPoints(om_space)
+    all_vertex_ids = list(range(mesh_fn.numVertices))
+    selection_min, selection_max, selection_center = _bounds(seed_vertex_ids, points)
+    object_min, object_max, object_center = _bounds(all_vertex_ids, points)
+    boundary_vertices = _boundary_vertices()
+    weights = _candidate_weights(points)
+    if not weights:
+        raise ValueError("No vertices fall within the requested soft selection.")
+
+    next_points = om.MPointArray(points)
+    applied = {}
+
+    if operation == "translate":
+        move_vector = _validate_vector(vector, 3, "vector")
+        for vertex_id, record in weights.items():
+            weight = record["weight"]
+            point = points[vertex_id]
+            next_points[vertex_id] = om.MPoint(
+                point.x + move_vector[0] * weight,
+                point.y + move_vector[1] * weight,
+                point.z + move_vector[2] * weight,
+            )
+        applied["vector"] = move_vector
+
+    elif operation == "scale":
+        scale_vector = _validate_vector(scale, 3, "scale")
+        pivot_value = _pivot(points)
+        for vertex_id, record in weights.items():
+            point = points[vertex_id]
+            target = om.MPoint(
+                pivot_value[0] + (point.x - pivot_value[0]) * scale_vector[0],
+                pivot_value[1] + (point.y - pivot_value[1]) * scale_vector[1],
+                pivot_value[2] + (point.z - pivot_value[2]) * scale_vector[2],
+            )
+            next_points[vertex_id] = _lerp_point(point, target, record["weight"])
+        applied["scale"] = scale_vector
+        applied["pivot"] = pivot_value
+
+    elif operation == "rotate":
+        rotation_value = _validate_vector(rotation, 3, "rotation")
+        pivot_value = _pivot(points)
+        for vertex_id, record in weights.items():
+            point = points[vertex_id]
+            target = _rotate_point(point, pivot_value, rotation_value)
+            next_points[vertex_id] = _lerp_point(point, target, record["weight"])
+        applied["rotation"] = rotation_value
+        applied["pivot"] = pivot_value
+
+    elif operation == "align_axis":
+        axis_idx = _axis_index(axis)
+        target_value = _validate_scalar(value, "value")
+        for vertex_id, record in weights.items():
+            values = _point_values(points[vertex_id])
+            values[axis_idx] = values[axis_idx] + (target_value - values[axis_idx]) * record["weight"]
+            next_points[vertex_id] = _point_from_values(values)
+        applied["axis"] = axis.lower().strip()
+        applied["value"] = target_value
+
+    elif operation in {"align_radial", "radial_offset"}:
+        axis_idx = _axis_index(axis)
+        center_value = _center(points)
+        radial_axes = [index for index in range(3) if index != axis_idx]
+        target_radius = _target_radius(points, center_value, axis_idx) if operation == "align_radial" else None
+        radial_offset_value = _validate_scalar(offset, "offset") if operation == "radial_offset" else None
+        fallback_axis = radial_axes[0]
+        for vertex_id, record in weights.items():
+            values = _point_values(points[vertex_id])
+            delta_a = values[radial_axes[0]] - center_value[radial_axes[0]]
+            delta_b = values[radial_axes[1]] - center_value[radial_axes[1]]
+            current_radius = math.sqrt(delta_a * delta_a + delta_b * delta_b)
+            if operation == "align_radial":
+                desired_radius = target_radius
+            else:
+                desired_radius = max(0.0, current_radius + radial_offset_value)
+            weighted_radius = current_radius + (desired_radius - current_radius) * record["weight"]
+            if current_radius <= 1.0e-12:
+                values[radial_axes[0]] = center_value[radial_axes[0]]
+                values[radial_axes[1]] = center_value[radial_axes[1]]
+                values[fallback_axis] = center_value[fallback_axis] + weighted_radius
+            else:
+                scale_factor = weighted_radius / current_radius
+                values[radial_axes[0]] = center_value[radial_axes[0]] + delta_a * scale_factor
+                values[radial_axes[1]] = center_value[radial_axes[1]] + delta_b * scale_factor
+            next_points[vertex_id] = _point_from_values(values)
+        applied["axis"] = axis.lower().strip()
+        applied["center"] = center_value
+        if operation == "align_radial":
+            applied["radius"] = target_radius
+            applied["radius_mode"] = radius_mode.lower().strip()
+        else:
+            applied["offset"] = radial_offset_value
+
+    mesh_fn.setPoints(next_points, om_space)
+    try:
+        mesh_fn.updateSurface()
+    except Exception:
+        pass
+
+    updated_points = mesh_fn.getPoints(om_space)
+    affected_ids = sorted(weights)
+    moved_ids = [vertex_id for vertex_id in affected_ids if _distance(points[vertex_id], updated_points[vertex_id]) > 1.0e-9]
+    if not moved_ids:
+        raise RuntimeError(f"{operation} did not move any vertices.")
+
+    if select_result:
+        cmds.select([f"{prefix_name}.vtx[{vertex_id}]" for vertex_id in affected_ids], replace=True)
+
+    distances = [weights[vertex_id]["distance"] for vertex_id in affected_ids]
+    return {
+        "success": True,
+        "object_name": object_name,
+        "shape_name": shape_name,
+        "operation": operation,
+        "component_type": component_type,
+        "space": space,
+        "seed_vertex_count": len(seed_vertex_ids),
+        "affected_vertex_count": len(affected_ids),
+        "moved_vertex_count": len(moved_ids),
+        "seed_vertices_preview": seed_vertex_ids[:max_preview],
+        "moved_vertices_preview": moved_ids[:max_preview],
+        "falloff_radius": clean_falloff_radius,
+        "falloff_curve": clean_falloff_curve,
+        "strength": clean_strength,
+        "affect_all_vertices": bool(affect_all_vertices),
+        "preserve_boundary": bool(preserve_boundary),
+        "distance_range": [float(min(distances)), float(max(distances))],
+        "selection_bounds_before": {
+            "min": selection_min,
+            "max": selection_max,
+            "center": selection_center,
+        },
+        "applied": applied,
+        "preview": _preview(affected_ids, points, updated_points, weights),
+    }

--- a/src/mayatools/object/symmetrize_mesh_components.py
+++ b/src/mayatools/object/symmetrize_mesh_components.py
@@ -1,0 +1,435 @@
+from typing import Dict, List, Any, Union
+
+
+def symmetrize_mesh_components(
+    object_name: str,
+    operation: str = "symmetrize",
+    component_type: str = "vertex",
+    indices: List[int] = None,
+    components: Union[str, List[str]] = None,
+    axis: str = "x",
+    center: List[float] = None,
+    center_mode: str = "origin",
+    direction: str = "average",
+    tolerance: float = 0.001,
+    snap_center_vertices: bool = True,
+    space: str = "object",
+    use_selection: bool = True,
+    select_result: bool = True,
+    max_preview: int = 50,
+) -> Dict[str, Any]:
+    """Mirror or symmetrize selected polygon mesh components by vertex pairs.
+
+    Operations:
+    - query_pairs: find mirror-paired vertices without editing the mesh
+    - symmetrize: move one or both sides of each pair
+
+    Directions:
+    - average: average both paired vertices into symmetric positions
+    - positive_to_negative: copy the positive side across the mirror plane
+    - negative_to_positive: copy the negative side across the mirror plane
+    - selected_to_mirror: copy the selected vertex to its unselected pair mate
+    - mirror_to_selected: copy the unselected pair mate into the selected vertex
+
+    Edges, faces, UVs, and vertex-faces are converted to vertices. This supports
+    Maya-style local symmetry cleanup after hand-moving components, without
+    rebuilding a procedural or object-wide shape.
+    """
+    import math
+    import re
+    import maya.cmds as cmds
+    import maya.api.OpenMaya as om
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return int(value)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(item) for item in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(item) for item in values]
+
+    def _axis_index(axis_name):
+        clean_axis = (axis_name or "").lower().strip()
+        if clean_axis not in {"x", "y", "z"}:
+            raise ValueError("axis must be x, y, or z.")
+        return {"x": 0, "y": 1, "z": 2}[clean_axis]
+
+    def _mesh_shape(node):
+        if not cmds.objExists(node):
+            raise ValueError(f"Object does not exist: {node}")
+        if cmds.objectType(node) == "mesh":
+            return node
+        shapes = cmds.listRelatives(node, shapes=True, fullPath=True) or []
+        mesh_shapes = []
+        for shape in shapes:
+            if cmds.objectType(shape) != "mesh":
+                continue
+            try:
+                if cmds.attributeQuery("intermediateObject", node=shape, exists=True) and cmds.getAttr(f"{shape}.intermediateObject"):
+                    continue
+            except Exception:
+                pass
+            mesh_shapes.append(shape)
+        if not mesh_shapes:
+            raise ValueError(f"{node} is not a polygon mesh transform or mesh shape.")
+        return mesh_shapes[0]
+
+    def _dag_path(shape):
+        selection = om.MSelectionList()
+        selection.add(shape)
+        return selection.getDagPath(0)
+
+    def _mesh_fn(shape):
+        return om.MFnMesh(_dag_path(shape))
+
+    def _prefix(shape):
+        parents = cmds.listRelatives(shape, parent=True, fullPath=False) or []
+        return parents[0] if parents else object_name
+
+    def _flatten(value):
+        if value is None:
+            return []
+        if isinstance(value, str):
+            value = [value]
+        if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+            raise ValueError("components must be a string, a list of strings, or None.")
+        return cmds.ls(value, flatten=True) or []
+
+    def _components_from_indices(kind):
+        if indices is None:
+            return []
+        if not isinstance(indices, list) or not all(isinstance(index, int) and not isinstance(index, bool) for index in indices):
+            raise ValueError("indices must be a list of integers.")
+        return [f"{prefix_name}.{kind}[{index}]" for index in indices]
+
+    def _selected_components():
+        if not use_selection:
+            return []
+        selected = cmds.ls(selection=True, flatten=True) or []
+        object_tokens = {object_name, prefix_name, shape_name}
+        return [item for item in selected if item.split(".", 1)[0] in object_tokens]
+
+    def _resolve_components():
+        clean_type = component_type.lower().strip()
+        kind_map = {
+            "vertex": "vtx",
+            "edge": "e",
+            "face": "f",
+            "uv": "map",
+            "vertex_face": "vtxFace",
+        }
+        if components is not None:
+            resolved = _flatten(components)
+        elif clean_type in kind_map and indices is not None:
+            resolved = _components_from_indices(kind_map[clean_type])
+        else:
+            resolved = _selected_components()
+        if not resolved:
+            raise ValueError("No components resolved from components, indices, or current selection.")
+        return resolved
+
+    def _vertex_ids_from_components(items):
+        converted = cmds.polyListComponentConversion(items, toVertex=True) or []
+        vertices = cmds.ls(converted, flatten=True) or []
+        ids = []
+        pattern = re.compile(r"\.vtx\[(\d+)\]$")
+        for vertex in vertices:
+            match = pattern.search(vertex)
+            if match:
+                ids.append(int(match.group(1)))
+        return sorted(set(ids))
+
+    def _point_values(point):
+        return [float(point.x), float(point.y), float(point.z)]
+
+    def _point_from_values(values):
+        return om.MPoint(float(values[0]), float(values[1]), float(values[2]))
+
+    def _distance(a, b):
+        return math.sqrt((a.x - b.x) ** 2 + (a.y - b.y) ** 2 + (a.z - b.z) ** 2)
+
+    def _distance_to_values(point, values):
+        return math.sqrt((point.x - values[0]) ** 2 + (point.y - values[1]) ** 2 + (point.z - values[2]) ** 2)
+
+    def _bounds(vertex_ids_to_check, current_points):
+        mins = [float("inf"), float("inf"), float("inf")]
+        maxs = [float("-inf"), float("-inf"), float("-inf")]
+        for vertex_id in vertex_ids_to_check:
+            values = _point_values(current_points[vertex_id])
+            for index in range(3):
+                mins[index] = min(mins[index], values[index])
+                maxs[index] = max(maxs[index], values[index])
+        center_value = [(mins[index] + maxs[index]) * 0.5 for index in range(3)]
+        return mins, maxs, center_value
+
+    def _center_point(current_points):
+        if center is not None:
+            return _validate_vector(center, 3, "center")
+        mode = center_mode.lower().strip()
+        if mode == "origin":
+            return [0.0, 0.0, 0.0]
+        if mode == "selection_center":
+            return _bounds(vertex_ids, current_points)[2]
+        if mode == "object_center":
+            return _bounds(list(range(mesh_fn.numVertices)), current_points)[2]
+        raise ValueError("center_mode must be origin, selection_center, or object_center.")
+
+    def _mirror_values(values, center_value, axis_idx):
+        mirrored = values[:]
+        mirrored[axis_idx] = center_value[axis_idx] * 2.0 - mirrored[axis_idx]
+        return mirrored
+
+    def _mirror_point(point, center_value, axis_idx):
+        return _point_from_values(_mirror_values(_point_values(point), center_value, axis_idx))
+
+    def _side(vertex_id, current_points, center_value, axis_idx, clean_tolerance):
+        delta = _point_values(current_points[vertex_id])[axis_idx] - center_value[axis_idx]
+        if delta > clean_tolerance:
+            return "positive"
+        if delta < -clean_tolerance:
+            return "negative"
+        return "center"
+
+    def _positive_negative(pair, current_points, center_value, axis_idx):
+        first, second = pair
+        first_value = _point_values(current_points[first])[axis_idx]
+        second_value = _point_values(current_points[second])[axis_idx]
+        if first_value >= second_value:
+            return first, second
+        return second, first
+
+    def _find_pairs(selected_ids, current_points, center_value, axis_idx, clean_tolerance):
+        pairs = []
+        skipped = []
+        center_vertices = []
+        seen_pairs = set()
+        tolerance_sq = clean_tolerance * clean_tolerance
+        all_ids = list(range(mesh_fn.numVertices))
+
+        for vertex_id in selected_ids:
+            current_side = _side(vertex_id, current_points, center_value, axis_idx, clean_tolerance)
+            if current_side == "center":
+                center_vertices.append(vertex_id)
+                continue
+
+            target_values = _mirror_values(_point_values(current_points[vertex_id]), center_value, axis_idx)
+            best_id = None
+            best_distance_sq = tolerance_sq
+            for candidate_id in all_ids:
+                if candidate_id == vertex_id:
+                    continue
+                candidate = current_points[candidate_id]
+                distance_sq = (
+                    (candidate.x - target_values[0]) ** 2
+                    + (candidate.y - target_values[1]) ** 2
+                    + (candidate.z - target_values[2]) ** 2
+                )
+                if distance_sq <= best_distance_sq:
+                    best_distance_sq = distance_sq
+                    best_id = candidate_id
+
+            if best_id is None:
+                skipped.append(
+                    {
+                        "index": vertex_id,
+                        "component": f"{prefix_name}.vtx[{vertex_id}]",
+                        "reason": "no_mirror_match_within_tolerance",
+                    }
+                )
+                continue
+
+            pair = tuple(sorted((vertex_id, best_id)))
+            if pair in seen_pairs:
+                continue
+            seen_pairs.add(pair)
+            positive_id, negative_id = _positive_negative(pair, current_points, center_value, axis_idx)
+            pairs.append(
+                {
+                    "positive": positive_id,
+                    "negative": negative_id,
+                    "distance": math.sqrt(best_distance_sq),
+                }
+            )
+
+        return pairs, center_vertices, skipped
+
+    def _average_pair_positions(positive_point, negative_point, center_value, axis_idx):
+        positive_values = _point_values(positive_point)
+        mirrored_negative = _mirror_values(_point_values(negative_point), center_value, axis_idx)
+        averaged_positive = [
+            (positive_values[index] + mirrored_negative[index]) * 0.5
+            for index in range(3)
+        ]
+        averaged_negative = _mirror_values(averaged_positive, center_value, axis_idx)
+        return _point_from_values(averaged_positive), _point_from_values(averaged_negative)
+
+    def _apply_pair(pair_record, current_points, next_points, selected_set, center_value, axis_idx, clean_direction):
+        positive_id = pair_record["positive"]
+        negative_id = pair_record["negative"]
+        positive_point = current_points[positive_id]
+        negative_point = current_points[negative_id]
+
+        if clean_direction == "average":
+            next_positive, next_negative = _average_pair_positions(positive_point, negative_point, center_value, axis_idx)
+            next_points[positive_id] = next_positive
+            next_points[negative_id] = next_negative
+            return [positive_id, negative_id], None
+
+        if clean_direction == "positive_to_negative":
+            next_points[negative_id] = _mirror_point(positive_point, center_value, axis_idx)
+            return [negative_id], None
+
+        if clean_direction == "negative_to_positive":
+            next_points[positive_id] = _mirror_point(negative_point, center_value, axis_idx)
+            return [positive_id], None
+
+        selected_in_pair = [vertex_id for vertex_id in (positive_id, negative_id) if vertex_id in selected_set]
+        if len(selected_in_pair) != 1:
+            return [], {
+                "indices": [positive_id, negative_id],
+                "components": [f"{prefix_name}.vtx[{positive_id}]", f"{prefix_name}.vtx[{negative_id}]"],
+                "reason": "requires_exactly_one_selected_vertex_in_pair",
+            }
+
+        selected_id = selected_in_pair[0]
+        other_id = negative_id if selected_id == positive_id else positive_id
+
+        if clean_direction == "selected_to_mirror":
+            next_points[other_id] = _mirror_point(current_points[selected_id], center_value, axis_idx)
+            return [other_id], None
+
+        next_points[selected_id] = _mirror_point(current_points[other_id], center_value, axis_idx)
+        return [selected_id], None
+
+    def _pair_preview(pair_records, before_points, after_points):
+        preview = []
+        for pair in pair_records[:max_preview]:
+            positive_id = pair["positive"]
+            negative_id = pair["negative"]
+            preview.append(
+                {
+                    "positive": {
+                        "index": positive_id,
+                        "component": f"{prefix_name}.vtx[{positive_id}]",
+                        "before": _point_values(before_points[positive_id]),
+                        "after": _point_values(after_points[positive_id]),
+                        "movement": _distance(before_points[positive_id], after_points[positive_id]),
+                    },
+                    "negative": {
+                        "index": negative_id,
+                        "component": f"{prefix_name}.vtx[{negative_id}]",
+                        "before": _point_values(before_points[negative_id]),
+                        "after": _point_values(after_points[negative_id]),
+                        "movement": _distance(before_points[negative_id], after_points[negative_id]),
+                    },
+                    "match_distance": float(pair["distance"]),
+                }
+            )
+        return preview
+
+    if not object_name:
+        raise ValueError("object_name is required.")
+    operation = operation.lower().strip()
+    if operation not in {"query_pairs", "symmetrize"}:
+        raise ValueError("operation must be query_pairs or symmetrize.")
+    component_type = component_type.lower().strip()
+    if component_type not in {"vertex", "edge", "face", "uv", "vertex_face"}:
+        raise ValueError("component_type must be vertex, edge, face, uv, or vertex_face.")
+    clean_direction = direction.lower().strip()
+    if clean_direction not in {"average", "positive_to_negative", "negative_to_positive", "selected_to_mirror", "mirror_to_selected"}:
+        raise ValueError("direction must be average, positive_to_negative, negative_to_positive, selected_to_mirror, or mirror_to_selected.")
+    clean_tolerance = _validate_scalar(tolerance, "tolerance")
+    if clean_tolerance <= 0.0:
+        raise ValueError("tolerance must be greater than 0.")
+    space = space.lower().strip()
+    if space not in {"world", "object"}:
+        raise ValueError("space must be world or object.")
+    max_preview = _validate_int(max_preview, "max_preview", 0)
+
+    shape_name = _mesh_shape(object_name)
+    mesh_fn = _mesh_fn(shape_name)
+    prefix_name = _prefix(shape_name)
+    om_space = om.MSpace.kWorld if space == "world" else om.MSpace.kObject
+
+    resolved_components = _resolve_components()
+    vertex_ids = _vertex_ids_from_components(resolved_components)
+    if not vertex_ids:
+        raise ValueError("No vertices resolved from components, indices, or current selection.")
+
+    axis_idx = _axis_index(axis)
+    points = mesh_fn.getPoints(om_space)
+    center_value = _center_point(points)
+    pairs, center_vertices, skipped = _find_pairs(vertex_ids, points, center_value, axis_idx, clean_tolerance)
+
+    next_points = om.MPointArray(points)
+    moved_ids = set()
+    pair_skipped = []
+
+    if operation == "symmetrize":
+        selected_set = set(vertex_ids)
+        for pair in pairs:
+            moved_pair_ids, skip_record = _apply_pair(pair, points, next_points, selected_set, center_value, axis_idx, clean_direction)
+            moved_ids.update(moved_pair_ids)
+            if skip_record:
+                pair_skipped.append(skip_record)
+
+        if snap_center_vertices:
+            for vertex_id in center_vertices:
+                values = _point_values(next_points[vertex_id])
+                values[axis_idx] = center_value[axis_idx]
+                next_points[vertex_id] = _point_from_values(values)
+                moved_ids.add(vertex_id)
+
+        mesh_fn.setPoints(next_points, om_space)
+        try:
+            mesh_fn.updateSurface()
+        except Exception:
+            pass
+
+    updated_points = mesh_fn.getPoints(om_space)
+    actual_moved_ids = sorted(
+        vertex_id
+        for vertex_id in moved_ids
+        if _distance(points[vertex_id], updated_points[vertex_id]) > 1.0e-9
+    )
+
+    if operation == "symmetrize" and not actual_moved_ids:
+        skipped.extend(pair_skipped)
+        raise RuntimeError("symmetrize did not move any vertices.")
+
+    result_components = [f"{prefix_name}.vtx[{vertex_id}]" for vertex_id in sorted(set(vertex_ids).union(actual_moved_ids))]
+    if select_result and result_components:
+        cmds.select(result_components, replace=True)
+
+    skipped.extend(pair_skipped)
+    return {
+        "success": True,
+        "object_name": object_name,
+        "shape_name": shape_name,
+        "operation": operation,
+        "component_type": component_type,
+        "space": space,
+        "axis": axis.lower().strip(),
+        "center": center_value,
+        "center_mode": center_mode.lower().strip() if center is None else "explicit",
+        "direction": clean_direction,
+        "tolerance": clean_tolerance,
+        "resolved_vertex_count": len(vertex_ids),
+        "pair_count": len(pairs),
+        "center_vertex_count": len(center_vertices),
+        "moved_vertex_count": len(actual_moved_ids),
+        "moved_vertices_preview": actual_moved_ids[:max_preview],
+        "skipped_count": len(skipped),
+        "skipped_preview": skipped[:max_preview],
+        "pair_preview": _pair_preview(pairs, points, updated_points),
+    }

--- a/src/mayatools/object/transform_mesh_components.py
+++ b/src/mayatools/object/transform_mesh_components.py
@@ -17,6 +17,10 @@ def transform_mesh_components(
     end_value: float = None,
     pivot: List[float] = None,
     pivot_mode: str = "selection_center",
+    plane_point: List[float] = None,
+    plane_normal: List[float] = None,
+    center: List[float] = None,
+    radius_mode: str = "explicit",
     space: str = "world",
     use_selection: bool = True,
     max_preview: int = 20,
@@ -29,6 +33,9 @@ def transform_mesh_components(
     - rotate: rotate resolved vertices around a pivot using XYZ degrees
     - align_axis: set all resolved vertices to one coordinate on x, y, or z
     - distribute_axis: evenly distribute resolved vertices along x, y, or z
+    - align_plane: project resolved vertices onto an arbitrary plane
+    - align_radial: set resolved vertices to a shared cylinder radius around
+      x, y, or z while preserving height and angle
 
     Components can be explicit, built from component_type plus indices, or read
     from the current selection. Edges and faces are converted to their unique
@@ -144,6 +151,13 @@ def transform_mesh_components(
     def _point_to_list(point):
         return [float(point.x), float(point.y), float(point.z)]
 
+    def _normalize(values, arg_name):
+        vector = _validate_vector(values, 3, arg_name)
+        length = math.sqrt(sum(item * item for item in vector))
+        if length <= 1e-12:
+            raise ValueError(f"{arg_name} must not be a zero vector.")
+        return [item / length for item in vector]
+
     def _point_preview(vertex_ids, current_points):
         return [
             {"index": vertex_id, "position": _point_to_list(current_points[vertex_id])}
@@ -211,6 +225,42 @@ def transform_mesh_components(
             return object_center[axis_idx]
         raise ValueError("value_mode must be explicit, selection_min, selection_max, selection_center, object_min, object_max, or object_center.")
 
+    def _center_point(current_points):
+        if center is not None:
+            return _validate_vector(center, 3, "center")
+        return _pivot(current_points)
+
+    def _target_radius(vertex_ids_to_check, current_points, center_value, axis_idx):
+        mode = radius_mode.lower().strip()
+        radial_axes = [index for index in range(3) if index != axis_idx]
+        radii = []
+        for vertex_id in vertex_ids_to_check:
+            point = current_points[vertex_id]
+            values = [point.x, point.y, point.z]
+            delta_a = values[radial_axes[0]] - center_value[radial_axes[0]]
+            delta_b = values[radial_axes[1]] - center_value[radial_axes[1]]
+            radii.append(math.sqrt(delta_a * delta_a + delta_b * delta_b))
+        if mode == "explicit":
+            radius = _validate_scalar(value, "value")
+        elif mode == "selection_min":
+            radius = min(radii)
+        elif mode == "selection_max":
+            radius = max(radii)
+        elif mode in {"selection_mean", "selection_center"}:
+            radius = sum(radii) / float(len(radii))
+        elif mode == "selection_median":
+            ordered = sorted(radii)
+            mid = len(ordered) // 2
+            if len(ordered) % 2:
+                radius = ordered[mid]
+            else:
+                radius = (ordered[mid - 1] + ordered[mid]) * 0.5
+        else:
+            raise ValueError("radius_mode must be explicit, selection_min, selection_max, selection_mean, selection_center, or selection_median.")
+        if radius < 0.0:
+            raise ValueError("target radius must be greater than or equal to zero.")
+        return radius
+
     def _rotate_point(point, pivot_value, rotation_value):
         rx, ry, rz = [math.radians(item) for item in rotation_value]
         x = point.x - pivot_value[0]
@@ -231,8 +281,8 @@ def transform_mesh_components(
     if not object_name:
         raise ValueError("object_name is required.")
     operation = operation.lower().strip()
-    if operation not in {"translate", "scale", "rotate", "align_axis", "distribute_axis"}:
-        raise ValueError("operation must be translate, scale, rotate, align_axis, or distribute_axis.")
+    if operation not in {"translate", "scale", "rotate", "align_axis", "distribute_axis", "align_plane", "align_radial"}:
+        raise ValueError("operation must be translate, scale, rotate, align_axis, distribute_axis, align_plane, or align_radial.")
     component_type = component_type.lower().strip()
     if component_type not in {"vertex", "edge", "face", "uv", "vertex_face"}:
         raise ValueError("component_type must be vertex, edge, face, uv, or vertex_face.")
@@ -323,6 +373,51 @@ def transform_mesh_components(
         applied["axis"] = axis.lower().strip()
         applied["start_value"] = start
         applied["end_value"] = end
+
+    elif operation == "align_plane":
+        normal = _normalize(plane_normal, "plane_normal")
+        point_on_plane = _validate_vector(plane_point, 3, "plane_point") if plane_point is not None else _pivot(points)
+        for vertex_id in vertex_ids:
+            point = points[vertex_id]
+            vector_to_point = [
+                point.x - point_on_plane[0],
+                point.y - point_on_plane[1],
+                point.z - point_on_plane[2],
+            ]
+            distance_to_plane = sum(vector_to_point[index] * normal[index] for index in range(3))
+            points[vertex_id] = om.MPoint(
+                point.x - normal[0] * distance_to_plane,
+                point.y - normal[1] * distance_to_plane,
+                point.z - normal[2] * distance_to_plane,
+            )
+        applied["plane_point"] = point_on_plane
+        applied["plane_normal"] = normal
+
+    elif operation == "align_radial":
+        axis_idx = _axis_index(axis)
+        center_value = _center_point(points)
+        target_radius = _target_radius(vertex_ids, points, center_value, axis_idx)
+        radial_axes = [index for index in range(3) if index != axis_idx]
+        fallback_axis = radial_axes[0]
+        for vertex_id in vertex_ids:
+            point = points[vertex_id]
+            values = [point.x, point.y, point.z]
+            delta_a = values[radial_axes[0]] - center_value[radial_axes[0]]
+            delta_b = values[radial_axes[1]] - center_value[radial_axes[1]]
+            current_radius = math.sqrt(delta_a * delta_a + delta_b * delta_b)
+            if current_radius <= 1e-12:
+                values[radial_axes[0]] = center_value[radial_axes[0]]
+                values[radial_axes[1]] = center_value[radial_axes[1]]
+                values[fallback_axis] = center_value[fallback_axis] + target_radius
+            else:
+                scale_factor = target_radius / current_radius
+                values[radial_axes[0]] = center_value[radial_axes[0]] + delta_a * scale_factor
+                values[radial_axes[1]] = center_value[radial_axes[1]] + delta_b * scale_factor
+            points[vertex_id] = om.MPoint(values[0], values[1], values[2])
+        applied["axis"] = axis.lower().strip()
+        applied["center"] = center_value
+        applied["radius"] = target_radius
+        applied["radius_mode"] = radius_mode.lower().strip()
 
     mesh_fn.setPoints(points, om_space)
     try:

--- a/src/mayatools/object/transform_mesh_components.py
+++ b/src/mayatools/object/transform_mesh_components.py
@@ -1,0 +1,354 @@
+from typing import Dict, List, Any, Union
+
+
+def transform_mesh_components(
+    object_name: str,
+    operation: str = "translate",
+    component_type: str = "vertex",
+    indices: List[int] = None,
+    components: Union[str, List[str]] = None,
+    vector: List[float] = None,
+    scale: List[float] = None,
+    rotation: List[float] = None,
+    axis: str = None,
+    value: float = None,
+    value_mode: str = "explicit",
+    start_value: float = None,
+    end_value: float = None,
+    pivot: List[float] = None,
+    pivot_mode: str = "selection_center",
+    space: str = "world",
+    use_selection: bool = True,
+    max_preview: int = 20,
+) -> Dict[str, Any]:
+    """Transform selected polygon components by editing mesh vertices.
+
+    Operations:
+    - translate: add vector to resolved vertices
+    - scale: scale resolved vertices around a pivot
+    - rotate: rotate resolved vertices around a pivot using XYZ degrees
+    - align_axis: set all resolved vertices to one coordinate on x, y, or z
+    - distribute_axis: evenly distribute resolved vertices along x, y, or z
+
+    Components can be explicit, built from component_type plus indices, or read
+    from the current selection. Edges and faces are converted to their unique
+    vertices, so this supports Maya-style local loop scaling, point flattening,
+    coordinate alignment, and manual proportional shaping without global
+    procedural deformation.
+    """
+    import math
+    import re
+    import maya.cmds as cmds
+    import maya.api.OpenMaya as om
+
+    def _is_number(value_to_check):
+        return isinstance(value_to_check, (int, float)) and not isinstance(value_to_check, bool)
+
+    def _validate_scalar(value_to_check, arg_name):
+        if not _is_number(value_to_check):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value_to_check)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(item) for item in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(item) for item in values]
+
+    def _validate_int(value_to_check, arg_name, minimum):
+        if not isinstance(value_to_check, int) or isinstance(value_to_check, bool) or value_to_check < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return int(value_to_check)
+
+    def _mesh_shape(node):
+        if not cmds.objExists(node):
+            raise ValueError(f"Object does not exist: {node}")
+        if cmds.objectType(node) == "mesh":
+            return node
+        shapes = cmds.listRelatives(node, shapes=True, fullPath=True) or []
+        mesh_shapes = []
+        for shape in shapes:
+            if cmds.objectType(shape) != "mesh":
+                continue
+            try:
+                if cmds.attributeQuery("intermediateObject", node=shape, exists=True) and cmds.getAttr(f"{shape}.intermediateObject"):
+                    continue
+            except Exception:
+                pass
+            mesh_shapes.append(shape)
+        if not mesh_shapes:
+            raise ValueError(f"{node} is not a polygon mesh transform or mesh shape.")
+        return mesh_shapes[0]
+
+    def _mesh_fn(shape):
+        selection = om.MSelectionList()
+        selection.add(shape)
+        return om.MFnMesh(selection.getDagPath(0))
+
+    def _prefix():
+        parents = cmds.listRelatives(shape_name, parent=True, fullPath=False) or []
+        return parents[0] if parents else object_name
+
+    def _flatten(value_to_flatten):
+        if value_to_flatten is None:
+            return []
+        if isinstance(value_to_flatten, str):
+            value_to_flatten = [value_to_flatten]
+        if not isinstance(value_to_flatten, list) or not all(isinstance(item, str) for item in value_to_flatten):
+            raise ValueError("components must be a string, a list of strings, or None.")
+        return cmds.ls(value_to_flatten, flatten=True) or []
+
+    def _components_from_indices(kind):
+        if indices is None:
+            return []
+        if not isinstance(indices, list) or not all(isinstance(index, int) and not isinstance(index, bool) for index in indices):
+            raise ValueError("indices must be a list of integers.")
+        return [f"{prefix_name}.{kind}[{index}]" for index in indices]
+
+    def _selected_components():
+        if not use_selection:
+            return []
+        selected = cmds.ls(selection=True, flatten=True) or []
+        object_tokens = {object_name, prefix_name, shape_name}
+        return [item for item in selected if item.split(".", 1)[0] in object_tokens]
+
+    def _resolve_components():
+        clean_type = component_type.lower().strip()
+        kind_map = {
+            "vertex": "vtx",
+            "edge": "e",
+            "face": "f",
+            "uv": "map",
+            "vertex_face": "vtxFace",
+        }
+        if components is not None:
+            resolved = _flatten(components)
+        elif clean_type in kind_map and indices is not None:
+            resolved = _components_from_indices(kind_map[clean_type])
+        else:
+            resolved = _selected_components()
+        if not resolved:
+            raise ValueError("No components resolved from components, indices, or current selection.")
+        return resolved
+
+    def _vertex_ids_from_components(items):
+        converted = cmds.polyListComponentConversion(items, toVertex=True) or []
+        vertices = cmds.ls(converted, flatten=True) or []
+        ids = []
+        pattern = re.compile(r"\.vtx\[(\d+)\]$")
+        for vertex in vertices:
+            match = pattern.search(vertex)
+            if match:
+                ids.append(int(match.group(1)))
+        return sorted(set(ids))
+
+    def _point_to_list(point):
+        return [float(point.x), float(point.y), float(point.z)]
+
+    def _point_preview(vertex_ids, current_points):
+        return [
+            {"index": vertex_id, "position": _point_to_list(current_points[vertex_id])}
+            for vertex_id in vertex_ids[:max_preview]
+        ]
+
+    def _bounds(vertex_ids, current_points):
+        mins = [float("inf"), float("inf"), float("inf")]
+        maxs = [float("-inf"), float("-inf"), float("-inf")]
+        for vertex_id in vertex_ids:
+            point = current_points[vertex_id]
+            values = [point.x, point.y, point.z]
+            for index in range(3):
+                mins[index] = min(mins[index], values[index])
+                maxs[index] = max(maxs[index], values[index])
+        center = [(mins[index] + maxs[index]) * 0.5 for index in range(3)]
+        return mins, maxs, center
+
+    def _all_vertex_ids():
+        return list(range(mesh_fn.numVertices))
+
+    def _pivot(current_points):
+        if pivot is not None:
+            return _validate_vector(pivot, 3, "pivot")
+        mode = pivot_mode.lower().strip()
+        if mode == "origin":
+            return [0.0, 0.0, 0.0]
+        if mode == "selection_center":
+            return selection_center[:]
+        if mode == "selection_min":
+            return selection_min[:]
+        if mode == "selection_max":
+            return selection_max[:]
+        if mode in {"object_center", "object_min", "object_max"}:
+            object_min, object_max, object_center = _bounds(_all_vertex_ids(), current_points)
+            if mode == "object_min":
+                return object_min
+            if mode == "object_max":
+                return object_max
+            return object_center
+        raise ValueError("pivot_mode must be origin, selection_center, selection_min, selection_max, object_center, object_min, or object_max.")
+
+    def _axis_index(axis_name):
+        clean_axis = (axis_name or "").lower().strip()
+        if clean_axis not in {"x", "y", "z"}:
+            raise ValueError("axis must be x, y, or z.")
+        return {"x": 0, "y": 1, "z": 2}[clean_axis]
+
+    def _target_axis_value(axis_idx, current_points):
+        mode = value_mode.lower().strip()
+        if mode == "explicit":
+            return _validate_scalar(value, "value")
+        if mode == "selection_min":
+            return selection_min[axis_idx]
+        if mode == "selection_max":
+            return selection_max[axis_idx]
+        if mode == "selection_center":
+            return selection_center[axis_idx]
+        if mode in {"object_min", "object_max", "object_center"}:
+            object_min, object_max, object_center = _bounds(_all_vertex_ids(), current_points)
+            if mode == "object_min":
+                return object_min[axis_idx]
+            if mode == "object_max":
+                return object_max[axis_idx]
+            return object_center[axis_idx]
+        raise ValueError("value_mode must be explicit, selection_min, selection_max, selection_center, object_min, object_max, or object_center.")
+
+    def _rotate_point(point, pivot_value, rotation_value):
+        rx, ry, rz = [math.radians(item) for item in rotation_value]
+        x = point.x - pivot_value[0]
+        y = point.y - pivot_value[1]
+        z = point.z - pivot_value[2]
+
+        cos_x, sin_x = math.cos(rx), math.sin(rx)
+        y, z = y * cos_x - z * sin_x, y * sin_x + z * cos_x
+
+        cos_y, sin_y = math.cos(ry), math.sin(ry)
+        x, z = x * cos_y + z * sin_y, -x * sin_y + z * cos_y
+
+        cos_z, sin_z = math.cos(rz), math.sin(rz)
+        x, y = x * cos_z - y * sin_z, x * sin_z + y * cos_z
+
+        return om.MPoint(x + pivot_value[0], y + pivot_value[1], z + pivot_value[2])
+
+    if not object_name:
+        raise ValueError("object_name is required.")
+    operation = operation.lower().strip()
+    if operation not in {"translate", "scale", "rotate", "align_axis", "distribute_axis"}:
+        raise ValueError("operation must be translate, scale, rotate, align_axis, or distribute_axis.")
+    component_type = component_type.lower().strip()
+    if component_type not in {"vertex", "edge", "face", "uv", "vertex_face"}:
+        raise ValueError("component_type must be vertex, edge, face, uv, or vertex_face.")
+    space = space.lower().strip()
+    if space not in {"world", "object"}:
+        raise ValueError("space must be world or object.")
+    max_preview = _validate_int(max_preview, "max_preview", 0)
+
+    shape_name = _mesh_shape(object_name)
+    mesh_fn = _mesh_fn(shape_name)
+    prefix_name = _prefix()
+    om_space = om.MSpace.kWorld if space == "world" else om.MSpace.kObject
+
+    resolved_components = _resolve_components()
+    vertex_ids = _vertex_ids_from_components(resolved_components)
+    if not vertex_ids:
+        raise ValueError("No vertices resolved from components, indices, or current selection.")
+
+    points = mesh_fn.getPoints(om_space)
+    selection_min, selection_max, selection_center = _bounds(vertex_ids, points)
+    before_preview = _point_preview(vertex_ids, points)
+
+    applied = {}
+    if operation == "translate":
+        move_vector = _validate_vector(vector, 3, "vector")
+        for vertex_id in vertex_ids:
+            point = points[vertex_id]
+            points[vertex_id] = om.MPoint(point.x + move_vector[0], point.y + move_vector[1], point.z + move_vector[2])
+        applied["vector"] = move_vector
+
+    elif operation == "scale":
+        scale_vector = _validate_vector(scale, 3, "scale")
+        pivot_value = _pivot(points)
+        for vertex_id in vertex_ids:
+            point = points[vertex_id]
+            points[vertex_id] = om.MPoint(
+                pivot_value[0] + (point.x - pivot_value[0]) * scale_vector[0],
+                pivot_value[1] + (point.y - pivot_value[1]) * scale_vector[1],
+                pivot_value[2] + (point.z - pivot_value[2]) * scale_vector[2],
+            )
+        applied["scale"] = scale_vector
+        applied["pivot"] = pivot_value
+
+    elif operation == "rotate":
+        rotation_value = _validate_vector(rotation, 3, "rotation")
+        pivot_value = _pivot(points)
+        for vertex_id in vertex_ids:
+            points[vertex_id] = _rotate_point(points[vertex_id], pivot_value, rotation_value)
+        applied["rotation"] = rotation_value
+        applied["pivot"] = pivot_value
+
+    elif operation == "align_axis":
+        axis_idx = _axis_index(axis)
+        target_value = _target_axis_value(axis_idx, points)
+        for vertex_id in vertex_ids:
+            point = points[vertex_id]
+            values = [point.x, point.y, point.z]
+            values[axis_idx] = target_value
+            points[vertex_id] = om.MPoint(values[0], values[1], values[2])
+        applied["axis"] = axis.lower().strip()
+        applied["value"] = target_value
+        applied["value_mode"] = value_mode
+
+    elif operation == "distribute_axis":
+        axis_idx = _axis_index(axis)
+        ordered_ids = sorted(
+            vertex_ids,
+            key=lambda vertex_id: (
+                [points[vertex_id].x, points[vertex_id].y, points[vertex_id].z][axis_idx],
+                vertex_id,
+            ),
+        )
+        if start_value is None:
+            start = selection_min[axis_idx]
+        else:
+            start = _validate_scalar(start_value, "start_value")
+        if end_value is None:
+            end = selection_max[axis_idx]
+        else:
+            end = _validate_scalar(end_value, "end_value")
+        denominator = max(1, len(ordered_ids) - 1)
+        for order_index, vertex_id in enumerate(ordered_ids):
+            target_value = start + (end - start) * (order_index / float(denominator))
+            point = points[vertex_id]
+            values = [point.x, point.y, point.z]
+            values[axis_idx] = target_value
+            points[vertex_id] = om.MPoint(values[0], values[1], values[2])
+        applied["axis"] = axis.lower().strip()
+        applied["start_value"] = start
+        applied["end_value"] = end
+
+    mesh_fn.setPoints(points, om_space)
+    try:
+        mesh_fn.updateSurface()
+    except Exception:
+        pass
+
+    updated_points = mesh_fn.getPoints(om_space)
+    after_preview = _point_preview(vertex_ids, updated_points)
+    cmds.select([f"{prefix_name}.vtx[{vertex_id}]" for vertex_id in vertex_ids], replace=True)
+
+    return {
+        "success": True,
+        "object_name": object_name,
+        "shape_name": shape_name,
+        "operation": operation,
+        "component_type": component_type,
+        "space": space,
+        "resolved_vertex_count": len(vertex_ids),
+        "resolved_vertices_preview": vertex_ids[:max_preview],
+        "selection_bounds_before": {
+            "min": selection_min,
+            "max": selection_max,
+            "center": selection_center,
+        },
+        "applied": applied,
+        "before_preview": before_preview,
+        "after_preview": after_preview,
+    }

--- a/src/mayatools/object/transform_mesh_components.py
+++ b/src/mayatools/object/transform_mesh_components.py
@@ -22,6 +22,7 @@ def transform_mesh_components(
     center: List[float] = None,
     radius_mode: str = "explicit",
     space: str = "world",
+    select_result: bool = True,
     use_selection: bool = True,
     max_preview: int = 20,
 ) -> Dict[str, Any]:
@@ -42,6 +43,9 @@ def transform_mesh_components(
     vertices, so this supports Maya-style local loop scaling, point flattening,
     coordinate alignment, and manual proportional shaping without global
     procedural deformation.
+    Set select_result=False for scripted or high-volume edits where preserving
+    the previous viewport selection is more useful than selecting all edited
+    vertices.
     """
     import math
     import re
@@ -427,7 +431,10 @@ def transform_mesh_components(
 
     updated_points = mesh_fn.getPoints(om_space)
     after_preview = _point_preview(vertex_ids, updated_points)
-    cmds.select([f"{prefix_name}.vtx[{vertex_id}]" for vertex_id in vertex_ids], replace=True)
+    if select_result:
+        cmds.select([f"{prefix_name}.vtx[{vertex_id}]" for vertex_id in vertex_ids], replace=True)
+    else:
+        cmds.select(clear=True)
 
     return {
         "success": True,
@@ -437,6 +444,7 @@ def transform_mesh_components(
         "component_type": component_type,
         "space": space,
         "resolved_vertex_count": len(vertex_ids),
+        "select_result": bool(select_result),
         "resolved_vertices_preview": vertex_ids[:max_preview],
         "selection_bounds_before": {
             "min": selection_min,

--- a/src/mayatools/object/transform_mesh_rings_by_axis.py
+++ b/src/mayatools/object/transform_mesh_rings_by_axis.py
@@ -1,0 +1,282 @@
+from typing import Dict, List, Any
+
+
+def transform_mesh_rings_by_axis(
+    object_name: str,
+    ring_edits: List[Dict[str, Any]],
+    axis: str = "y",
+    center: List[float] = [0.0, 0.0, 0.0],
+    group_tolerance: float = 0.001,
+    target_tolerance: float = None,
+    radius_stat: str = "mean",
+    space: str = "world",
+    select_result: bool = False,
+    max_preview: int = 20,
+) -> Dict[str, Any]:
+    """Batch-edit coordinate-clustered mesh rings around an axis.
+
+    Each ring edit selects the nearest vertex row along the chosen axis and
+    changes its radial distance around center. This is the batch equivalent of
+    a Maya artist selecting several edge/vertex loops and scaling them one at a
+    time while preserving each vertex's angular position.
+
+    ring_edits entries support:
+    - target: axis coordinate used to find the nearest ring
+    - radius: explicit target radius
+    - radius_offset: add to the current representative radius
+    - radius_scale: multiply the current representative radius
+    - axis_value: optional coordinate to move the ring to along the axis
+    - label: optional note echoed in the report
+
+    Exactly one of radius, radius_offset, or radius_scale must be provided for
+    each edit.
+    """
+    import math
+    import maya.cmds as cmds
+    import maya.api.OpenMaya as om
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(item) for item in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(item) for item in values]
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return int(value)
+
+    def _axis_index(axis_name):
+        clean = (axis_name or "").lower().strip()
+        if clean not in {"x", "y", "z"}:
+            raise ValueError("axis must be x, y, or z.")
+        return {"x": 0, "y": 1, "z": 2}[clean]
+
+    def _mesh_shape(node):
+        if not cmds.objExists(node):
+            raise ValueError(f"Object does not exist: {node}")
+        if cmds.objectType(node) == "mesh":
+            return node
+        shapes = cmds.listRelatives(node, shapes=True, fullPath=True) or []
+        mesh_shapes = []
+        for shape in shapes:
+            if cmds.objectType(shape) != "mesh":
+                continue
+            try:
+                if cmds.attributeQuery("intermediateObject", node=shape, exists=True) and cmds.getAttr(f"{shape}.intermediateObject"):
+                    continue
+            except Exception:
+                pass
+            mesh_shapes.append(shape)
+        if not mesh_shapes:
+            raise ValueError(f"{node} is not a polygon mesh transform or mesh shape.")
+        return mesh_shapes[0]
+
+    def _mesh_fn(shape):
+        selection = om.MSelectionList()
+        selection.add(shape)
+        return om.MFnMesh(selection.getDagPath(0))
+
+    def _prefix(shape):
+        parents = cmds.listRelatives(shape, parent=True, fullPath=False) or []
+        return parents[0] if parents else object_name
+
+    def _point_values(point):
+        return [float(point.x), float(point.y), float(point.z)]
+
+    def _radius(values):
+        delta_a = values[radial_axes[0]] - clean_center[radial_axes[0]]
+        delta_b = values[radial_axes[1]] - clean_center[radial_axes[1]]
+        return math.sqrt(delta_a * delta_a + delta_b * delta_b)
+
+    def _representative_radius(radii):
+        if clean_radius_stat == "mean":
+            return sum(radii) / float(len(radii))
+        if clean_radius_stat == "min":
+            return min(radii)
+        if clean_radius_stat == "max":
+            return max(radii)
+        ordered = sorted(radii)
+        middle = len(ordered) // 2
+        if len(ordered) % 2:
+            return ordered[middle]
+        return (ordered[middle - 1] + ordered[middle]) * 0.5
+
+    def _build_ring_groups():
+        records = []
+        for vertex_id, point in enumerate(points):
+            values = _point_values(point)
+            records.append({"id": vertex_id, "axis_value": values[axis_idx]})
+        records.sort(key=lambda item: (item["axis_value"], item["id"]))
+
+        groups = []
+        current = []
+        group_start = None
+        for record in records:
+            if not current or record["axis_value"] - group_start <= clean_group_tolerance:
+                current.append(record)
+                if group_start is None:
+                    group_start = record["axis_value"]
+                continue
+            groups.append(current)
+            current = [record]
+            group_start = record["axis_value"]
+        if current:
+            groups.append(current)
+
+        result = []
+        for group_index, group in enumerate(groups):
+            values = [item["axis_value"] for item in group]
+            ids = sorted(item["id"] for item in group)
+            result.append(
+                {
+                    "group_index": group_index,
+                    "axis_value": sum(values) / float(len(values)),
+                    "axis_min": min(values),
+                    "axis_max": max(values),
+                    "vertex_ids": ids,
+                }
+            )
+        return result
+
+    def _pick_group(target):
+        candidates = sorted(ring_groups, key=lambda group: (abs(group["axis_value"] - target), group["axis_value"]))
+        if not candidates:
+            raise ValueError("No vertex rings found.")
+        group = candidates[0]
+        distance = abs(group["axis_value"] - target)
+        if clean_target_tolerance is not None and distance > clean_target_tolerance:
+            raise ValueError(f"No ring within target_tolerance for target {target}. Nearest distance was {distance}.")
+        return group, distance
+
+    def _target_radius(edit, current_radius):
+        keys = [key for key in ("radius", "radius_offset", "radius_scale") if key in edit and edit[key] is not None]
+        if len(keys) != 1:
+            raise ValueError("Each ring edit must provide exactly one of radius, radius_offset, or radius_scale.")
+        if keys[0] == "radius":
+            radius = _validate_scalar(edit["radius"], "radius")
+        elif keys[0] == "radius_offset":
+            radius = current_radius + _validate_scalar(edit["radius_offset"], "radius_offset")
+        else:
+            radius = current_radius * _validate_scalar(edit["radius_scale"], "radius_scale")
+        if radius < 0.0:
+            raise ValueError("Target radius must be greater than or equal to zero.")
+        return radius
+
+    if not object_name:
+        raise ValueError("object_name is required.")
+    if not isinstance(ring_edits, list) or not ring_edits:
+        raise ValueError("ring_edits must be a non-empty list.")
+
+    axis_idx = _axis_index(axis)
+    radial_axes = [index for index in range(3) if index != axis_idx]
+    clean_center = _validate_vector(center, 3, "center")
+    clean_group_tolerance = _validate_scalar(group_tolerance, "group_tolerance")
+    if clean_group_tolerance < 0.0:
+        raise ValueError("group_tolerance must be greater than or equal to zero.")
+    clean_target_tolerance = None if target_tolerance is None else _validate_scalar(target_tolerance, "target_tolerance")
+    if clean_target_tolerance is not None and clean_target_tolerance < 0.0:
+        raise ValueError("target_tolerance must be greater than or equal to zero.")
+    clean_radius_stat = (radius_stat or "").lower().strip()
+    if clean_radius_stat not in {"mean", "min", "max", "median"}:
+        raise ValueError("radius_stat must be mean, min, max, or median.")
+    space = (space or "").lower().strip()
+    if space not in {"world", "object"}:
+        raise ValueError("space must be world or object.")
+    max_preview = _validate_int(max_preview, "max_preview", 0)
+
+    shape_name = _mesh_shape(object_name)
+    mesh_fn = _mesh_fn(shape_name)
+    prefix_name = _prefix(shape_name)
+    om_space = om.MSpace.kWorld if space == "world" else om.MSpace.kObject
+    points = mesh_fn.getPoints(om_space)
+    ring_groups = _build_ring_groups()
+
+    used_groups = set()
+    edited_vertex_ids = []
+    edits_report = []
+    for edit_index, edit in enumerate(ring_edits):
+        if not isinstance(edit, dict):
+            raise ValueError("Each ring_edits entry must be a dictionary.")
+        if "target" not in edit:
+            raise ValueError("Each ring edit requires target.")
+        target = _validate_scalar(edit["target"], "target")
+        group, distance = _pick_group(target)
+        if group["group_index"] in used_groups:
+            raise ValueError(f"Multiple edits resolved to the same ring near axis value {group['axis_value']}.")
+        used_groups.add(group["group_index"])
+
+        vertex_ids = group["vertex_ids"]
+        radii_before = [_radius(_point_values(points[vertex_id])) for vertex_id in vertex_ids]
+        current_radius = _representative_radius(radii_before)
+        target_radius = _target_radius(edit, current_radius)
+        target_axis = edit.get("axis_value")
+        if target_axis is not None:
+            target_axis = _validate_scalar(target_axis, "axis_value")
+
+        for vertex_id in vertex_ids:
+            values = _point_values(points[vertex_id])
+            delta_a = values[radial_axes[0]] - clean_center[radial_axes[0]]
+            delta_b = values[radial_axes[1]] - clean_center[radial_axes[1]]
+            current = math.sqrt(delta_a * delta_a + delta_b * delta_b)
+            if current <= 1e-12:
+                values[radial_axes[0]] = clean_center[radial_axes[0]] + target_radius
+                values[radial_axes[1]] = clean_center[radial_axes[1]]
+            else:
+                scale_factor = target_radius / current
+                values[radial_axes[0]] = clean_center[radial_axes[0]] + delta_a * scale_factor
+                values[radial_axes[1]] = clean_center[radial_axes[1]] + delta_b * scale_factor
+            if target_axis is not None:
+                values[axis_idx] = target_axis
+            points[vertex_id] = om.MPoint(values[0], values[1], values[2])
+
+        edited_vertex_ids.extend(vertex_ids)
+        edits_report.append(
+            {
+                "edit_index": edit_index,
+                "label": edit.get("label"),
+                "target": target,
+                "resolved_axis_value": group["axis_value"],
+                "target_distance": distance,
+                "vertex_count": len(vertex_ids),
+                "radius_before": current_radius,
+                "radius_after": target_radius,
+                "axis_value_after": target_axis if target_axis is not None else group["axis_value"],
+                "vertex_ids_preview": vertex_ids[:max_preview],
+            }
+        )
+
+    mesh_fn.setPoints(points, om_space)
+    try:
+        mesh_fn.updateSurface()
+    except Exception:
+        pass
+
+    unique_vertex_ids = sorted(set(edited_vertex_ids))
+    if select_result and unique_vertex_ids:
+        cmds.select([f"{prefix_name}.vtx[{vertex_id}]" for vertex_id in unique_vertex_ids], replace=True)
+    elif not select_result:
+        cmds.select(clear=True)
+
+    return {
+        "success": True,
+        "object_name": object_name,
+        "shape_name": shape_name,
+        "axis": axis.lower().strip(),
+        "center": clean_center,
+        "space": space,
+        "group_tolerance": clean_group_tolerance,
+        "target_tolerance": clean_target_tolerance,
+        "available_ring_count": len(ring_groups),
+        "edited_ring_count": len(edits_report),
+        "edited_vertex_count": len(unique_vertex_ids),
+        "select_result": bool(select_result),
+        "edits": edits_report,
+    }

--- a/src/mayatools/object/transform_mesh_rings_by_axis.py
+++ b/src/mayatools/object/transform_mesh_rings_by_axis.py
@@ -10,6 +10,7 @@ def transform_mesh_rings_by_axis(
     target_tolerance: float = None,
     radius_stat: str = "mean",
     space: str = "world",
+    preserve_radius_variation: bool = False,
     select_result: bool = False,
     max_preview: int = 20,
 ) -> Dict[str, Any]:
@@ -26,10 +27,13 @@ def transform_mesh_rings_by_axis(
     - radius_offset: add to the current representative radius
     - radius_scale: multiply the current representative radius
     - axis_value: optional coordinate to move the ring to along the axis
+    - preserve_radius_variation: optional per-edit override
     - label: optional note echoed in the report
 
     Exactly one of radius, radius_offset, or radius_scale must be provided for
-    each edit.
+    each edit. With preserve_radius_variation=True, the edit changes the ring's
+    overall radius while preserving existing local dents, grooves, dimples, and
+    other radius offsets on that ring.
     """
     import math
     import maya.cmds as cmds
@@ -52,6 +56,11 @@ def transform_mesh_rings_by_axis(
         if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
             raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
         return int(value)
+
+    def _validate_bool(value, arg_name):
+        if not isinstance(value, bool):
+            raise ValueError(f"{arg_name} must be a boolean.")
+        return value
 
     def _axis_index(axis_name):
         clean = (axis_name or "").lower().strip()
@@ -161,14 +170,26 @@ def transform_mesh_rings_by_axis(
         if len(keys) != 1:
             raise ValueError("Each ring edit must provide exactly one of radius, radius_offset, or radius_scale.")
         if keys[0] == "radius":
-            radius = _validate_scalar(edit["radius"], "radius")
+            operation_value = _validate_scalar(edit["radius"], "radius")
+            radius = operation_value
         elif keys[0] == "radius_offset":
-            radius = current_radius + _validate_scalar(edit["radius_offset"], "radius_offset")
+            operation_value = _validate_scalar(edit["radius_offset"], "radius_offset")
+            radius = current_radius + operation_value
         else:
-            radius = current_radius * _validate_scalar(edit["radius_scale"], "radius_scale")
+            operation_value = _validate_scalar(edit["radius_scale"], "radius_scale")
+            radius = current_radius * operation_value
         if radius < 0.0:
             raise ValueError("Target radius must be greater than or equal to zero.")
-        return radius
+        return radius, keys[0], operation_value
+
+    def _vertex_target_radius(current_vertex_radius, current_radius, target_radius, operation, operation_value, preserve_variation):
+        if not preserve_variation:
+            return target_radius
+        if operation == "radius_offset":
+            return max(0.0, current_vertex_radius + operation_value)
+        if operation == "radius_scale":
+            return max(0.0, current_vertex_radius * operation_value)
+        return max(0.0, current_vertex_radius + (target_radius - current_radius))
 
     if not object_name:
         raise ValueError("object_name is required.")
@@ -190,6 +211,7 @@ def transform_mesh_rings_by_axis(
     space = (space or "").lower().strip()
     if space not in {"world", "object"}:
         raise ValueError("space must be world or object.")
+    clean_preserve_radius_variation = _validate_bool(preserve_radius_variation, "preserve_radius_variation")
     max_preview = _validate_int(max_preview, "max_preview", 0)
 
     shape_name = _mesh_shape(object_name)
@@ -216,7 +238,9 @@ def transform_mesh_rings_by_axis(
         vertex_ids = group["vertex_ids"]
         radii_before = [_radius(_point_values(points[vertex_id])) for vertex_id in vertex_ids]
         current_radius = _representative_radius(radii_before)
-        target_radius = _target_radius(edit, current_radius)
+        target_radius, radius_operation, radius_operation_value = _target_radius(edit, current_radius)
+        edit_preserve_variation = edit.get("preserve_radius_variation", clean_preserve_radius_variation)
+        edit_preserve_variation = _validate_bool(edit_preserve_variation, "preserve_radius_variation")
         target_axis = edit.get("axis_value")
         if target_axis is not None:
             target_axis = _validate_scalar(target_axis, "axis_value")
@@ -226,11 +250,19 @@ def transform_mesh_rings_by_axis(
             delta_a = values[radial_axes[0]] - clean_center[radial_axes[0]]
             delta_b = values[radial_axes[1]] - clean_center[radial_axes[1]]
             current = math.sqrt(delta_a * delta_a + delta_b * delta_b)
+            vertex_target_radius = _vertex_target_radius(
+                current,
+                current_radius,
+                target_radius,
+                radius_operation,
+                radius_operation_value,
+                edit_preserve_variation,
+            )
             if current <= 1e-12:
-                values[radial_axes[0]] = clean_center[radial_axes[0]] + target_radius
+                values[radial_axes[0]] = clean_center[radial_axes[0]] + vertex_target_radius
                 values[radial_axes[1]] = clean_center[radial_axes[1]]
             else:
-                scale_factor = target_radius / current
+                scale_factor = vertex_target_radius / current
                 values[radial_axes[0]] = clean_center[radial_axes[0]] + delta_a * scale_factor
                 values[radial_axes[1]] = clean_center[radial_axes[1]] + delta_b * scale_factor
             if target_axis is not None:
@@ -248,6 +280,8 @@ def transform_mesh_rings_by_axis(
                 "vertex_count": len(vertex_ids),
                 "radius_before": current_radius,
                 "radius_after": target_radius,
+                "radius_operation": radius_operation,
+                "preserve_radius_variation": bool(edit_preserve_variation),
                 "axis_value_after": target_axis if target_axis is not None else group["axis_value"],
                 "vertex_ids_preview": vertex_ids[:max_preview],
             }
@@ -274,6 +308,7 @@ def transform_mesh_rings_by_axis(
         "space": space,
         "group_tolerance": clean_group_tolerance,
         "target_tolerance": clean_target_tolerance,
+        "preserve_radius_variation": bool(clean_preserve_radius_variation),
         "available_ring_count": len(ring_groups),
         "edited_ring_count": len(edits_report),
         "edited_vertex_count": len(unique_vertex_ids),

--- a/src/mayatools/object/transform_uv_components.py
+++ b/src/mayatools/object/transform_uv_components.py
@@ -113,6 +113,15 @@ def transform_uv_components(
         match = re.search(r"\.map\[(\d+)\]$", component)
         return int(match.group(1)) if match else None
 
+    def _mesh_fn():
+        try:
+            import maya.api.OpenMaya as om
+        except Exception as exc:
+            raise RuntimeError("maya.api.OpenMaya is required for bulk UV edits.") from exc
+        selection = om.MSelectionList()
+        selection.add(shape_name)
+        return om.MFnMesh(selection.getDagPath(0))
+
     def _resolve_uv_components():
         if uv_indices is not None:
             if not isinstance(uv_indices, list) or not all(isinstance(index, int) and not isinstance(index, bool) for index in uv_indices):
@@ -136,20 +145,36 @@ def transform_uv_components(
         return uv_items
 
     def _query_uvs(items):
-        values = cmds.polyEditUV(items, query=True) or []
-        records = []
-        for index, component in enumerate(items):
-            value_index = index * 2
-            if value_index + 1 >= len(values):
-                continue
-            records.append(
-                {
-                    "component": component,
-                    "index": _uv_id(component),
-                    "uv": [float(values[value_index]), float(values[value_index + 1])],
-                }
-            )
-        return records
+        uv_ids = [_uv_id(component) for component in items]
+        try:
+            u_values, v_values = _mesh_fn().getUVs(active_uv_set)
+            records = []
+            for component, uv_id in zip(items, uv_ids):
+                if uv_id is None or uv_id < 0 or uv_id >= len(u_values):
+                    continue
+                records.append(
+                    {
+                        "component": component,
+                        "index": uv_id,
+                        "uv": [float(u_values[uv_id]), float(v_values[uv_id])],
+                    }
+                )
+            return records
+        except Exception:
+            values = cmds.polyEditUV(items, query=True) or []
+            records = []
+            for index, component in enumerate(items):
+                value_index = index * 2
+                if value_index + 1 >= len(values):
+                    continue
+                records.append(
+                    {
+                        "component": component,
+                        "index": uv_ids[index],
+                        "uv": [float(values[value_index]), float(values[value_index + 1])],
+                    }
+                )
+            return records
 
     def _bounds(records):
         if not records:
@@ -198,8 +223,25 @@ def transform_uv_components(
         raise ValueError("value_mode must be explicit, selection_min, selection_max, or selection_center.")
 
     def _set_uvs(updated_by_component):
-        for component, uv_value in updated_by_component.items():
-            cmds.polyEditUV(component, relative=False, uValue=uv_value[0], vValue=uv_value[1])
+        if not updated_by_component:
+            return
+        try:
+            mesh_fn = _mesh_fn()
+            u_values, v_values = mesh_fn.getUVs(active_uv_set)
+            u_values = list(u_values)
+            v_values = list(v_values)
+            for component, uv_value in updated_by_component.items():
+                uv_id = _uv_id(component)
+                if uv_id is None or uv_id < 0 or uv_id >= len(u_values):
+                    continue
+                u_values[uv_id] = float(uv_value[0])
+                v_values[uv_id] = float(uv_value[1])
+            mesh_fn.setUVs(u_values, v_values, active_uv_set)
+            mesh_fn.updateSurface()
+            return
+        except Exception:
+            for component, uv_value in updated_by_component.items():
+                cmds.polyEditUV(component, relative=False, uValue=uv_value[0], vValue=uv_value[1])
 
     def _fit_to_box(records, bounds):
         box = _validate_vector(target_box or [0.0, 0.0, 1.0, 1.0], 4, "target_box")
@@ -243,6 +285,7 @@ def transform_uv_components(
         if uv_set not in all_uv_sets:
             raise ValueError(f"UV set {uv_set} does not exist on {object_name}.")
         cmds.polyUVSet(object_name, currentUVSet=True, uvSet=uv_set)
+    active_uv_set = uv_set or previous_uv_set
 
     try:
         uv_items = _resolve_uv_components()

--- a/src/mayatools/object/transform_uv_components.py
+++ b/src/mayatools/object/transform_uv_components.py
@@ -20,6 +20,7 @@ def transform_uv_components(
     pivot_mode: str = "selection_center",
     uv_set: str = None,
     expand_uv_shell: bool = False,
+    select_result: bool = True,
     use_selection: bool = True,
     max_preview: int = 50,
 ) -> Dict[str, Any]:
@@ -37,6 +38,8 @@ def transform_uv_components(
     faces/edges/vertices, or expanded to their UV shell. This supports localized
     UV layout work for labels, decals, panels, seams, and texture islands
     without remapping an entire mesh.
+    Set select_result=False for automated previews or high-volume edits where
+    leaving thousands of UVs selected would obscure the viewport.
     """
     import math
     import re
@@ -358,7 +361,8 @@ def transform_uv_components(
         _set_uvs(updated_uvs)
         after_records = _query_uvs(uv_items)
         bounds_after = _bounds(after_records)
-        cmds.select(uv_items, replace=True)
+        if select_result:
+            cmds.select(uv_items, replace=True)
 
         return {
             "success": True,
@@ -367,6 +371,7 @@ def transform_uv_components(
             "uv_set": uv_set or previous_uv_set,
             "uv_count": len(uv_items),
             "expand_uv_shell": bool(expand_uv_shell),
+            "select_result": bool(select_result),
             "bounds_before": bounds_before,
             "bounds_after": bounds_after,
             "applied": applied,

--- a/src/mayatools/object/transform_uv_components.py
+++ b/src/mayatools/object/transform_uv_components.py
@@ -1,0 +1,338 @@
+from typing import Dict, List, Any, Union
+
+
+def transform_uv_components(
+    object_name: str,
+    operation: str = "translate",
+    uv_indices: List[int] = None,
+    components: Union[str, List[str]] = None,
+    offset: List[float] = None,
+    scale: List[float] = None,
+    rotation_degrees: float = None,
+    axis: str = None,
+    value: float = None,
+    value_mode: str = "explicit",
+    start_value: float = None,
+    end_value: float = None,
+    target_box: List[float] = None,
+    fit_mode: str = "independent",
+    pivot: List[float] = None,
+    pivot_mode: str = "selection_center",
+    uv_set: str = None,
+    expand_uv_shell: bool = False,
+    use_selection: bool = True,
+    max_preview: int = 50,
+) -> Dict[str, Any]:
+    """Transform selected UV components with UV-editor style operations.
+
+    Operations:
+    - translate: add offset [u, v]
+    - scale: scale UVs around a pivot
+    - rotate: rotate UVs around a pivot in degrees
+    - align_axis: set all selected UVs to one u or v coordinate
+    - distribute_axis: evenly distribute selected UVs along u or v
+    - fit_box: fit selected UVs into target_box [min_u, min_v, max_u, max_v]
+
+    UVs can be passed by index, explicit UV components, converted from selected
+    faces/edges/vertices, or expanded to their UV shell. This supports localized
+    UV layout work for labels, decals, panels, seams, and texture islands
+    without remapping an entire mesh.
+    """
+    import math
+    import re
+    import maya.cmds as cmds
+
+    def _is_number(value_to_check):
+        return isinstance(value_to_check, (int, float)) and not isinstance(value_to_check, bool)
+
+    def _validate_scalar(value_to_check, arg_name):
+        if not _is_number(value_to_check):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value_to_check)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(item) for item in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(item) for item in values]
+
+    def _validate_int(value_to_check, arg_name, minimum):
+        if not isinstance(value_to_check, int) or isinstance(value_to_check, bool) or value_to_check < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return int(value_to_check)
+
+    def _mesh_shape(node):
+        if not cmds.objExists(node):
+            raise ValueError(f"Object does not exist: {node}")
+        if cmds.objectType(node) == "mesh":
+            return node
+        shapes = cmds.listRelatives(node, shapes=True, fullPath=True) or []
+        mesh_shapes = []
+        for shape in shapes:
+            if cmds.objectType(shape) != "mesh":
+                continue
+            try:
+                if cmds.attributeQuery("intermediateObject", node=shape, exists=True) and cmds.getAttr(f"{shape}.intermediateObject"):
+                    continue
+            except Exception:
+                pass
+            mesh_shapes.append(shape)
+        if not mesh_shapes:
+            raise ValueError(f"{node} is not a polygon mesh transform or mesh shape.")
+        return mesh_shapes[0]
+
+    def _prefix(shape):
+        parents = cmds.listRelatives(shape, parent=True, fullPath=False) or []
+        return parents[0] if parents else object_name
+
+    def _flatten(value_to_flatten):
+        if value_to_flatten is None:
+            return []
+        if isinstance(value_to_flatten, str):
+            value_to_flatten = [value_to_flatten]
+        if not isinstance(value_to_flatten, list) or not all(isinstance(item, str) for item in value_to_flatten):
+            raise ValueError("components must be a string, a list of strings, or None.")
+        return cmds.ls(value_to_flatten, flatten=True) or []
+
+    def _unique(items):
+        seen = set()
+        result = []
+        for item in cmds.ls(items, flatten=True) or []:
+            if item not in seen:
+                seen.add(item)
+                result.append(item)
+        return result
+
+    def _selected_components():
+        if not use_selection:
+            return []
+        selected = cmds.ls(selection=True, flatten=True) or []
+        object_tokens = {object_name, prefix_name, shape_name}
+        return [item for item in selected if item.split(".", 1)[0] in object_tokens]
+
+    def _uv_id(component):
+        match = re.search(r"\.map\[(\d+)\]$", component)
+        return int(match.group(1)) if match else None
+
+    def _resolve_uv_components():
+        if uv_indices is not None:
+            if not isinstance(uv_indices, list) or not all(isinstance(index, int) and not isinstance(index, bool) for index in uv_indices):
+                raise ValueError("uv_indices must be a list of integers.")
+            resolved = [f"{prefix_name}.map[{index}]" for index in uv_indices]
+        elif components is not None:
+            resolved = _flatten(components)
+            if not all(".map[" in item for item in resolved):
+                resolved = cmds.polyListComponentConversion(resolved, toUV=True) or []
+        else:
+            selected = _selected_components()
+            if not selected:
+                raise ValueError("No UV components resolved from uv_indices, components, or current selection.")
+            resolved = selected if all(".map[" in item for item in selected) else cmds.polyListComponentConversion(selected, toUV=True) or []
+
+        if expand_uv_shell:
+            resolved = cmds.polyListComponentConversion(resolved, toUV=True, uvShell=True) or []
+        uv_items = [item for item in _unique(resolved) if ".map[" in item]
+        if not uv_items:
+            raise ValueError("No UV components resolved.")
+        return uv_items
+
+    def _query_uvs(items):
+        values = cmds.polyEditUV(items, query=True) or []
+        records = []
+        for index, component in enumerate(items):
+            value_index = index * 2
+            if value_index + 1 >= len(values):
+                continue
+            records.append(
+                {
+                    "component": component,
+                    "index": _uv_id(component),
+                    "uv": [float(values[value_index]), float(values[value_index + 1])],
+                }
+            )
+        return records
+
+    def _bounds(records):
+        if not records:
+            raise ValueError("Cannot compute UV bounds without UV records.")
+        min_u = min(record["uv"][0] for record in records)
+        min_v = min(record["uv"][1] for record in records)
+        max_u = max(record["uv"][0] for record in records)
+        max_v = max(record["uv"][1] for record in records)
+        return {
+            "min": [min_u, min_v],
+            "max": [max_u, max_v],
+            "center": [(min_u + max_u) * 0.5, (min_v + max_v) * 0.5],
+            "size": [max_u - min_u, max_v - min_v],
+        }
+
+    def _pivot(bounds):
+        if pivot is not None:
+            return _validate_vector(pivot, 2, "pivot")
+        mode = pivot_mode.lower().strip()
+        if mode == "origin":
+            return [0.0, 0.0]
+        if mode == "selection_min":
+            return bounds["min"][:]
+        if mode == "selection_max":
+            return bounds["max"][:]
+        if mode == "selection_center":
+            return bounds["center"][:]
+        raise ValueError("pivot_mode must be origin, selection_min, selection_max, or selection_center.")
+
+    def _axis_index(axis_name):
+        clean_axis = (axis_name or "").lower().strip()
+        if clean_axis not in {"u", "v"}:
+            raise ValueError("axis must be u or v.")
+        return 0 if clean_axis == "u" else 1
+
+    def _target_axis_value(axis_index, bounds):
+        mode = value_mode.lower().strip()
+        if mode == "explicit":
+            return _validate_scalar(value, "value")
+        if mode == "selection_min":
+            return bounds["min"][axis_index]
+        if mode == "selection_max":
+            return bounds["max"][axis_index]
+        if mode == "selection_center":
+            return bounds["center"][axis_index]
+        raise ValueError("value_mode must be explicit, selection_min, selection_max, or selection_center.")
+
+    def _set_uvs(updated_by_component):
+        for component, uv_value in updated_by_component.items():
+            cmds.polyEditUV(component, relative=False, uValue=uv_value[0], vValue=uv_value[1])
+
+    def _fit_to_box(records, bounds):
+        box = _validate_vector(target_box or [0.0, 0.0, 1.0, 1.0], 4, "target_box")
+        if box[2] <= box[0] or box[3] <= box[1]:
+            raise ValueError("target_box must be [min_u, min_v, max_u, max_v] with positive size.")
+        source_size = bounds["size"]
+        target_size = [box[2] - box[0], box[3] - box[1]]
+        if source_size[0] <= 1e-9 or source_size[1] <= 1e-9:
+            raise ValueError("Selected UVs must have non-zero width and height for fit_box.")
+        mode = fit_mode.lower().strip()
+        if mode == "independent":
+            scales = [target_size[0] / source_size[0], target_size[1] / source_size[1]]
+        elif mode in {"uniform_fit", "uniform_fill"}:
+            candidates = [target_size[0] / source_size[0], target_size[1] / source_size[1]]
+            uniform = min(candidates) if mode == "uniform_fit" else max(candidates)
+            scales = [uniform, uniform]
+        else:
+            raise ValueError("fit_mode must be independent, uniform_fit, or uniform_fill.")
+        target_center = [(box[0] + box[2]) * 0.5, (box[1] + box[3]) * 0.5]
+        updated = {}
+        for record in records:
+            u_value, v_value = record["uv"]
+            updated[record["component"]] = [
+                target_center[0] + (u_value - bounds["center"][0]) * scales[0],
+                target_center[1] + (v_value - bounds["center"][1]) * scales[1],
+            ]
+        return updated, {"target_box": box, "fit_mode": mode, "scale": scales}
+
+    if not object_name:
+        raise ValueError("object_name is required.")
+    operation = operation.lower().strip()
+    if operation not in {"translate", "scale", "rotate", "align_axis", "distribute_axis", "fit_box"}:
+        raise ValueError("operation must be translate, scale, rotate, align_axis, distribute_axis, or fit_box.")
+    max_preview = _validate_int(max_preview, "max_preview", 0)
+
+    shape_name = _mesh_shape(object_name)
+    prefix_name = _prefix(shape_name)
+    all_uv_sets = cmds.polyUVSet(object_name, query=True, allUVSets=True) or []
+    previous_uv_set = (cmds.polyUVSet(object_name, query=True, currentUVSet=True) or [None])[0]
+    if uv_set:
+        if uv_set not in all_uv_sets:
+            raise ValueError(f"UV set {uv_set} does not exist on {object_name}.")
+        cmds.polyUVSet(object_name, currentUVSet=True, uvSet=uv_set)
+
+    try:
+        uv_items = _resolve_uv_components()
+        before_records = _query_uvs(uv_items)
+        bounds_before = _bounds(before_records)
+        updated_uvs = {}
+        applied = {}
+
+        if operation == "translate":
+            clean_offset = _validate_vector(offset, 2, "offset")
+            for record in before_records:
+                updated_uvs[record["component"]] = [record["uv"][0] + clean_offset[0], record["uv"][1] + clean_offset[1]]
+            applied["offset"] = clean_offset
+
+        elif operation == "scale":
+            clean_scale = _validate_vector(scale, 2, "scale")
+            pivot_value = _pivot(bounds_before)
+            for record in before_records:
+                updated_uvs[record["component"]] = [
+                    pivot_value[0] + (record["uv"][0] - pivot_value[0]) * clean_scale[0],
+                    pivot_value[1] + (record["uv"][1] - pivot_value[1]) * clean_scale[1],
+                ]
+            applied["scale"] = clean_scale
+            applied["pivot"] = pivot_value
+
+        elif operation == "rotate":
+            degrees = _validate_scalar(rotation_degrees, "rotation_degrees")
+            pivot_value = _pivot(bounds_before)
+            radians = math.radians(degrees)
+            cos_value = math.cos(radians)
+            sin_value = math.sin(radians)
+            for record in before_records:
+                local_u = record["uv"][0] - pivot_value[0]
+                local_v = record["uv"][1] - pivot_value[1]
+                updated_uvs[record["component"]] = [
+                    pivot_value[0] + local_u * cos_value - local_v * sin_value,
+                    pivot_value[1] + local_u * sin_value + local_v * cos_value,
+                ]
+            applied["rotation_degrees"] = degrees
+            applied["pivot"] = pivot_value
+
+        elif operation == "align_axis":
+            axis_idx = _axis_index(axis)
+            target_value = _target_axis_value(axis_idx, bounds_before)
+            for record in before_records:
+                uv_value = record["uv"][:]
+                uv_value[axis_idx] = target_value
+                updated_uvs[record["component"]] = uv_value
+            applied["axis"] = axis.lower().strip()
+            applied["value"] = target_value
+            applied["value_mode"] = value_mode
+
+        elif operation == "distribute_axis":
+            axis_idx = _axis_index(axis)
+            ordered = sorted(before_records, key=lambda record: (record["uv"][axis_idx], record["index"]))
+            start = bounds_before["min"][axis_idx] if start_value is None else _validate_scalar(start_value, "start_value")
+            end = bounds_before["max"][axis_idx] if end_value is None else _validate_scalar(end_value, "end_value")
+            denominator = max(1, len(ordered) - 1)
+            for order_index, record in enumerate(ordered):
+                uv_value = record["uv"][:]
+                uv_value[axis_idx] = start + (end - start) * (order_index / float(denominator))
+                updated_uvs[record["component"]] = uv_value
+            applied["axis"] = axis.lower().strip()
+            applied["start_value"] = start
+            applied["end_value"] = end
+
+        elif operation == "fit_box":
+            updated_uvs, applied = _fit_to_box(before_records, bounds_before)
+
+        _set_uvs(updated_uvs)
+        after_records = _query_uvs(uv_items)
+        bounds_after = _bounds(after_records)
+        cmds.select(uv_items, replace=True)
+
+        return {
+            "success": True,
+            "object_name": object_name,
+            "operation": operation,
+            "uv_set": uv_set or previous_uv_set,
+            "uv_count": len(uv_items),
+            "expand_uv_shell": bool(expand_uv_shell),
+            "bounds_before": bounds_before,
+            "bounds_after": bounds_after,
+            "applied": applied,
+            "before_preview": before_records[:max_preview],
+            "after_preview": after_records[:max_preview],
+        }
+    finally:
+        if uv_set and previous_uv_set and previous_uv_set in all_uv_sets and cmds.objExists(object_name):
+            try:
+                cmds.polyUVSet(object_name, currentUVSet=True, uvSet=previous_uv_set)
+            except Exception:
+                pass

--- a/src/mayatools/object/trim_mesh_by_axis_range.py
+++ b/src/mayatools/object/trim_mesh_by_axis_range.py
@@ -1,0 +1,149 @@
+from typing import Dict, List, Any
+
+
+def trim_mesh_by_axis_range(
+    object_name: str,
+    axis: str = "y",
+    axis_range: List[float] = None,
+    keep_inside: bool = True,
+    sample_mode: str = "center",
+    min_keep_faces: int = 1,
+    dry_run: bool = False,
+    smooth: bool = True,
+) -> Dict[str, Any]:
+    """Delete mesh faces by testing their position along an axis.
+
+    This is a generic mesh cleanup tool for clipping lathed shells, cylinders,
+    pipes, labels, cards, terrain strips, scan fragments, and other polygon
+    geometry to an axial range. Faces can be tested by center, all vertices, or
+    any vertex. Use dry_run to inspect how many faces would be removed before
+    editing the mesh.
+    """
+    import maya.cmds as cmds
+    import maya.api.OpenMaya as om
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(value) for value in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(value) for value in values]
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return value
+
+    if not cmds.objExists(object_name):
+        raise ValueError(f"Object does not exist: {object_name}")
+    if axis_range is None:
+        raise ValueError("axis_range is required.")
+
+    axis = axis.lower().strip()
+    axis_indices = {"x": 0, "y": 1, "z": 2}
+    if axis not in axis_indices:
+        raise ValueError("axis must be one of x, y, or z.")
+    axis_index = axis_indices[axis]
+
+    clean_range = _validate_vector(axis_range, 2, "axis_range")
+    if clean_range[1] < clean_range[0]:
+        clean_range = [clean_range[1], clean_range[0]]
+    if clean_range[1] == clean_range[0]:
+        raise ValueError("axis_range must have non-zero length.")
+
+    if not isinstance(keep_inside, bool):
+        raise ValueError("keep_inside must be a boolean.")
+    if not isinstance(dry_run, bool):
+        raise ValueError("dry_run must be a boolean.")
+    if not isinstance(smooth, bool):
+        raise ValueError("smooth must be a boolean.")
+    min_keep_faces = _validate_int(min_keep_faces, "min_keep_faces", 0)
+
+    sample_mode = sample_mode.lower().strip()
+    if sample_mode not in {"center", "all_vertices", "any_vertex"}:
+        raise ValueError("sample_mode must be center, all_vertices, or any_vertex.")
+
+    shapes = cmds.listRelatives(object_name, shapes=True, fullPath=True) or []
+    if cmds.objectType(object_name) == "mesh":
+        shapes = [object_name]
+    mesh_shapes = [shape for shape in shapes if cmds.objectType(shape) == "mesh"]
+    if not mesh_shapes:
+        raise ValueError(f"{object_name} is not a polygon mesh transform or mesh shape.")
+
+    selection = om.MSelectionList()
+    selection.add(mesh_shapes[0])
+    dag_path = selection.getDagPath(0)
+    mesh_fn = om.MFnMesh(dag_path)
+    points = mesh_fn.getPoints(om.MSpace.kWorld)
+    face_count = mesh_fn.numPolygons
+    if face_count < 1:
+        raise ValueError(f"No polygon faces found on {object_name}.")
+
+    def _inside(value):
+        return clean_range[0] <= value <= clean_range[1]
+
+    matched_faces = []
+    kept_faces = 0
+    min_sample_value = None
+    max_sample_value = None
+    for face_index in range(face_count):
+        vertex_indices = mesh_fn.getPolygonVertices(face_index)
+        values = [points[index][axis_index] for index in vertex_indices]
+        if not values:
+            continue
+        min_value = min(values)
+        max_value = max(values)
+        min_sample_value = min(min_sample_value, min_value) if min_sample_value is not None else min_value
+        max_sample_value = max(max_sample_value, max_value) if max_sample_value is not None else max_value
+
+        if sample_mode == "center":
+            face_is_inside = _inside(sum(values) / float(len(values)))
+        elif sample_mode == "all_vertices":
+            face_is_inside = all(_inside(value) for value in values)
+        else:
+            face_is_inside = any(_inside(value) for value in values)
+
+        should_delete = face_is_inside != keep_inside
+        if should_delete:
+            matched_faces.append(face_index)
+        else:
+            kept_faces += 1
+
+    if kept_faces < min_keep_faces:
+        raise ValueError(
+            f"Axis trim would leave {kept_faces} faces, which is below min_keep_faces={min_keep_faces}."
+        )
+
+    deleted_faces = []
+    if matched_faces and not dry_run:
+        target_transform = object_name
+        if cmds.objectType(object_name) == "mesh":
+            parents = cmds.listRelatives(object_name, parent=True, fullPath=False) or []
+            target_transform = parents[0] if parents else object_name
+        delete_components = [f"{target_transform}.f[{index}]" for index in matched_faces]
+        cmds.delete(delete_components)
+        deleted_faces = delete_components[:]
+        if smooth and cmds.objExists(target_transform):
+            try:
+                cmds.polySoftEdge(target_transform, angle=180, constructionHistory=False)
+            except Exception:
+                pass
+
+    return {
+        "success": True,
+        "object_name": object_name,
+        "axis": axis,
+        "axis_range": clean_range,
+        "keep_inside": bool(keep_inside),
+        "sample_mode": sample_mode,
+        "dry_run": bool(dry_run),
+        "face_count_before": face_count,
+        "matched_face_count": len(matched_faces),
+        "deleted_face_count": len(deleted_faces),
+        "face_count_after": face_count if dry_run else face_count - len(deleted_faces),
+        "min_keep_faces": min_keep_faces,
+        "min_sample_value": min_sample_value,
+        "max_sample_value": max_sample_value,
+        "matched_faces_preview": [f"{object_name}.f[{index}]" for index in matched_faces[:20]],
+    }

--- a/src/mayatools/object/trim_mesh_by_texture.py
+++ b/src/mayatools/object/trim_mesh_by_texture.py
@@ -1,0 +1,244 @@
+from typing import Dict, List, Any
+
+
+def trim_mesh_by_texture(
+    object_name: str,
+    image_path: str,
+    uv_set: str = None,
+    sample_channel: str = "alpha",
+    threshold: float = 0.5,
+    delete_below: bool = True,
+    flip_v: bool = True,
+    wrap_u: bool = False,
+    wrap_v: bool = False,
+    min_keep_faces: int = 1,
+    dry_run: bool = False,
+    smooth: bool = True,
+) -> Dict[str, Any]:
+    """Delete polygon faces by sampling an image through mesh UVs.
+
+    Each face is sampled at its average UV coordinate against the provided
+    image. Faces whose sampled channel falls below or above the threshold can
+    be removed. This is useful for generic alpha-cut labels, decals, panels,
+    cloth cards, leaf cards, vents, grates, masks, and other textured meshes
+    where transparent or masked texture regions should become real cutout
+    geometry instead of relying on viewport or material transparency sorting.
+    """
+    import math
+    import os
+    import maya.cmds as cmds
+
+    try:
+        from PySide6.QtGui import QImage
+    except Exception:
+        try:
+            from PySide2.QtGui import QImage
+        except Exception as exc:
+            raise RuntimeError("PySide QImage is required to sample image pixels in Maya.") from exc
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return value
+
+    def _clamp(value, lower=0.0, upper=1.0):
+        return max(lower, min(upper, value))
+
+    def _wrap_or_clamp(value, wrap):
+        if wrap:
+            return value % 1.0
+        return _clamp(value)
+
+    def _pixel_rgb_alpha(image, x, y):
+        color = image.pixelColor(int(x), int(y))
+        return color.redF(), color.greenF(), color.blueF(), color.alphaF()
+
+    def _sample_bilinear(image, u, v):
+        width = image.width()
+        height = image.height()
+        u = _wrap_or_clamp(u, wrap_u)
+        v = _wrap_or_clamp(v, wrap_v)
+        if flip_v:
+            v = 1.0 - v
+        x = u * float(width - 1)
+        y = v * float(height - 1)
+        x0 = int(math.floor(x))
+        y0 = int(math.floor(y))
+        x1 = min(width - 1, x0 + 1)
+        y1 = min(height - 1, y0 + 1)
+        tx = x - x0
+        ty = y - y0
+        c00 = _pixel_rgb_alpha(image, x0, y0)
+        c10 = _pixel_rgb_alpha(image, x1, y0)
+        c01 = _pixel_rgb_alpha(image, x0, y1)
+        c11 = _pixel_rgb_alpha(image, x1, y1)
+        channels = []
+        for index in range(4):
+            top = c00[index] * (1.0 - tx) + c10[index] * tx
+            bottom = c01[index] * (1.0 - tx) + c11[index] * tx
+            channels.append(top * (1.0 - ty) + bottom * ty)
+        return channels
+
+    def _rgb_to_hsv(red, green, blue):
+        max_value = max(red, green, blue)
+        min_value = min(red, green, blue)
+        delta = max_value - min_value
+        if delta == 0.0:
+            hue = 0.0
+        elif max_value == red:
+            hue = ((green - blue) / delta) % 6.0
+        elif max_value == green:
+            hue = ((blue - red) / delta) + 2.0
+        else:
+            hue = ((red - green) / delta) + 4.0
+        hue /= 6.0
+        saturation = 0.0 if max_value == 0.0 else delta / max_value
+        return hue, saturation, max_value
+
+    def _channel_value(channels):
+        red, green, blue, alpha = channels
+        if sample_channel == "red":
+            return red
+        if sample_channel == "green":
+            return green
+        if sample_channel == "blue":
+            return blue
+        if sample_channel == "alpha":
+            return alpha
+        if sample_channel == "value":
+            return max(red, green, blue)
+        if sample_channel == "saturation":
+            return _rgb_to_hsv(red, green, blue)[1]
+        return 0.2126 * red + 0.7152 * green + 0.0722 * blue
+
+    def _face_uv_center(face):
+        uv_components = cmds.polyListComponentConversion(face, fromFace=True, toUV=True) or []
+        uv_components = cmds.ls(uv_components, flatten=True) or []
+        if not uv_components:
+            return None
+        values = cmds.polyEditUV(uv_components, query=True) or []
+        if len(values) < 2:
+            return None
+        us = values[0::2]
+        vs = values[1::2]
+        return sum(us) / float(len(us)), sum(vs) / float(len(vs))
+
+    if not cmds.objExists(object_name):
+        raise ValueError(f"Object does not exist: {object_name}")
+    if not image_path:
+        raise ValueError("image_path is required.")
+    normalized_image_path = os.path.normpath(image_path)
+    if not os.path.isfile(normalized_image_path):
+        raise ValueError(f"Image path does not exist: {image_path}")
+
+    threshold = _clamp(_validate_scalar(threshold, "threshold"))
+    min_keep_faces = _validate_int(min_keep_faces, "min_keep_faces", 0)
+
+    sample_channel = sample_channel.lower().strip()
+    if sample_channel not in {"alpha", "luminance", "red", "green", "blue", "value", "saturation"}:
+        raise ValueError("sample_channel must be one of alpha, luminance, red, green, blue, value, or saturation.")
+
+    shapes = cmds.listRelatives(object_name, shapes=True, fullPath=True) or []
+    if cmds.objectType(object_name) == "mesh":
+        shapes = [object_name]
+    if not any(cmds.objectType(shape) == "mesh" for shape in shapes):
+        raise ValueError(f"{object_name} is not a polygon mesh transform or mesh shape.")
+
+    all_uv_sets = cmds.polyUVSet(object_name, query=True, allUVSets=True) or []
+    previous_uv_set = None
+    current_uv = cmds.polyUVSet(object_name, query=True, currentUVSet=True) or []
+    if current_uv:
+        previous_uv_set = current_uv[0]
+    if uv_set:
+        if uv_set not in all_uv_sets:
+            raise ValueError(f"UV set {uv_set} does not exist on {object_name}.")
+        cmds.polyUVSet(object_name, currentUVSet=True, uvSet=uv_set)
+    else:
+        uv_set = previous_uv_set
+
+    image = QImage(normalized_image_path)
+    if image.isNull():
+        raise ValueError(f"Unable to load image: {image_path}")
+    if image.width() < 2 or image.height() < 2:
+        raise ValueError("image must be at least 2x2 pixels.")
+
+    face_count = cmds.polyEvaluate(object_name, face=True)
+    if face_count < 1:
+        raise ValueError(f"No polygon faces found on {object_name}.")
+
+    sampled_faces = []
+    delete_faces = []
+    skipped_faces = []
+    sample_values = []
+    for index in range(face_count):
+        face = f"{object_name}.f[{index}]"
+        uv_center = _face_uv_center(face)
+        if uv_center is None:
+            skipped_faces.append(face)
+            continue
+        value = _channel_value(_sample_bilinear(image, uv_center[0], uv_center[1]))
+        should_delete = value < threshold if delete_below else value > threshold
+        sample_values.append(value)
+        face_record = {
+            "face": face,
+            "uv": [uv_center[0], uv_center[1]],
+            "value": value,
+            "delete": should_delete,
+        }
+        sampled_faces.append(face_record)
+        if should_delete:
+            delete_faces.append(face)
+
+    keep_count = face_count - len(delete_faces)
+    if keep_count < min_keep_faces:
+        raise ValueError(
+            f"Texture trim would leave {keep_count} faces, which is below min_keep_faces={min_keep_faces}."
+        )
+
+    deleted_faces = []
+    if delete_faces and not dry_run:
+        cmds.delete(delete_faces)
+        deleted_faces = delete_faces[:]
+        if smooth and cmds.objExists(object_name):
+            cmds.polySoftEdge(object_name, angle=180, constructionHistory=False)
+
+    if previous_uv_set and previous_uv_set in all_uv_sets and previous_uv_set != uv_set and cmds.objExists(object_name):
+        try:
+            cmds.polyUVSet(object_name, currentUVSet=True, uvSet=previous_uv_set)
+        except Exception:
+            pass
+
+    return {
+        "success": True,
+        "object_name": object_name,
+        "image_path": normalized_image_path,
+        "image_width": image.width(),
+        "image_height": image.height(),
+        "uv_set": uv_set,
+        "sample_channel": sample_channel,
+        "threshold": threshold,
+        "delete_below": bool(delete_below),
+        "flip_v": bool(flip_v),
+        "wrap_u": bool(wrap_u),
+        "wrap_v": bool(wrap_v),
+        "dry_run": bool(dry_run),
+        "face_count_before": face_count,
+        "sampled_face_count": len(sampled_faces),
+        "skipped_face_count": len(skipped_faces),
+        "matched_face_count": len(delete_faces),
+        "deleted_face_count": len(deleted_faces),
+        "face_count_after": face_count if dry_run else face_count - len(deleted_faces),
+        "min_sample_value": min(sample_values) if sample_values else 0.0,
+        "max_sample_value": max(sample_values) if sample_values else 0.0,
+        "mean_sample_value": sum(sample_values) / float(len(sample_values)) if sample_values else 0.0,
+        "sampled_faces_preview": sampled_faces[:20],
+        "skipped_faces_preview": skipped_faces[:20],
+    }

--- a/src/mayatools/object/trim_mesh_by_texture.py
+++ b/src/mayatools/object/trim_mesh_by_texture.py
@@ -14,15 +14,20 @@ def trim_mesh_by_texture(
     min_keep_faces: int = 1,
     dry_run: bool = False,
     smooth: bool = True,
+    uv_sample_mode: str = "center",
+    sample_aggregation: str = "mean",
 ) -> Dict[str, Any]:
     """Delete polygon faces by sampling an image through mesh UVs.
 
-    Each face is sampled at its average UV coordinate against the provided
-    image. Faces whose sampled channel falls below or above the threshold can
-    be removed. This is useful for generic alpha-cut labels, decals, panels,
-    cloth cards, leaf cards, vents, grates, masks, and other textured meshes
-    where transparent or masked texture regions should become real cutout
-    geometry instead of relying on viewport or material transparency sorting.
+    Each face is sampled through its UVs against the provided image. Faces
+    whose sampled channel falls below or above the threshold can be removed.
+    uv_sample_mode controls whether each face is sampled at its center, UV
+    vertices, or both. sample_aggregation controls whether those samples are
+    combined by mean, min, or max before thresholding. This is useful for
+    generic alpha-cut labels, decals, panels, cloth cards, leaf cards, vents,
+    grates, masks, and other textured meshes where transparent or masked
+    texture regions should become real cutout geometry instead of relying on
+    viewport or material transparency sorting.
     """
     import math
     import os
@@ -119,7 +124,7 @@ def trim_mesh_by_texture(
             return _rgb_to_hsv(red, green, blue)[1]
         return 0.2126 * red + 0.7152 * green + 0.0722 * blue
 
-    def _face_uv_center(face):
+    def _face_uv_samples(face):
         uv_components = cmds.polyListComponentConversion(face, fromFace=True, toUV=True) or []
         uv_components = cmds.ls(uv_components, flatten=True) or []
         if not uv_components:
@@ -127,9 +132,25 @@ def trim_mesh_by_texture(
         values = cmds.polyEditUV(uv_components, query=True) or []
         if len(values) < 2:
             return None
-        us = values[0::2]
-        vs = values[1::2]
-        return sum(us) / float(len(us)), sum(vs) / float(len(vs))
+        pairs = list(zip(values[0::2], values[1::2]))
+        if not pairs:
+            return None
+        center = (
+            sum(pair[0] for pair in pairs) / float(len(pairs)),
+            sum(pair[1] for pair in pairs) / float(len(pairs)),
+        )
+        if uv_sample_mode == "center":
+            return [center]
+        if uv_sample_mode == "vertices":
+            return pairs
+        return [center] + pairs
+
+    def _aggregate_values(values):
+        if sample_aggregation == "min":
+            return min(values)
+        if sample_aggregation == "max":
+            return max(values)
+        return sum(values) / float(len(values))
 
     if not cmds.objExists(object_name):
         raise ValueError(f"Object does not exist: {object_name}")
@@ -145,6 +166,12 @@ def trim_mesh_by_texture(
     sample_channel = sample_channel.lower().strip()
     if sample_channel not in {"alpha", "luminance", "red", "green", "blue", "value", "saturation"}:
         raise ValueError("sample_channel must be one of alpha, luminance, red, green, blue, value, or saturation.")
+    uv_sample_mode = uv_sample_mode.lower().strip()
+    if uv_sample_mode not in {"center", "vertices", "center_vertices"}:
+        raise ValueError("uv_sample_mode must be one of center, vertices, or center_vertices.")
+    sample_aggregation = sample_aggregation.lower().strip()
+    if sample_aggregation not in {"mean", "min", "max"}:
+        raise ValueError("sample_aggregation must be one of mean, min, or max.")
 
     shapes = cmds.listRelatives(object_name, shapes=True, fullPath=True) or []
     if cmds.objectType(object_name) == "mesh":
@@ -178,19 +205,28 @@ def trim_mesh_by_texture(
     delete_faces = []
     skipped_faces = []
     sample_values = []
+    sample_counts = []
     for index in range(face_count):
         face = f"{object_name}.f[{index}]"
-        uv_center = _face_uv_center(face)
-        if uv_center is None:
+        uv_samples = _face_uv_samples(face)
+        if not uv_samples:
             skipped_faces.append(face)
             continue
-        value = _channel_value(_sample_bilinear(image, uv_center[0], uv_center[1]))
+        values = [
+            _channel_value(_sample_bilinear(image, uv[0], uv[1]))
+            for uv in uv_samples
+        ]
+        value = _aggregate_values(values)
         should_delete = value < threshold if delete_below else value > threshold
         sample_values.append(value)
+        sample_counts.append(len(values))
         face_record = {
             "face": face,
-            "uv": [uv_center[0], uv_center[1]],
+            "uv": [uv_samples[0][0], uv_samples[0][1]],
             "value": value,
+            "sample_count": len(values),
+            "sample_min": min(values),
+            "sample_max": max(values),
             "delete": should_delete,
         }
         sampled_faces.append(face_record)
@@ -230,12 +266,16 @@ def trim_mesh_by_texture(
         "wrap_u": bool(wrap_u),
         "wrap_v": bool(wrap_v),
         "dry_run": bool(dry_run),
+        "uv_sample_mode": uv_sample_mode,
+        "sample_aggregation": sample_aggregation,
         "face_count_before": face_count,
         "sampled_face_count": len(sampled_faces),
         "skipped_face_count": len(skipped_faces),
         "matched_face_count": len(delete_faces),
         "deleted_face_count": len(deleted_faces),
         "face_count_after": face_count if dry_run else face_count - len(deleted_faces),
+        "min_samples_per_face": min(sample_counts) if sample_counts else 0,
+        "max_samples_per_face": max(sample_counts) if sample_counts else 0,
         "min_sample_value": min(sample_values) if sample_values else 0.0,
         "max_sample_value": max(sample_values) if sample_values else 0.0,
         "mean_sample_value": sum(sample_values) / float(len(sample_values)) if sample_values else 0.0,

--- a/src/mayatools/object/uv_operations.py
+++ b/src/mayatools/object/uv_operations.py
@@ -1,0 +1,212 @@
+from typing import Dict, List, Any
+
+
+def uv_operations(
+    object_name: str,
+    operation: str,
+    parameters: Dict[str, Any] = None,
+    uv_set: str = None,
+) -> Dict[str, Any]:
+    """Manage and generate UVs for polygon meshes.
+
+    Operations:
+    - list: report UV sets, current UV set, UV count, and UV range
+    - create_uv_set: create a UV set named uv_set
+    - set_current_uv_set: set uv_set as current
+    - delete_uv_set: delete uv_set
+    - planar: run a planar projection
+    - cylindrical: run a cylindrical projection
+    - spherical: run a spherical projection
+    - automatic: run Maya automatic projection
+    - normalize: normalize UVs into tile space
+    - layout: lay out UV shells
+    """
+    import maya.cmds as cmds
+
+    if not cmds.objExists(object_name):
+        raise ValueError(f"Object does not exist: {object_name}")
+
+    shapes = cmds.listRelatives(object_name, shapes=True, fullPath=True) or []
+    if cmds.objectType(object_name) == "mesh":
+        shapes = [object_name]
+    if not any(cmds.objectType(shape) == "mesh" for shape in shapes):
+        raise ValueError(f"{object_name} is not a polygon mesh transform or mesh shape.")
+
+    if parameters is None:
+        parameters = {}
+
+    operation = operation.lower()
+
+    def _all_faces():
+        return f"{object_name}.f[*]"
+
+    def _uv_range():
+        uv_components = cmds.ls(f"{object_name}.map[*]", flatten=True) or []
+        if not uv_components:
+            return None
+        values = cmds.polyEditUV(uv_components, query=True) or []
+        if not values:
+            return None
+        us = values[0::2]
+        vs = values[1::2]
+        return {
+            "min_u": min(us),
+            "max_u": max(us),
+            "min_v": min(vs),
+            "max_v": max(vs),
+        }
+
+    def _list_info():
+        all_sets = cmds.polyUVSet(object_name, query=True, allUVSets=True) or []
+        current = cmds.polyUVSet(object_name, query=True, currentUVSet=True) or []
+        return {
+            "success": True,
+            "object_name": object_name,
+            "uv_sets": all_sets,
+            "current_uv_set": current[0] if current else None,
+            "uv_count": cmds.polyEvaluate(object_name, uvcoord=True),
+            "uv_range": _uv_range(),
+        }
+
+    if operation == "list":
+        return _list_info()
+
+    if operation == "create_uv_set":
+        if not uv_set:
+            raise ValueError("uv_set is required for create_uv_set.")
+        existing = cmds.polyUVSet(object_name, query=True, allUVSets=True) or []
+        if uv_set not in existing:
+            cmds.polyUVSet(object_name, create=True, uvSet=uv_set)
+        cmds.polyUVSet(object_name, currentUVSet=True, uvSet=uv_set)
+        return _list_info()
+
+    if operation == "set_current_uv_set":
+        if not uv_set:
+            raise ValueError("uv_set is required for set_current_uv_set.")
+        existing = cmds.polyUVSet(object_name, query=True, allUVSets=True) or []
+        if uv_set not in existing:
+            raise ValueError(f"UV set {uv_set} does not exist on {object_name}.")
+        cmds.polyUVSet(object_name, currentUVSet=True, uvSet=uv_set)
+        return _list_info()
+
+    if operation == "delete_uv_set":
+        if not uv_set:
+            raise ValueError("uv_set is required for delete_uv_set.")
+        current = cmds.polyUVSet(object_name, query=True, currentUVSet=True) or []
+        if current and current[0] == uv_set:
+            raise ValueError("Cannot delete the current UV set. Switch to another UV set first.")
+        cmds.polyUVSet(object_name, delete=True, uvSet=uv_set)
+        return _list_info()
+
+    create_new_map = bool(parameters.get("create_new_map", False))
+    construction_history = bool(parameters.get("construction_history", True))
+    world_space = bool(parameters.get("world_space", True))
+
+    def _with_create_new_map(kwargs):
+        if create_new_map:
+            kwargs["createNewMap"] = True
+        return kwargs
+
+    if operation == "planar":
+        result = cmds.polyPlanarProjection(
+            _all_faces(),
+            **_with_create_new_map({
+                "mapDirection": parameters.get("map_direction", "y"),
+                "projectionWidth": parameters.get("projection_width", 1.0),
+                "projectionHeight": parameters.get("projection_height", 1.0),
+                "imageCenter": parameters.get("image_center", [0.5, 0.5]),
+                "imageScale": parameters.get("image_scale", [1.0, 1.0]),
+                "rotate": parameters.get("rotate", [0.0, 0.0, 0.0]),
+                "constructionHistory": construction_history,
+                "worldSpace": world_space,
+            }),
+        )
+        info = _list_info()
+        info.update({"operation": operation, "projection_node": result})
+        return info
+
+    if operation == "cylindrical":
+        result = cmds.polyCylindricalProjection(
+            _all_faces(),
+            **_with_create_new_map({
+                "mapDirection": parameters.get("map_direction", "y"),
+                "projectionWidth": parameters.get("projection_width", 1.0),
+                "projectionHeight": parameters.get("projection_height", 1.0),
+                "imageCenter": parameters.get("image_center", [0.5, 0.5]),
+                "imageScale": parameters.get("image_scale", [1.0, 1.0]),
+                "rotate": parameters.get("rotate", [0.0, 0.0, 0.0]),
+                "constructionHistory": construction_history,
+                "worldSpace": world_space,
+            }),
+        )
+        info = _list_info()
+        info.update({"operation": operation, "projection_node": result})
+        return info
+
+    if operation == "spherical":
+        result = cmds.polySphericalProjection(
+            _all_faces(),
+            **_with_create_new_map({
+                "mapDirection": parameters.get("map_direction", "y"),
+                "projectionWidth": parameters.get("projection_width", 1.0),
+                "projectionHeight": parameters.get("projection_height", 1.0),
+                "imageCenter": parameters.get("image_center", [0.5, 0.5]),
+                "imageScale": parameters.get("image_scale", [1.0, 1.0]),
+                "rotate": parameters.get("rotate", [0.0, 0.0, 0.0]),
+                "constructionHistory": construction_history,
+                "worldSpace": world_space,
+            }),
+        )
+        info = _list_info()
+        info.update({"operation": operation, "projection_node": result})
+        return info
+
+    if operation == "automatic":
+        result = cmds.polyAutoProjection(
+            _all_faces(),
+            **_with_create_new_map({
+                "planes": int(parameters.get("planes", 6)),
+                "layout": int(parameters.get("layout", 2)),
+                "layoutMethod": int(parameters.get("layout_method", 1)),
+                "percentageSpace": float(parameters.get("percentage_space", 2.0)),
+                "optimize": int(parameters.get("optimize", 1)),
+                "constructionHistory": construction_history,
+                "worldSpace": world_space,
+            }),
+        )
+        info = _list_info()
+        info.update({"operation": operation, "projection_node": result})
+        return info
+
+    if operation == "normalize":
+        result = cmds.polyNormalizeUV(
+            _all_faces(),
+            normalizeType=int(parameters.get("normalize_type", 0)),
+            preserveAspectRatio=bool(parameters.get("preserve_aspect_ratio", True)),
+            centerOnTile=bool(parameters.get("center_on_tile", False)),
+            constructionHistory=construction_history,
+            worldSpace=world_space,
+        )
+        info = _list_info()
+        info.update({"operation": operation, "node": result})
+        return info
+
+    if operation == "layout":
+        result = cmds.polyLayoutUV(
+            _all_faces(),
+            layout=int(parameters.get("layout", 2)),
+            layoutMethod=int(parameters.get("layout_method", 1)),
+            percentageSpace=float(parameters.get("percentage_space", 2.0)),
+            rotateForBestFit=int(parameters.get("rotate_for_best_fit", 2)),
+            scale=int(parameters.get("scale", 1)),
+            constructionHistory=construction_history,
+            worldSpace=world_space,
+        )
+        info = _list_info()
+        info.update({"operation": operation, "node": result})
+        return info
+
+    raise ValueError(
+        "Unknown UV operation. Use list, create_uv_set, set_current_uv_set, delete_uv_set, "
+        "planar, cylindrical, spherical, automatic, normalize, or layout."
+    )

--- a/src/mayatools/object/uv_texture_deform.py
+++ b/src/mayatools/object/uv_texture_deform.py
@@ -1,0 +1,346 @@
+from typing import Dict, List, Any
+
+
+def uv_texture_deform(
+    object_name: str,
+    image_path: str,
+    uv_set: str = None,
+    amplitude: float = 0.02,
+    direction: str = "normal",
+    radial_axis: str = "y",
+    center: List[float] = [0.0, 0.0, 0.0],
+    sample_channel: str = "luminance",
+    invert: bool = False,
+    black_point: float = 0.0,
+    white_point: float = 1.0,
+    threshold: float = None,
+    threshold_softness: float = 0.0,
+    neutral_value: float = 0.0,
+    gamma: float = 1.0,
+    flip_v: bool = True,
+    wrap_u: bool = False,
+    wrap_v: bool = False,
+    min_abs_displacement: float = 0.0,
+    smooth: bool = True,
+) -> Dict[str, Any]:
+    """Deform a UV-mapped polygon mesh by sampling an image through vertex UVs.
+
+    Each vertex samples the supplied image at the average of its connected UVs.
+    The sampled value can move vertices along their normals, along a world axis,
+    or radially around a selected axis. This is useful for generic texture to
+    geometry transfer: emboss/deboss details, stamped panels, fabric puckering,
+    decals, relief labels, surface scuffs, grip textures, and other UV-driven
+    displacement workflows.
+    """
+    import math
+    import os
+    import maya.cmds as cmds
+
+    try:
+        from PySide6.QtGui import QImage
+    except Exception:
+        try:
+            from PySide2.QtGui import QImage
+        except Exception as exc:
+            raise RuntimeError("PySide QImage is required to sample image pixels in Maya.") from exc
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(value) for value in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(value) for value in values]
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _clamp(value, lower=0.0, upper=1.0):
+        return max(lower, min(upper, value))
+
+    def _wrap_or_clamp(value, wrap):
+        if wrap:
+            return value % 1.0
+        return _clamp(value)
+
+    def _length(vector):
+        return math.sqrt(sum(component * component for component in vector))
+
+    def _normalize(vector):
+        length = _length(vector)
+        if length <= 1e-12:
+            return None
+        return [component / length for component in vector]
+
+    def _pixel_rgb_alpha(image, x, y):
+        color = image.pixelColor(int(x), int(y))
+        return [color.redF(), color.greenF(), color.blueF(), color.alphaF()]
+
+    def _sample_bilinear(image, u, v):
+        width = image.width()
+        height = image.height()
+        u = _wrap_or_clamp(u, wrap_u)
+        v = _wrap_or_clamp(v, wrap_v)
+        if flip_v:
+            v = 1.0 - v
+        x = u * float(width - 1)
+        y = v * float(height - 1)
+        x0 = int(math.floor(x))
+        y0 = int(math.floor(y))
+        x1 = min(width - 1, x0 + 1)
+        y1 = min(height - 1, y0 + 1)
+        tx = x - x0
+        ty = y - y0
+        c00 = _pixel_rgb_alpha(image, x0, y0)
+        c10 = _pixel_rgb_alpha(image, x1, y0)
+        c01 = _pixel_rgb_alpha(image, x0, y1)
+        c11 = _pixel_rgb_alpha(image, x1, y1)
+        channels = []
+        for index in range(4):
+            top = c00[index] * (1.0 - tx) + c10[index] * tx
+            bottom = c01[index] * (1.0 - tx) + c11[index] * tx
+            channels.append(top * (1.0 - ty) + bottom * ty)
+        return channels
+
+    def _rgb_to_hsv(red, green, blue):
+        max_value = max(red, green, blue)
+        min_value = min(red, green, blue)
+        delta = max_value - min_value
+        if delta == 0.0:
+            hue = 0.0
+        elif max_value == red:
+            hue = ((green - blue) / delta) % 6.0
+        elif max_value == green:
+            hue = ((blue - red) / delta) + 2.0
+        else:
+            hue = ((red - green) / delta) + 4.0
+        hue /= 6.0
+        saturation = 0.0 if max_value == 0.0 else delta / max_value
+        return hue, saturation, max_value
+
+    def _channel_value(channels):
+        red, green, blue, alpha = channels
+        if sample_channel == "red":
+            return red
+        if sample_channel == "green":
+            return green
+        if sample_channel == "blue":
+            return blue
+        if sample_channel == "alpha":
+            return alpha
+        if sample_channel == "value":
+            return max(red, green, blue)
+        if sample_channel == "saturation":
+            return _rgb_to_hsv(red, green, blue)[1]
+        return 0.2126 * red + 0.7152 * green + 0.0722 * blue
+
+    def _sample_value(image, u, v):
+        value = _channel_value(_sample_bilinear(image, u, v))
+        value = _clamp((value - black_point) / max(1e-9, white_point - black_point))
+        if invert:
+            value = 1.0 - value
+        if threshold is not None:
+            if threshold_softness <= 0.0:
+                value = 1.0 if value >= threshold else 0.0
+            else:
+                lower = threshold - threshold_softness * 0.5
+                upper = threshold + threshold_softness * 0.5
+                value = _clamp((value - lower) / max(1e-9, upper - lower))
+                value = value * value * (3.0 - 2.0 * value)
+        if gamma != 1.0:
+            value = value ** gamma
+        return value
+
+    def _vertex_uv(vertex):
+        uv_components = cmds.polyListComponentConversion(vertex, fromVertex=True, toUV=True) or []
+        uv_components = cmds.ls(uv_components, flatten=True) or []
+        if not uv_components:
+            return None
+        values = cmds.polyEditUV(uv_components, query=True) or []
+        if len(values) < 2:
+            return None
+        us = values[0::2]
+        vs = values[1::2]
+        return sum(us) / float(len(us)), sum(vs) / float(len(vs))
+
+    def _vertex_normal(vertex):
+        values = cmds.polyNormalPerVertex(vertex, query=True, xyz=True) or []
+        if len(values) < 3:
+            return None
+        normals = []
+        for index in range(0, len(values) - 2, 3):
+            normal = _normalize([values[index], values[index + 1], values[index + 2]])
+            if normal is not None:
+                normals.append(normal)
+        if not normals:
+            return None
+        averaged = [
+            sum(normal[axis_index] for normal in normals) / float(len(normals))
+            for axis_index in range(3)
+        ]
+        return _normalize(averaged)
+
+    def _direction_vector(vertex, position):
+        if direction == "normal":
+            return _vertex_normal(vertex)
+        if direction in axis_vectors:
+            return axis_vectors[direction][:]
+        axis_index, radial_a, radial_b = radial_axes[radial_axis]
+        vector = [0.0, 0.0, 0.0]
+        vector[radial_a] = position[radial_a] - center[radial_a]
+        vector[radial_b] = position[radial_b] - center[radial_b]
+        return _normalize(vector)
+
+    if not cmds.objExists(object_name):
+        raise ValueError(f"Object does not exist: {object_name}")
+    if not image_path:
+        raise ValueError("image_path is required.")
+    normalized_image_path = os.path.normpath(image_path)
+    if not os.path.isfile(normalized_image_path):
+        raise ValueError(f"Image path does not exist: {image_path}")
+
+    amplitude = _validate_scalar(amplitude, "amplitude")
+    center = _validate_vector(center, 3, "center")
+    black_point = _validate_scalar(black_point, "black_point")
+    white_point = _validate_scalar(white_point, "white_point")
+    if abs(white_point - black_point) <= 1e-9:
+        raise ValueError("white_point must differ from black_point.")
+    if threshold is not None:
+        threshold = _validate_scalar(threshold, "threshold")
+    threshold_softness = _validate_scalar(threshold_softness, "threshold_softness")
+    if threshold_softness < 0.0:
+        raise ValueError("threshold_softness must be greater than or equal to zero.")
+    neutral_value = _validate_scalar(neutral_value, "neutral_value")
+    gamma = _validate_scalar(gamma, "gamma")
+    if gamma <= 0.0:
+        raise ValueError("gamma must be greater than zero.")
+    min_abs_displacement = _validate_scalar(min_abs_displacement, "min_abs_displacement")
+    if min_abs_displacement < 0.0:
+        raise ValueError("min_abs_displacement must be greater than or equal to zero.")
+
+    direction = direction.lower().strip()
+    axis_vectors = {
+        "x": [1.0, 0.0, 0.0],
+        "y": [0.0, 1.0, 0.0],
+        "z": [0.0, 0.0, 1.0],
+        "-x": [-1.0, 0.0, 0.0],
+        "-y": [0.0, -1.0, 0.0],
+        "-z": [0.0, 0.0, -1.0],
+    }
+    if direction not in {"normal", "radial", *axis_vectors.keys()}:
+        raise ValueError("direction must be normal, radial, x, y, z, -x, -y, or -z.")
+    radial_axis = radial_axis.lower().strip()
+    radial_axes = {
+        "x": (0, 1, 2),
+        "y": (1, 0, 2),
+        "z": (2, 0, 1),
+    }
+    if radial_axis not in radial_axes:
+        raise ValueError("radial_axis must be one of x, y, or z.")
+    sample_channel = sample_channel.lower().strip()
+    if sample_channel not in {"luminance", "red", "green", "blue", "alpha", "value", "saturation"}:
+        raise ValueError("sample_channel must be one of luminance, red, green, blue, alpha, value, or saturation.")
+
+    shapes = cmds.listRelatives(object_name, shapes=True, fullPath=True) or []
+    if cmds.objectType(object_name) == "mesh":
+        shapes = [object_name]
+    if not any(cmds.objectType(shape) == "mesh" for shape in shapes):
+        raise ValueError(f"{object_name} is not a polygon mesh transform or mesh shape.")
+
+    all_uv_sets = cmds.polyUVSet(object_name, query=True, allUVSets=True) or []
+    previous_uv_set = None
+    current_uv = cmds.polyUVSet(object_name, query=True, currentUVSet=True) or []
+    if current_uv:
+        previous_uv_set = current_uv[0]
+    if uv_set:
+        if uv_set not in all_uv_sets:
+            raise ValueError(f"UV set {uv_set} does not exist on {object_name}.")
+        cmds.polyUVSet(object_name, currentUVSet=True, uvSet=uv_set)
+    else:
+        uv_set = previous_uv_set
+
+    image = QImage(normalized_image_path)
+    if image.isNull():
+        raise ValueError(f"Unable to load image: {image_path}")
+    if image.width() < 2 or image.height() < 2:
+        raise ValueError("image must be at least 2x2 pixels.")
+
+    vertices = cmds.ls(f"{object_name}.vtx[*]", flatten=True) or []
+    if not vertices:
+        raise ValueError(f"No vertices found on {object_name}.")
+
+    sampled_vertices = 0
+    deformed_vertices = 0
+    skipped_vertices = 0
+    sample_values = []
+    displacement_values = []
+    for vertex in vertices:
+        uv = _vertex_uv(vertex)
+        if uv is None:
+            skipped_vertices += 1
+            continue
+        sampled = _sample_value(image, uv[0], uv[1])
+        displacement = amplitude * (sampled - neutral_value)
+        sampled_vertices += 1
+        sample_values.append(sampled)
+        if abs(displacement) <= min_abs_displacement:
+            continue
+
+        position = cmds.xform(vertex, query=True, worldSpace=True, translation=True)
+        vector = _direction_vector(vertex, position)
+        if vector is None:
+            skipped_vertices += 1
+            continue
+        new_position = [
+            position[index] + vector[index] * displacement
+            for index in range(3)
+        ]
+        cmds.xform(vertex, worldSpace=True, translation=new_position)
+        deformed_vertices += 1
+        displacement_values.append(displacement)
+
+    if previous_uv_set and previous_uv_set in all_uv_sets and previous_uv_set != uv_set and cmds.objExists(object_name):
+        try:
+            cmds.polyUVSet(object_name, currentUVSet=True, uvSet=previous_uv_set)
+        except Exception:
+            pass
+
+    if smooth and cmds.objExists(object_name):
+        cmds.polySoftEdge(object_name, angle=180, constructionHistory=False)
+
+    return {
+        "success": True,
+        "object_name": object_name,
+        "image_path": normalized_image_path,
+        "image_width": image.width(),
+        "image_height": image.height(),
+        "uv_set": uv_set,
+        "amplitude": amplitude,
+        "direction": direction,
+        "radial_axis": radial_axis,
+        "center": center,
+        "sample_channel": sample_channel,
+        "invert": bool(invert),
+        "black_point": black_point,
+        "white_point": white_point,
+        "threshold": threshold,
+        "threshold_softness": threshold_softness,
+        "neutral_value": neutral_value,
+        "gamma": gamma,
+        "flip_v": bool(flip_v),
+        "wrap_u": bool(wrap_u),
+        "wrap_v": bool(wrap_v),
+        "min_abs_displacement": min_abs_displacement,
+        "vertex_count": len(vertices),
+        "sampled_vertices": sampled_vertices,
+        "deformed_vertices": deformed_vertices,
+        "skipped_vertices": skipped_vertices,
+        "min_sample_value": min(sample_values) if sample_values else 0.0,
+        "max_sample_value": max(sample_values) if sample_values else 0.0,
+        "mean_sample_value": sum(sample_values) / float(len(sample_values)) if sample_values else 0.0,
+        "min_displacement": min(displacement_values) if displacement_values else 0.0,
+        "max_displacement": max(displacement_values) if displacement_values else 0.0,
+        "bounding_box": cmds.exactWorldBoundingBox(object_name) if cmds.objExists(object_name) else None,
+    }

--- a/src/mayatools/scene/audit_scene_strings.py
+++ b/src/mayatools/scene/audit_scene_strings.py
@@ -1,0 +1,348 @@
+from typing import Any, Dict, List
+
+
+def audit_scene_strings(
+    pattern: str = None,
+    preset: str = "cjk",
+    categories: List[str] = None,
+    include_default_nodes: bool = False,
+    long_names: bool = True,
+    case_sensitive: bool = True,
+    max_results: int = 1000,
+) -> Dict[str, Any]:
+    """Audit scene names, node names, texture paths, and related strings.
+
+    The tool reports values that match a configurable regular expression. It is
+    useful for pipeline naming checks such as CJK characters, non-ASCII text,
+    whitespace, or Maya-unsafe characters. It only inspects the scene and does
+    not rename nodes, repair paths, or save files.
+    """
+    import os
+    import re
+    import maya.cmds as cmds
+
+    preset_patterns = {
+        "cjk": r"[\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff]",
+        "non_ascii": r"[^\x00-\x7f]",
+        "whitespace": r"\s",
+        "maya_unsafe": r"[<>:\"/\\|?*\[\]{};]",
+    }
+    default_categories = [
+        "scene",
+        "dag",
+        "dependency_nodes",
+        "transforms",
+        "shapes",
+        "geometry",
+        "cameras",
+        "lights",
+        "curves",
+        "materials",
+        "shading_groups",
+        "textures",
+        "file_textures",
+        "namespaces",
+        "references",
+        "sets",
+        "display_layers",
+        "render_layers",
+    ]
+    category_aliases = {
+        "all": "all",
+        "*": "all",
+        "dependency": "dependency_nodes",
+        "dependency_node": "dependency_nodes",
+        "dependency_nodes": "dependency_nodes",
+        "dag_nodes": "dag",
+        "object_sets": "sets",
+        "object_set": "sets",
+        "set": "sets",
+        "display_layer": "display_layers",
+        "render_layer": "render_layers",
+        "render_layers": "render_layers",
+        "shading_group": "shading_groups",
+        "shading_engine": "shading_groups",
+        "shading_engines": "shading_groups",
+        "file": "file_textures",
+        "files": "file_textures",
+        "file_texture": "file_textures",
+    }
+    default_node_names = {
+        "defaultColorMgtGlobals",
+        "defaultHardwareRenderGlobals",
+        "defaultLightList1",
+        "defaultLightSet",
+        "defaultObjectSet",
+        "defaultRenderGlobals",
+        "defaultRenderLayer",
+        "defaultResolution",
+        "defaultShaderList1",
+        "defaultTextureList1",
+        "defaultViewColorManager",
+        "displayLayerManager",
+        "front",
+        "frontShape",
+        "hardwareRenderGlobals",
+        "hardwareRenderingGlobals",
+        "initialParticleSE",
+        "initialShadingGroup",
+        "lambert1",
+        "lightLinker1",
+        "particleCloud1",
+        "persp",
+        "perspShape",
+        "postProcessList1",
+        "renderLayerManager",
+        "renderPartition",
+        "sequenceManager1",
+        "shaderGlow1",
+        "side",
+        "sideShape",
+        "standardSurface1",
+        "time1",
+        "top",
+        "topShape",
+        "UI",
+        "shared",
+    }
+    default_prefixes = (
+        "default",
+        "initial",
+        "lightLinker",
+        "renderPartition",
+        "shaderGlow",
+        "time",
+        "uiConfigurationScriptNode",
+    )
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return int(value)
+
+    def _as_categories(values):
+        if values is None:
+            return default_categories[:]
+        if isinstance(values, str):
+            values = [values]
+        if not isinstance(values, list) or not all(isinstance(value, str) for value in values):
+            raise ValueError("categories must be a string, list of strings, or None.")
+        normalized = []
+        for value in values:
+            key = value.lower().strip().replace("-", "_")
+            key = category_aliases.get(key, key)
+            if key == "all":
+                return default_categories[:]
+            if key not in default_categories:
+                raise ValueError(f"Unsupported category: {value}. Supported categories: {', '.join(default_categories)}.")
+            if key not in normalized:
+                normalized.append(key)
+        return normalized
+
+    def _short_name(node):
+        if not node:
+            return node
+        return str(node).split("|")[-1]
+
+    def _base_name(node):
+        short = _short_name(node)
+        return short.split(":")[-1] if short else short
+
+    def _is_default_node(node):
+        clean = _base_name(node)
+        return clean in default_node_names or any(clean.startswith(prefix) for prefix in default_prefixes)
+
+    def _node_type(node):
+        if not node or not cmds.objExists(node):
+            return None
+        try:
+            return cmds.objectType(node)
+        except Exception:
+            return None
+
+    def _unique(values):
+        result = []
+        seen = set()
+        for value in values or []:
+            if value in seen:
+                continue
+            seen.add(value)
+            result.append(value)
+        return result
+
+    def _add_record(records, category, field, value, node=None, node_type=None, path_exists=None):
+        if value is None:
+            return
+        value = str(value)
+        if not value:
+            return
+        if node and not include_default_nodes and _is_default_node(node):
+            return
+        records.append(
+            {
+                "category": category,
+                "field": field,
+                "node": node,
+                "node_type": node_type if node_type is not None else _node_type(node),
+                "value": value,
+                "path_exists": path_exists,
+            }
+        )
+
+    def _add_node_name(records, category, node, field="node_name"):
+        _add_record(records, category, field, node, node=node)
+
+    def _add_dag_node(records, node):
+        _add_record(records, "dag", "dag_path", node, node=node)
+        short = _short_name(node)
+        if short and short != node:
+            _add_record(records, "dag", "short_name", short, node=node)
+        for segment in [part for part in str(node).split("|") if part]:
+            _add_record(records, "dag", "path_segment", segment, node=node)
+
+    def _add_scene(records):
+        scene_path = cmds.file(query=True, sceneName=True) or ""
+        if scene_path:
+            clean_path = os.path.normpath(scene_path).replace("\\", "/")
+            _add_record(records, "scene", "scene_path", clean_path, path_exists=os.path.exists(clean_path))
+            _add_record(records, "scene", "scene_basename", os.path.basename(clean_path), path_exists=os.path.exists(clean_path))
+            scene_dir = os.path.dirname(clean_path)
+            _add_record(records, "scene", "scene_directory", scene_dir, path_exists=os.path.isdir(scene_dir))
+
+    def _add_nodes_by_ls(records, category, field, **kwargs):
+        for node in _unique(cmds.ls(**kwargs) or []):
+            _add_node_name(records, category, node, field)
+
+    def _add_references(records):
+        for ref_node in _unique(cmds.ls(type="reference") or []):
+            if ref_node == "sharedReferenceNode" and not include_default_nodes:
+                continue
+            _add_node_name(records, "references", ref_node, "reference_node")
+            try:
+                ref_path = cmds.referenceQuery(ref_node, filename=True)
+                if ref_path:
+                    clean_path = os.path.normpath(ref_path).replace("\\", "/")
+                    _add_record(records, "references", "reference_path", clean_path, node=ref_node, node_type="reference", path_exists=os.path.exists(clean_path))
+                    _add_record(records, "references", "reference_basename", os.path.basename(clean_path), node=ref_node, node_type="reference", path_exists=os.path.exists(clean_path))
+            except Exception:
+                pass
+
+    def _add_file_textures(records):
+        for node in _unique(cmds.ls(type="file") or []):
+            _add_node_name(records, "file_textures", node, "file_node")
+            try:
+                raw_path = cmds.getAttr(f"{node}.fileTextureName") or ""
+            except Exception:
+                raw_path = ""
+            if raw_path:
+                clean_path = os.path.normpath(raw_path).replace("\\", "/")
+                _add_record(records, "file_textures", "fileTextureName", clean_path, node=node, node_type="file", path_exists=os.path.exists(clean_path))
+                _add_record(records, "file_textures", "texture_basename", os.path.basename(clean_path), node=node, node_type="file", path_exists=os.path.exists(clean_path))
+                texture_dir = os.path.dirname(clean_path)
+                _add_record(records, "file_textures", "texture_directory", texture_dir, node=node, node_type="file", path_exists=os.path.isdir(texture_dir))
+
+    def _add_namespaces(records):
+        namespaces = []
+        try:
+            namespaces = cmds.namespaceInfo(listOnlyNamespaces=True, recurse=True) or []
+        except Exception:
+            pass
+        for namespace in _unique(namespaces):
+            if not include_default_nodes and namespace in {"UI", "shared"}:
+                continue
+            _add_record(records, "namespaces", "namespace", namespace)
+
+    clean_preset = (preset or "cjk").lower().strip()
+    if clean_preset == "custom":
+        if not pattern:
+            raise ValueError("pattern is required when preset is custom.")
+        regex_pattern = pattern
+    elif clean_preset in preset_patterns:
+        if pattern:
+            regex_pattern = pattern
+        else:
+            regex_pattern = preset_patterns[clean_preset]
+    else:
+        raise ValueError("preset must be cjk, non_ascii, whitespace, maya_unsafe, or custom.")
+
+    max_results = _validate_int(max_results, "max_results", 1)
+    flags = 0 if case_sensitive else re.IGNORECASE
+    regex = re.compile(regex_pattern, flags)
+    selected_categories = _as_categories(categories)
+
+    records = []
+    if "scene" in selected_categories:
+        _add_scene(records)
+    if "dag" in selected_categories:
+        for node in _unique(cmds.ls(dag=True, long=bool(long_names)) or []):
+            if include_default_nodes or not _is_default_node(node):
+                _add_dag_node(records, node)
+    if "dependency_nodes" in selected_categories:
+        for node in _unique(cmds.ls(dependencyNodes=True) or []):
+            _add_node_name(records, "dependency_nodes", node)
+    if "transforms" in selected_categories:
+        _add_nodes_by_ls(records, "transforms", "transform", type="transform", long=bool(long_names))
+    if "shapes" in selected_categories:
+        _add_nodes_by_ls(records, "shapes", "shape", shapes=True, long=bool(long_names))
+    if "geometry" in selected_categories:
+        for node_type_name in ["mesh", "nurbsSurface", "subdiv", "nurbsCurve", "bezierCurve"]:
+            for node in _unique(cmds.ls(type=node_type_name, long=bool(long_names)) or []):
+                _add_node_name(records, "geometry", node, node_type_name)
+    if "cameras" in selected_categories:
+        _add_nodes_by_ls(records, "cameras", "camera", cameras=True, long=bool(long_names))
+    if "lights" in selected_categories:
+        _add_nodes_by_ls(records, "lights", "light", lights=True, long=bool(long_names))
+    if "curves" in selected_categories:
+        for node_type_name in ["nurbsCurve", "bezierCurve"]:
+            for node in _unique(cmds.ls(type=node_type_name, long=bool(long_names)) or []):
+                _add_node_name(records, "curves", node, node_type_name)
+    if "materials" in selected_categories:
+        _add_nodes_by_ls(records, "materials", "material", materials=True)
+    if "shading_groups" in selected_categories:
+        _add_nodes_by_ls(records, "shading_groups", "shading_group", type="shadingEngine")
+    if "textures" in selected_categories:
+        _add_nodes_by_ls(records, "textures", "texture", textures=True)
+    if "file_textures" in selected_categories:
+        _add_file_textures(records)
+    if "namespaces" in selected_categories:
+        _add_namespaces(records)
+    if "references" in selected_categories:
+        _add_references(records)
+    if "sets" in selected_categories:
+        _add_nodes_by_ls(records, "sets", "object_set", type="objectSet")
+    if "display_layers" in selected_categories:
+        _add_nodes_by_ls(records, "display_layers", "display_layer", type="displayLayer")
+    if "render_layers" in selected_categories:
+        _add_nodes_by_ls(records, "render_layers", "render_layer", type="renderLayer")
+
+    unique_records = []
+    seen_records = set()
+    for record in records:
+        key = (record["category"], record["field"], record["node"], record["value"])
+        if key in seen_records:
+            continue
+        seen_records.add(key)
+        unique_records.append(record)
+
+    matches = []
+    match_count = 0
+    for record in unique_records:
+        match = regex.search(record["value"])
+        if not match:
+            continue
+        match_count += 1
+        if len(matches) < max_results:
+            item = dict(record)
+            item["matched_text"] = match.group(0)
+            matches.append(item)
+
+    return {
+        "success": match_count == 0,
+        "preset": clean_preset,
+        "pattern": regex_pattern,
+        "scanned_count": len(unique_records),
+        "match_count": match_count,
+        "truncated": match_count > len(matches),
+        "categories_scanned": selected_categories,
+        "matches": matches,
+    }

--- a/src/mayatools/scene/compare_image_appearance.py
+++ b/src/mayatools/scene/compare_image_appearance.py
@@ -22,6 +22,9 @@ def compare_image_appearance(
     band_edges_normalized: List[float] = None,
     grid_rows: int = 0,
     grid_columns: int = 0,
+    auto_crop_reference: bool = False,
+    auto_crop_candidate: bool = False,
+    auto_crop_padding_pixels: int = 0,
 ) -> Dict[str, Any]:
     """Compare aligned image appearance with color-error metrics.
 
@@ -31,7 +34,8 @@ def compare_image_appearance(
     optional alpha/foreground masks, computes RGB and luminance error metrics,
     optionally summarizes errors by vertical bands or a 2D grid, and can write
     a three-panel diagnostic image: reference, candidate, and heatmapped
-    absolute difference.
+    absolute difference. Optional foreground auto-cropping is useful when
+    renders are centered on a larger product-preview canvas.
     """
     import math
     import os
@@ -177,6 +181,35 @@ def compare_image_appearance(
             mask.append(row)
         return mask, count
 
+    def _auto_crop_bbox(image, bg_color, padding_pixels, image_arg):
+        width = image.width()
+        height = image.height()
+        min_x = width
+        min_y = height
+        max_x = -1
+        max_y = -1
+        foreground_pixels = 0
+        for y in range(height):
+            for x in range(width):
+                red, green, blue, alpha = _pixel_rgb_alpha(image, x, y)
+                if alpha >= alpha_threshold and _color_distance((red, green, blue), bg_color) > background_tolerance:
+                    min_x = min(min_x, x)
+                    min_y = min(min_y, y)
+                    max_x = max(max_x, x)
+                    max_y = max(max_y, y)
+                    foreground_pixels += 1
+        if foreground_pixels < min_compare_pixels:
+            raise ValueError(
+                f"Unable to auto-crop {image_arg}: not enough foreground pixels. "
+                "Adjust background colors, tolerances, alpha threshold, or provide an explicit bbox."
+            )
+        return [
+            max(0, min_x - padding_pixels),
+            max(0, min_y - padding_pixels),
+            min(width - 1, max_x + padding_pixels),
+            min(height - 1, max_y + padding_pixels),
+        ]
+
     def _combine_masks(reference_mask, candidate_mask):
         combined = []
         count = 0
@@ -287,6 +320,11 @@ def compare_image_appearance(
     compare_width = _validate_int(compare_width, "compare_width", 8)
     compare_height = _validate_int(compare_height, "compare_height", 8)
     min_compare_pixels = _validate_int(min_compare_pixels, "min_compare_pixels", 1)
+    auto_crop_padding_pixels = _validate_int(auto_crop_padding_pixels, "auto_crop_padding_pixels", 0)
+    if not isinstance(auto_crop_reference, bool):
+        raise ValueError("auto_crop_reference must be a boolean.")
+    if not isinstance(auto_crop_candidate, bool):
+        raise ValueError("auto_crop_candidate must be a boolean.")
     if not isinstance(grid_rows, int) or isinstance(grid_rows, bool) or grid_rows < 0:
         raise ValueError("grid_rows must be an integer greater than or equal to zero.")
     if not isinstance(grid_columns, int) or isinstance(grid_columns, bool) or grid_columns < 0:
@@ -312,20 +350,30 @@ def compare_image_appearance(
     reference_background = _normalize_color(reference_background_color, "reference_background_color") or shared_background
     candidate_background = _normalize_color(candidate_background_color, "candidate_background_color") or shared_background
 
-    reference_bbox = _bbox_from_args(
-        reference_image,
-        reference_bbox_pixels,
-        reference_bbox_normalized,
-        "reference_bbox_pixels",
-        "reference_bbox_normalized",
-    )
-    candidate_bbox = _bbox_from_args(
-        candidate_image,
-        candidate_bbox_pixels,
-        candidate_bbox_normalized,
-        "candidate_bbox_pixels",
-        "candidate_bbox_normalized",
-    )
+    if auto_crop_reference and reference_bbox_pixels is None and reference_bbox_normalized is None:
+        if reference_background is None:
+            reference_background = _estimate_background(reference_image)
+        reference_bbox = _auto_crop_bbox(reference_image, reference_background, auto_crop_padding_pixels, "reference_image_path")
+    else:
+        reference_bbox = _bbox_from_args(
+            reference_image,
+            reference_bbox_pixels,
+            reference_bbox_normalized,
+            "reference_bbox_pixels",
+            "reference_bbox_normalized",
+        )
+    if auto_crop_candidate and candidate_bbox_pixels is None and candidate_bbox_normalized is None:
+        if candidate_background is None:
+            candidate_background = _estimate_background(candidate_image)
+        candidate_bbox = _auto_crop_bbox(candidate_image, candidate_background, auto_crop_padding_pixels, "candidate_image_path")
+    else:
+        candidate_bbox = _bbox_from_args(
+            candidate_image,
+            candidate_bbox_pixels,
+            candidate_bbox_normalized,
+            "candidate_bbox_pixels",
+            "candidate_bbox_normalized",
+        )
 
     reference_scaled = _crop_and_scale(reference_image, reference_bbox)
     candidate_scaled = _crop_and_scale(candidate_image, candidate_bbox)
@@ -466,6 +514,9 @@ def compare_image_appearance(
         "band_edges_normalized": band_edges,
         "grid_rows": grid_rows,
         "grid_columns": grid_columns,
+        "auto_crop_reference": auto_crop_reference,
+        "auto_crop_candidate": auto_crop_candidate,
+        "auto_crop_padding_pixels": auto_crop_padding_pixels,
         "mask_mode": mask_mode,
         "comparison_mask_mode": comparison_mask_mode,
         "reference_background_color": reference_background,

--- a/src/mayatools/scene/compare_image_appearance.py
+++ b/src/mayatools/scene/compare_image_appearance.py
@@ -19,6 +19,7 @@ def compare_image_appearance(
     compare_width: int = 256,
     compare_height: int = 512,
     min_compare_pixels: int = 16,
+    band_edges_normalized: List[float] = None,
 ) -> Dict[str, Any]:
     """Compare aligned image appearance with color-error metrics.
 
@@ -26,8 +27,8 @@ def compare_image_appearance(
     product previews, and reference-matching workflows. It crops reference and
     candidate images, stretches both crops to a shared comparison size, builds
     optional alpha/foreground masks, computes RGB and luminance error metrics,
-    and can write a three-panel diagnostic image: reference, candidate, and
-    heatmapped absolute difference.
+    optionally summarizes errors by vertical bands, and can write a three-panel
+    diagnostic image: reference, candidate, and heatmapped absolute difference.
     """
     import math
     import os
@@ -205,6 +206,78 @@ def compare_image_appearance(
             return _make_color(1.0, (heat - 0.5) / 0.35, 0.0)
         return _make_color(1.0, 1.0, (heat - 0.85) / 0.15)
 
+    def _validate_band_edges(values):
+        if values is None:
+            return None
+        if not isinstance(values, list) or len(values) < 2 or not all(_is_number(value) for value in values):
+            raise ValueError("band_edges_normalized must be a list of at least two numeric values.")
+        edges = [_clamp(float(value)) for value in values]
+        if edges[0] != 0.0:
+            edges.insert(0, 0.0)
+        if edges[-1] != 1.0:
+            edges.append(1.0)
+        for index in range(len(edges) - 1):
+            if edges[index + 1] <= edges[index]:
+                raise ValueError("band_edges_normalized values must be strictly increasing.")
+        return edges
+
+    def _new_stats():
+        return {
+            "pixels": 0,
+            "sum_abs": [0.0, 0.0, 0.0],
+            "sum_squared": [0.0, 0.0, 0.0],
+            "sum_signed": [0.0, 0.0, 0.0],
+            "luminance_abs": 0.0,
+            "luminance_squared": 0.0,
+            "luminance_signed": 0.0,
+            "max_abs_error": 0.0,
+        }
+
+    def _update_stats(stats, rgb_delta, luma_delta):
+        stats["pixels"] += 1
+        stats["luminance_abs"] += abs(luma_delta)
+        stats["luminance_squared"] += luma_delta * luma_delta
+        stats["luminance_signed"] += luma_delta
+        for index in range(3):
+            abs_delta = abs(rgb_delta[index])
+            stats["sum_abs"][index] += abs_delta
+            stats["sum_squared"][index] += rgb_delta[index] * rgb_delta[index]
+            stats["sum_signed"][index] += rgb_delta[index]
+            stats["max_abs_error"] = max(stats["max_abs_error"], abs_delta)
+
+    def _finalize_stats(stats, extra=None):
+        result = dict(extra or {})
+        if stats["pixels"] <= 0:
+            result.update({
+                "pixels": 0,
+                "mean_abs_error_rgb": [None, None, None],
+                "mean_signed_error_rgb": [None, None, None],
+                "rmse_rgb": [None, None, None],
+                "mean_abs_error": None,
+                "rmse": None,
+                "max_abs_error": None,
+                "mean_abs_luminance_error": None,
+                "mean_signed_luminance_error": None,
+                "luminance_rmse": None,
+            })
+            return result
+        inv = 1.0 / stats["pixels"]
+        mean_abs_rgb = [value * inv for value in stats["sum_abs"]]
+        rmse_rgb_values = [math.sqrt(value * inv) for value in stats["sum_squared"]]
+        result.update({
+            "pixels": stats["pixels"],
+            "mean_abs_error_rgb": mean_abs_rgb,
+            "mean_signed_error_rgb": [value * inv for value in stats["sum_signed"]],
+            "rmse_rgb": rmse_rgb_values,
+            "mean_abs_error": sum(mean_abs_rgb) / 3.0,
+            "rmse": math.sqrt(sum(value * inv for value in stats["sum_squared"]) / 3.0),
+            "max_abs_error": stats["max_abs_error"],
+            "mean_abs_luminance_error": stats["luminance_abs"] * inv,
+            "mean_signed_luminance_error": stats["luminance_signed"] * inv,
+            "luminance_rmse": math.sqrt(stats["luminance_squared"] * inv),
+        })
+        return result
+
     reference_path, reference_image = _load_image(reference_image_path, "reference_image_path")
     candidate_path, candidate_image = _load_image(candidate_image_path, "candidate_image_path")
 
@@ -224,6 +297,7 @@ def compare_image_appearance(
     comparison_mask_mode = comparison_mask_mode.lower().strip()
     if comparison_mask_mode not in {"intersection", "union", "reference", "candidate", "all"}:
         raise ValueError("comparison_mask_mode must be intersection, union, reference, candidate, or all.")
+    band_edges = _validate_band_edges(band_edges_normalized)
 
     shared_background = _normalize_color(background_color, "background_color")
     reference_background = _normalize_color(reference_background_color, "reference_background_color") or shared_background
@@ -272,6 +346,10 @@ def compare_image_appearance(
     luminance_abs = 0.0
     luminance_squared = 0.0
     luminance_signed = 0.0
+    band_stats = []
+    if band_edges:
+        for band_index in range(len(band_edges) - 1):
+            band_stats.append(_new_stats())
 
     diff_image = None
     if output_path:
@@ -297,8 +375,10 @@ def compare_image_appearance(
             luminance_abs += abs(luma_delta)
             luminance_squared += luma_delta * luma_delta
             pixel_abs_sum = 0.0
+            rgb_delta = [0.0, 0.0, 0.0]
             for index in range(3):
                 delta = candidate_rgb[index] - ref_rgb[index]
+                rgb_delta[index] = delta
                 abs_delta = abs(delta)
                 sum_reference[index] += ref_rgb[index]
                 sum_candidate[index] += candidate_rgb[index]
@@ -307,6 +387,12 @@ def compare_image_appearance(
                 sum_squared[index] += delta * delta
                 max_abs_error = max(max_abs_error, abs_delta)
                 pixel_abs_sum += abs_delta
+            if band_edges:
+                y_normalized = y / float(max(1, compare_height - 1))
+                for band_index in range(len(band_edges) - 1):
+                    if band_edges[band_index] <= y_normalized <= band_edges[band_index + 1]:
+                        _update_stats(band_stats[band_index], rgb_delta, luma_delta)
+                        break
             if diff_image is not None:
                 diff_image.setPixelColor(x + compare_width * 2, y, _heat_color(pixel_abs_sum / 3.0))
 
@@ -328,6 +414,14 @@ def compare_image_appearance(
     rmse_rgb = [math.sqrt(value * inv_count) for value in sum_squared]
     mean_abs_error = sum(mean_abs_error_rgb) / 3.0
     rmse = math.sqrt(sum(value * inv_count for value in sum_squared) / 3.0)
+    band_appearance_metrics = []
+    if band_edges:
+        for band_index, stats in enumerate(band_stats):
+            band_appearance_metrics.append(_finalize_stats(stats, {
+                "band_index": band_index,
+                "y_min_normalized": band_edges[band_index],
+                "y_max_normalized": band_edges[band_index + 1],
+            }))
 
     return {
         "success": True,
@@ -338,6 +432,7 @@ def compare_image_appearance(
         "candidate_crop_bbox_pixels": candidate_bbox,
         "compare_width": compare_width,
         "compare_height": compare_height,
+        "band_edges_normalized": band_edges,
         "mask_mode": mask_mode,
         "comparison_mask_mode": comparison_mask_mode,
         "reference_background_color": reference_background,
@@ -357,4 +452,5 @@ def compare_image_appearance(
         "mean_signed_luminance_error": luminance_signed * inv_count,
         "mean_abs_luminance_error": luminance_abs * inv_count,
         "luminance_rmse": math.sqrt(luminance_squared * inv_count),
+        "band_appearance_metrics": band_appearance_metrics,
     }

--- a/src/mayatools/scene/compare_image_appearance.py
+++ b/src/mayatools/scene/compare_image_appearance.py
@@ -1,0 +1,360 @@
+from typing import Dict, List, Any
+
+
+def compare_image_appearance(
+    reference_image_path: str,
+    candidate_image_path: str,
+    output_path: str = None,
+    reference_bbox_pixels: List[float] = None,
+    candidate_bbox_pixels: List[float] = None,
+    reference_bbox_normalized: List[float] = None,
+    candidate_bbox_normalized: List[float] = None,
+    mask_mode: str = "foreground",
+    comparison_mask_mode: str = "intersection",
+    background_color: List[float] = None,
+    reference_background_color: List[float] = None,
+    candidate_background_color: List[float] = None,
+    background_tolerance: float = 0.08,
+    alpha_threshold: float = 0.05,
+    compare_width: int = 256,
+    compare_height: int = 512,
+    min_compare_pixels: int = 16,
+) -> Dict[str, Any]:
+    """Compare aligned image appearance with color-error metrics.
+
+    This is a generic visual QA tool for renders, textures, sprites, decals,
+    product previews, and reference-matching workflows. It crops reference and
+    candidate images, stretches both crops to a shared comparison size, builds
+    optional alpha/foreground masks, computes RGB and luminance error metrics,
+    and can write a three-panel diagnostic image: reference, candidate, and
+    heatmapped absolute difference.
+    """
+    import math
+    import os
+
+    try:
+        from PySide6.QtCore import Qt
+        from PySide6.QtGui import QImage, QColor
+    except Exception:
+        try:
+            from PySide2.QtCore import Qt
+            from PySide2.QtGui import QImage, QColor
+        except Exception as exc:
+            raise RuntimeError("PySide QImage is required to compare image appearance in Maya.") from exc
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(value) for value in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(value) for value in values]
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return value
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _clamp(value, lower=0.0, upper=1.0):
+        return max(lower, min(upper, value))
+
+    def _normalize_color(values, arg_name):
+        if values is None:
+            return None
+        color = _validate_vector(values, 3, arg_name)
+        if max(color) > 1.0:
+            color = [channel / 255.0 for channel in color]
+        return [_clamp(channel) for channel in color]
+
+    def _pixel_rgb_alpha(image, x, y):
+        color = image.pixelColor(int(x), int(y))
+        return color.redF(), color.greenF(), color.blueF(), color.alphaF()
+
+    def _make_color(red, green, blue, alpha=1.0):
+        color = QColor()
+        color.setRgbF(_clamp(red), _clamp(green), _clamp(blue), _clamp(alpha))
+        return color
+
+    def _color_distance(a, b):
+        dr = a[0] - b[0]
+        dg = a[1] - b[1]
+        db = a[2] - b[2]
+        return math.sqrt(dr * dr + dg * dg + db * db)
+
+    def _luminance(rgb):
+        return 0.2126 * rgb[0] + 0.7152 * rgb[1] + 0.0722 * rgb[2]
+
+    def _load_image(path, arg_name):
+        if not path:
+            raise ValueError(f"{arg_name} is required.")
+        normalized = os.path.normpath(path)
+        if not os.path.exists(normalized):
+            raise ValueError(f"{arg_name} does not exist: {path}")
+        image = QImage(normalized)
+        if image.isNull():
+            raise ValueError(f"Unable to load image: {path}")
+        return normalized, image.convertToFormat(QImage.Format_ARGB32)
+
+    def _bbox_from_args(image, pixels, normalized, pixels_arg, normalized_arg):
+        width = image.width()
+        height = image.height()
+        if pixels is not None and normalized is not None:
+            raise ValueError(f"Provide either {pixels_arg} or {normalized_arg}, not both.")
+        if normalized is not None:
+            values = _validate_vector(normalized, 4, normalized_arg)
+            x0 = int(round(_clamp(values[0]) * (width - 1)))
+            y0 = int(round(_clamp(values[1]) * (height - 1)))
+            x1 = int(round(_clamp(values[2]) * (width - 1)))
+            y1 = int(round(_clamp(values[3]) * (height - 1)))
+        elif pixels is not None:
+            values = _validate_vector(pixels, 4, pixels_arg)
+            x0 = int(round(values[0]))
+            y0 = int(round(values[1]))
+            x1 = int(round(values[2]))
+            y1 = int(round(values[3]))
+        else:
+            x0, y0, x1, y1 = 0, 0, width - 1, height - 1
+        x0 = max(0, min(width - 1, x0))
+        x1 = max(0, min(width - 1, x1))
+        y0 = max(0, min(height - 1, y0))
+        y1 = max(0, min(height - 1, y1))
+        if x1 < x0 or y1 < y0:
+            raise ValueError(f"{pixels_arg} must be [min_x, min_y, max_x, max_y].")
+        return [x0, y0, x1, y1]
+
+    def _estimate_background(image):
+        width = image.width()
+        height = image.height()
+        radius = max(1, min(8, width // 24, height // 24))
+        corners = [
+            (radius, radius),
+            (width - 1 - radius, radius),
+            (radius, height - 1 - radius),
+            (width - 1 - radius, height - 1 - radius),
+        ]
+        samples = []
+        for corner_x, corner_y in corners:
+            for dy in range(-radius, radius + 1):
+                for dx in range(-radius, radius + 1):
+                    x = max(0, min(width - 1, corner_x + dx))
+                    y = max(0, min(height - 1, corner_y + dy))
+                    samples.append(_pixel_rgb_alpha(image, x, y)[:3])
+        channels = []
+        for index in range(3):
+            values = sorted(sample[index] for sample in samples)
+            channels.append(values[len(values) // 2])
+        return channels
+
+    def _crop_and_scale(image, bbox):
+        x0, y0, x1, y1 = bbox
+        cropped = image.copy(x0, y0, x1 - x0 + 1, y1 - y0 + 1)
+        return cropped.scaled(compare_width, compare_height, Qt.IgnoreAspectRatio, Qt.SmoothTransformation)
+
+    def _mask(image, bg_color):
+        mask = []
+        count = 0
+        for y in range(compare_height):
+            row = []
+            for x in range(compare_width):
+                red, green, blue, alpha = _pixel_rgb_alpha(image, x, y)
+                keep = True
+                if mask_mode == "alpha":
+                    keep = alpha >= alpha_threshold
+                elif mask_mode == "foreground":
+                    keep = alpha >= alpha_threshold and _color_distance((red, green, blue), bg_color) > background_tolerance
+                row.append(keep)
+                if keep:
+                    count += 1
+            mask.append(row)
+        return mask, count
+
+    def _combine_masks(reference_mask, candidate_mask):
+        combined = []
+        count = 0
+        for y in range(compare_height):
+            row = []
+            for x in range(compare_width):
+                ref_value = reference_mask[y][x]
+                candidate_value = candidate_mask[y][x]
+                if comparison_mask_mode == "intersection":
+                    keep = ref_value and candidate_value
+                elif comparison_mask_mode == "union":
+                    keep = ref_value or candidate_value
+                elif comparison_mask_mode == "reference":
+                    keep = ref_value
+                elif comparison_mask_mode == "candidate":
+                    keep = candidate_value
+                else:
+                    keep = True
+                row.append(keep)
+                if keep:
+                    count += 1
+            combined.append(row)
+        return combined, count
+
+    def _heat_color(error_value):
+        heat = _clamp(error_value * 4.0)
+        if heat < 0.5:
+            return _make_color(heat * 2.0, 0.0, 0.0)
+        if heat < 0.85:
+            return _make_color(1.0, (heat - 0.5) / 0.35, 0.0)
+        return _make_color(1.0, 1.0, (heat - 0.85) / 0.15)
+
+    reference_path, reference_image = _load_image(reference_image_path, "reference_image_path")
+    candidate_path, candidate_image = _load_image(candidate_image_path, "candidate_image_path")
+
+    compare_width = _validate_int(compare_width, "compare_width", 8)
+    compare_height = _validate_int(compare_height, "compare_height", 8)
+    min_compare_pixels = _validate_int(min_compare_pixels, "min_compare_pixels", 1)
+    background_tolerance = _validate_scalar(background_tolerance, "background_tolerance")
+    alpha_threshold = _validate_scalar(alpha_threshold, "alpha_threshold")
+    if background_tolerance < 0.0:
+        raise ValueError("background_tolerance must be greater than or equal to zero.")
+    if alpha_threshold < 0.0 or alpha_threshold > 1.0:
+        raise ValueError("alpha_threshold must be in the 0..1 range.")
+
+    mask_mode = mask_mode.lower().strip()
+    if mask_mode not in {"none", "alpha", "foreground"}:
+        raise ValueError("mask_mode must be none, alpha, or foreground.")
+    comparison_mask_mode = comparison_mask_mode.lower().strip()
+    if comparison_mask_mode not in {"intersection", "union", "reference", "candidate", "all"}:
+        raise ValueError("comparison_mask_mode must be intersection, union, reference, candidate, or all.")
+
+    shared_background = _normalize_color(background_color, "background_color")
+    reference_background = _normalize_color(reference_background_color, "reference_background_color") or shared_background
+    candidate_background = _normalize_color(candidate_background_color, "candidate_background_color") or shared_background
+
+    reference_bbox = _bbox_from_args(
+        reference_image,
+        reference_bbox_pixels,
+        reference_bbox_normalized,
+        "reference_bbox_pixels",
+        "reference_bbox_normalized",
+    )
+    candidate_bbox = _bbox_from_args(
+        candidate_image,
+        candidate_bbox_pixels,
+        candidate_bbox_normalized,
+        "candidate_bbox_pixels",
+        "candidate_bbox_normalized",
+    )
+
+    reference_scaled = _crop_and_scale(reference_image, reference_bbox)
+    candidate_scaled = _crop_and_scale(candidate_image, candidate_bbox)
+    if reference_background is None:
+        reference_background = _estimate_background(reference_scaled)
+    if candidate_background is None:
+        candidate_background = _estimate_background(candidate_scaled)
+
+    if mask_mode == "none":
+        reference_mask = [[True for _ in range(compare_width)] for _ in range(compare_height)]
+        candidate_mask = [[True for _ in range(compare_width)] for _ in range(compare_height)]
+        reference_mask_count = compare_width * compare_height
+        candidate_mask_count = compare_width * compare_height
+    else:
+        reference_mask, reference_mask_count = _mask(reference_scaled, reference_background)
+        candidate_mask, candidate_mask_count = _mask(candidate_scaled, candidate_background)
+    compare_mask, compare_pixel_count = _combine_masks(reference_mask, candidate_mask)
+    if compare_pixel_count < min_compare_pixels:
+        raise ValueError("Not enough comparison pixels. Adjust masks, bboxes, tolerances, or min_compare_pixels.")
+
+    sum_reference = [0.0, 0.0, 0.0]
+    sum_candidate = [0.0, 0.0, 0.0]
+    sum_signed = [0.0, 0.0, 0.0]
+    sum_abs = [0.0, 0.0, 0.0]
+    sum_squared = [0.0, 0.0, 0.0]
+    max_abs_error = 0.0
+    luminance_abs = 0.0
+    luminance_squared = 0.0
+    luminance_signed = 0.0
+
+    diff_image = None
+    if output_path:
+        diff_image = QImage(compare_width * 3, compare_height, QImage.Format_ARGB32)
+        diff_image.fill(_make_color(0.08, 0.08, 0.08))
+
+    for y in range(compare_height):
+        for x in range(compare_width):
+            ref_rgb = _pixel_rgb_alpha(reference_scaled, x, y)[:3]
+            candidate_rgb = _pixel_rgb_alpha(candidate_scaled, x, y)[:3]
+            keep = compare_mask[y][x]
+            if diff_image is not None:
+                diff_image.setPixelColor(x, y, _make_color(ref_rgb[0], ref_rgb[1], ref_rgb[2], 1.0 if keep else 0.35))
+                diff_image.setPixelColor(x + compare_width, y, _make_color(candidate_rgb[0], candidate_rgb[1], candidate_rgb[2], 1.0 if keep else 0.35))
+            if not keep:
+                if diff_image is not None:
+                    diff_image.setPixelColor(x + compare_width * 2, y, _make_color(0.12, 0.12, 0.12))
+                continue
+            ref_luma = _luminance(ref_rgb)
+            candidate_luma = _luminance(candidate_rgb)
+            luma_delta = candidate_luma - ref_luma
+            luminance_signed += luma_delta
+            luminance_abs += abs(luma_delta)
+            luminance_squared += luma_delta * luma_delta
+            pixel_abs_sum = 0.0
+            for index in range(3):
+                delta = candidate_rgb[index] - ref_rgb[index]
+                abs_delta = abs(delta)
+                sum_reference[index] += ref_rgb[index]
+                sum_candidate[index] += candidate_rgb[index]
+                sum_signed[index] += delta
+                sum_abs[index] += abs_delta
+                sum_squared[index] += delta * delta
+                max_abs_error = max(max_abs_error, abs_delta)
+                pixel_abs_sum += abs_delta
+            if diff_image is not None:
+                diff_image.setPixelColor(x + compare_width * 2, y, _heat_color(pixel_abs_sum / 3.0))
+
+    output_saved = None
+    if diff_image is not None:
+        normalized_output_path = os.path.normpath(output_path)
+        directory = os.path.dirname(normalized_output_path)
+        if directory and not os.path.exists(directory):
+            os.makedirs(directory)
+        if not diff_image.save(normalized_output_path):
+            raise RuntimeError(f"Unable to save appearance comparison image: {output_path}")
+        output_saved = normalized_output_path
+
+    inv_count = 1.0 / compare_pixel_count
+    mean_reference_rgb = [value * inv_count for value in sum_reference]
+    mean_candidate_rgb = [value * inv_count for value in sum_candidate]
+    mean_signed_error_rgb = [value * inv_count for value in sum_signed]
+    mean_abs_error_rgb = [value * inv_count for value in sum_abs]
+    rmse_rgb = [math.sqrt(value * inv_count) for value in sum_squared]
+    mean_abs_error = sum(mean_abs_error_rgb) / 3.0
+    rmse = math.sqrt(sum(value * inv_count for value in sum_squared) / 3.0)
+
+    return {
+        "success": True,
+        "reference_image_path": reference_path,
+        "candidate_image_path": candidate_path,
+        "output_path": output_saved,
+        "reference_crop_bbox_pixels": reference_bbox,
+        "candidate_crop_bbox_pixels": candidate_bbox,
+        "compare_width": compare_width,
+        "compare_height": compare_height,
+        "mask_mode": mask_mode,
+        "comparison_mask_mode": comparison_mask_mode,
+        "reference_background_color": reference_background,
+        "candidate_background_color": candidate_background,
+        "reference_mask_pixels": reference_mask_count,
+        "candidate_mask_pixels": candidate_mask_count,
+        "compare_pixels": compare_pixel_count,
+        "compare_coverage": compare_pixel_count / float(compare_width * compare_height),
+        "mean_reference_rgb": mean_reference_rgb,
+        "mean_candidate_rgb": mean_candidate_rgb,
+        "mean_signed_error_rgb": mean_signed_error_rgb,
+        "mean_abs_error_rgb": mean_abs_error_rgb,
+        "mean_abs_error": mean_abs_error,
+        "rmse_rgb": rmse_rgb,
+        "rmse": rmse,
+        "max_abs_error": max_abs_error,
+        "mean_signed_luminance_error": luminance_signed * inv_count,
+        "mean_abs_luminance_error": luminance_abs * inv_count,
+        "luminance_rmse": math.sqrt(luminance_squared * inv_count),
+    }

--- a/src/mayatools/scene/compare_image_appearance.py
+++ b/src/mayatools/scene/compare_image_appearance.py
@@ -20,6 +20,8 @@ def compare_image_appearance(
     compare_height: int = 512,
     min_compare_pixels: int = 16,
     band_edges_normalized: List[float] = None,
+    grid_rows: int = 0,
+    grid_columns: int = 0,
 ) -> Dict[str, Any]:
     """Compare aligned image appearance with color-error metrics.
 
@@ -27,8 +29,9 @@ def compare_image_appearance(
     product previews, and reference-matching workflows. It crops reference and
     candidate images, stretches both crops to a shared comparison size, builds
     optional alpha/foreground masks, computes RGB and luminance error metrics,
-    optionally summarizes errors by vertical bands, and can write a three-panel
-    diagnostic image: reference, candidate, and heatmapped absolute difference.
+    optionally summarizes errors by vertical bands or a 2D grid, and can write
+    a three-panel diagnostic image: reference, candidate, and heatmapped
+    absolute difference.
     """
     import math
     import os
@@ -284,6 +287,12 @@ def compare_image_appearance(
     compare_width = _validate_int(compare_width, "compare_width", 8)
     compare_height = _validate_int(compare_height, "compare_height", 8)
     min_compare_pixels = _validate_int(min_compare_pixels, "min_compare_pixels", 1)
+    if not isinstance(grid_rows, int) or isinstance(grid_rows, bool) or grid_rows < 0:
+        raise ValueError("grid_rows must be an integer greater than or equal to zero.")
+    if not isinstance(grid_columns, int) or isinstance(grid_columns, bool) or grid_columns < 0:
+        raise ValueError("grid_columns must be an integer greater than or equal to zero.")
+    if (grid_rows == 0) != (grid_columns == 0):
+        raise ValueError("grid_rows and grid_columns must both be zero or both be greater than zero.")
     background_tolerance = _validate_scalar(background_tolerance, "background_tolerance")
     alpha_threshold = _validate_scalar(alpha_threshold, "alpha_threshold")
     if background_tolerance < 0.0:
@@ -350,6 +359,12 @@ def compare_image_appearance(
     if band_edges:
         for band_index in range(len(band_edges) - 1):
             band_stats.append(_new_stats())
+    grid_stats = []
+    if grid_rows and grid_columns:
+        for row in range(grid_rows):
+            grid_stats.append([])
+            for column in range(grid_columns):
+                grid_stats[row].append(_new_stats())
 
     diff_image = None
     if output_path:
@@ -393,6 +408,10 @@ def compare_image_appearance(
                     if band_edges[band_index] <= y_normalized <= band_edges[band_index + 1]:
                         _update_stats(band_stats[band_index], rgb_delta, luma_delta)
                         break
+            if grid_stats:
+                grid_row = min(grid_rows - 1, int((y / float(compare_height)) * grid_rows))
+                grid_column = min(grid_columns - 1, int((x / float(compare_width)) * grid_columns))
+                _update_stats(grid_stats[grid_row][grid_column], rgb_delta, luma_delta)
             if diff_image is not None:
                 diff_image.setPixelColor(x + compare_width * 2, y, _heat_color(pixel_abs_sum / 3.0))
 
@@ -422,6 +441,18 @@ def compare_image_appearance(
                 "y_min_normalized": band_edges[band_index],
                 "y_max_normalized": band_edges[band_index + 1],
             }))
+    grid_appearance_metrics = []
+    if grid_stats:
+        for row in range(grid_rows):
+            for column in range(grid_columns):
+                grid_appearance_metrics.append(_finalize_stats(grid_stats[row][column], {
+                    "row": row,
+                    "column": column,
+                    "x_min_normalized": column / float(grid_columns),
+                    "x_max_normalized": (column + 1) / float(grid_columns),
+                    "y_min_normalized": row / float(grid_rows),
+                    "y_max_normalized": (row + 1) / float(grid_rows),
+                }))
 
     return {
         "success": True,
@@ -433,6 +464,8 @@ def compare_image_appearance(
         "compare_width": compare_width,
         "compare_height": compare_height,
         "band_edges_normalized": band_edges,
+        "grid_rows": grid_rows,
+        "grid_columns": grid_columns,
         "mask_mode": mask_mode,
         "comparison_mask_mode": comparison_mask_mode,
         "reference_background_color": reference_background,
@@ -453,4 +486,5 @@ def compare_image_appearance(
         "mean_abs_luminance_error": luminance_abs * inv_count,
         "luminance_rmse": math.sqrt(luminance_squared * inv_count),
         "band_appearance_metrics": band_appearance_metrics,
+        "grid_appearance_metrics": grid_appearance_metrics,
     }

--- a/src/mayatools/scene/compare_image_silhouettes.py
+++ b/src/mayatools/scene/compare_image_silhouettes.py
@@ -12,6 +12,8 @@ def compare_image_silhouettes(
     mask_mode: str = "foreground",
     fill_holes: bool = True,
     background_color: List[float] = None,
+    reference_background_color: List[float] = None,
+    candidate_background_color: List[float] = None,
     background_tolerance: float = 0.08,
     alpha_threshold: float = 0.05,
     luminance_threshold: float = 0.5,
@@ -32,6 +34,9 @@ def compare_image_silhouettes(
     auto_crop_reference: bool = False,
     auto_crop_candidate: bool = False,
     auto_crop_padding_pixels: int = 0,
+    band_edges: List[float] = None,
+    correction_profile_samples: int = None,
+    scale_range: List[float] = None,
 ) -> Dict[str, Any]:
     """Compare two image silhouettes and optionally write an overlap diagnostic.
 
@@ -48,7 +53,11 @@ def compare_image_silhouettes(
     tools. This is useful for generic visual QA of modeled products, props,
     icons, sprites, masks, decals, or rendered assets against reference images.
     Optional foreground auto-cropping is useful when renders are centered on a
-    larger preview canvas.
+    larger preview canvas. reference_background_color and
+    candidate_background_color can be used when the compared images use
+    different studio backgrounds. band_edges, correction_profile_samples, and
+    scale_range are convenience aliases for the normalized band/profile
+    arguments.
     """
     import math
     import os
@@ -527,6 +536,19 @@ def compare_image_silhouettes(
     compare_height = _validate_int(compare_height, "compare_height", 8)
     row_sample_count = _validate_int(row_sample_count, "row_sample_count", 2)
     band_sample_count = _validate_int(band_sample_count, "band_sample_count", 2)
+    if band_edges is not None:
+        if band_edges_normalized is not None:
+            raise ValueError("Provide only one of band_edges or band_edges_normalized.")
+        band_edges_normalized = band_edges
+    if correction_profile_samples is not None:
+        if correction_profile_sample_count != 0:
+            raise ValueError("Provide only one of correction_profile_samples or correction_profile_sample_count.")
+        correction_profile_sample_count = correction_profile_samples
+    if scale_range is not None:
+        if correction_profile_scale_range is not None:
+            raise ValueError("Provide only one of scale_range or correction_profile_scale_range.")
+        correction_profile_scale_range = scale_range
+
     correction_profile_sample_count = _validate_int(correction_profile_sample_count, "correction_profile_sample_count", 0)
     if correction_profile_sample_count == 1:
         raise ValueError("correction_profile_sample_count must be 0 or an integer greater than or equal to 2.")
@@ -580,10 +602,28 @@ def compare_image_silhouettes(
         raise ValueError(f"Unable to load candidate image: {candidate_image_path}")
 
     clean_background_color = _normalize_color(background_color, "background_color") if background_color else None
+    clean_reference_background_color = (
+        _normalize_color(reference_background_color, "reference_background_color")
+        if reference_background_color
+        else None
+    )
+    clean_candidate_background_color = (
+        _normalize_color(candidate_background_color, "candidate_background_color")
+        if candidate_background_color
+        else None
+    )
     reference_search_bbox = _resolve_bbox(reference_image, reference_bbox_pixels, reference_bbox_normalized, "reference")
     candidate_search_bbox = _resolve_bbox(candidate_image, candidate_bbox_pixels, candidate_bbox_normalized, "candidate")
-    reference_background = clean_background_color or _estimate_background(reference_image, reference_search_bbox)
-    candidate_background = clean_background_color or _estimate_background(candidate_image, candidate_search_bbox)
+    reference_background = (
+        clean_reference_background_color
+        or clean_background_color
+        or _estimate_background(reference_image, reference_search_bbox)
+    )
+    candidate_background = (
+        clean_candidate_background_color
+        or clean_background_color
+        or _estimate_background(candidate_image, candidate_search_bbox)
+    )
     if auto_crop_reference and reference_bbox_pixels is None and reference_bbox_normalized is None:
         reference_bbox = _auto_crop_bbox(
             reference_image,

--- a/src/mayatools/scene/compare_image_silhouettes.py
+++ b/src/mayatools/scene/compare_image_silhouettes.py
@@ -22,6 +22,8 @@ def compare_image_silhouettes(
     scale_mode: str = "height",
     padding_fraction: float = 0.04,
     row_sample_count: int = 64,
+    band_edges_normalized: List[float] = None,
+    band_sample_count: int = 64,
     min_foreground_pixels: int = 8,
 ) -> Dict[str, Any]:
     """Compare two image silhouettes and optionally write an overlap diagnostic.
@@ -33,10 +35,10 @@ def compare_image_silhouettes(
     matching height, so width errors remain measurable instead of being hidden
     by a full x/y stretch. Hole filling is enabled by default so transparent or
     outlined objects can be compared as solid silhouettes. Returned metrics
-    include IoU, overlap counts, aspect/centroid differences, and per-row
-    silhouette width error. This is useful for generic visual QA of modeled
-    products, props, icons, sprites, masks, decals, or rendered assets against
-    reference images.
+    include IoU, overlap counts, aspect/centroid differences, per-row
+    silhouette width error, and optional vertical band width summaries. This is
+    useful for generic visual QA of modeled products, props, icons, sprites,
+    masks, decals, or rendered assets against reference images.
     """
     import math
     import os
@@ -323,6 +325,48 @@ def compare_image_silhouettes(
             "samples": samples,
         }
 
+    def _band_width_errors(reference_mask, candidate_mask, edges):
+        bands = []
+        for index in range(len(edges) - 1):
+            start = edges[index]
+            end = edges[index + 1]
+            if end <= start:
+                raise ValueError("band_edges_normalized must be strictly increasing.")
+            start_row = int(round(_clamp(start) * (compare_height - 1)))
+            end_row = int(round(_clamp(end) * (compare_height - 1)))
+            if end_row < start_row:
+                start_row, end_row = end_row, start_row
+            sample_total = max(2, band_sample_count)
+            errors = []
+            signed_errors = []
+            reference_widths = []
+            candidate_widths = []
+            for sample_index in range(sample_total):
+                if sample_total == 1 or end_row == start_row:
+                    row = start_row
+                else:
+                    row = int(round(start_row + sample_index * (end_row - start_row) / float(sample_total - 1)))
+                reference_width = _row_width(reference_mask, row)
+                candidate_width = _row_width(candidate_mask, row)
+                signed = candidate_width - reference_width
+                errors.append(abs(signed))
+                signed_errors.append(signed)
+                reference_widths.append(reference_width)
+                candidate_widths.append(candidate_width)
+            bands.append({
+                "index": index,
+                "start_normalized": start,
+                "end_normalized": end,
+                "start_row": start_row,
+                "end_row": end_row,
+                "mean_reference_width": sum(reference_widths) / float(len(reference_widths)) if reference_widths else 0.0,
+                "mean_candidate_width": sum(candidate_widths) / float(len(candidate_widths)) if candidate_widths else 0.0,
+                "mean_abs_width_error": sum(errors) / float(len(errors)) if errors else 0.0,
+                "max_abs_width_error": max(errors) if errors else 0.0,
+                "mean_signed_width_error": sum(signed_errors) / float(len(signed_errors)) if signed_errors else 0.0,
+            })
+        return bands
+
     def _write_overlay(path, reference_mask, candidate_mask):
         image = QImage(compare_width, compare_height, QImage.Format_ARGB32)
         for y in range(compare_height):
@@ -370,7 +414,21 @@ def compare_image_silhouettes(
     compare_width = _validate_int(compare_width, "compare_width", 8)
     compare_height = _validate_int(compare_height, "compare_height", 8)
     row_sample_count = _validate_int(row_sample_count, "row_sample_count", 2)
+    band_sample_count = _validate_int(band_sample_count, "band_sample_count", 2)
     min_foreground_pixels = _validate_int(min_foreground_pixels, "min_foreground_pixels", 1)
+    clean_band_edges = None
+    if band_edges_normalized is not None:
+        if not isinstance(band_edges_normalized, list) or len(band_edges_normalized) < 2:
+            raise ValueError("band_edges_normalized must be a list with at least two numeric values.")
+        clean_band_edges = []
+        for value in band_edges_normalized:
+            clean_value = _validate_scalar(value, "band_edges_normalized")
+            if clean_value < 0.0 or clean_value > 1.0:
+                raise ValueError("band_edges_normalized values must be in the range 0..1.")
+            clean_band_edges.append(clean_value)
+        for index in range(len(clean_band_edges) - 1):
+            if clean_band_edges[index + 1] <= clean_band_edges[index]:
+                raise ValueError("band_edges_normalized must be strictly increasing.")
     padding_fraction = _validate_scalar(padding_fraction, "padding_fraction")
     if padding_fraction < 0.0 or padding_fraction >= 0.45:
         raise ValueError("padding_fraction must be greater than or equal to 0 and less than 0.45.")
@@ -419,6 +477,7 @@ def compare_image_silhouettes(
     precision = intersection / float(candidate_count) if candidate_count else 0.0
     recall = intersection / float(reference_count) if reference_count else 0.0
     width_metrics = _row_width_errors(reference_mask, candidate_mask)
+    band_metrics = _band_width_errors(reference_mask, candidate_mask, clean_band_edges) if clean_band_edges else []
 
     if output_path:
         output_path = os.path.normpath(output_path)
@@ -443,6 +502,8 @@ def compare_image_silhouettes(
         "padding_fraction": padding_fraction,
         "compare_width": compare_width,
         "compare_height": compare_height,
+        "band_edges_normalized": clean_band_edges,
+        "band_sample_count": band_sample_count,
         "reference_crop_bbox_pixels": reference_bbox,
         "candidate_crop_bbox_pixels": candidate_bbox,
         "reference_foreground_bbox_pixels": reference_data["foreground_bbox"],
@@ -475,4 +536,5 @@ def compare_image_silhouettes(
         "max_abs_width_error": width_metrics["max_abs_width_error"],
         "mean_signed_width_error": width_metrics["mean_signed_width_error"],
         "row_width_samples": width_metrics["samples"],
+        "band_width_metrics": band_metrics,
     }

--- a/src/mayatools/scene/compare_image_silhouettes.py
+++ b/src/mayatools/scene/compare_image_silhouettes.py
@@ -1,0 +1,478 @@
+from typing import Dict, List, Any
+
+
+def compare_image_silhouettes(
+    reference_image_path: str,
+    candidate_image_path: str,
+    output_path: str = None,
+    reference_bbox_pixels: List[float] = None,
+    candidate_bbox_pixels: List[float] = None,
+    reference_bbox_normalized: List[float] = None,
+    candidate_bbox_normalized: List[float] = None,
+    mask_mode: str = "foreground",
+    fill_holes: bool = True,
+    background_color: List[float] = None,
+    background_tolerance: float = 0.08,
+    alpha_threshold: float = 0.05,
+    luminance_threshold: float = 0.5,
+    invert_luminance: bool = False,
+    compare_width: int = 256,
+    compare_height: int = 512,
+    align_mode: str = "bbox",
+    scale_mode: str = "height",
+    padding_fraction: float = 0.04,
+    row_sample_count: int = 64,
+    min_foreground_pixels: int = 8,
+) -> Dict[str, Any]:
+    """Compare two image silhouettes and optionally write an overlap diagnostic.
+
+    The tool extracts binary masks from reference and candidate images using
+    alpha, foreground-vs-background, or luminance thresholding. Masks can be
+    normalized by their foreground bounding boxes or crop regions before
+    comparison. By default the normalization preserves silhouette aspect by
+    matching height, so width errors remain measurable instead of being hidden
+    by a full x/y stretch. Hole filling is enabled by default so transparent or
+    outlined objects can be compared as solid silhouettes. Returned metrics
+    include IoU, overlap counts, aspect/centroid differences, and per-row
+    silhouette width error. This is useful for generic visual QA of modeled
+    products, props, icons, sprites, masks, decals, or rendered assets against
+    reference images.
+    """
+    import math
+    import os
+
+    try:
+        from PySide6.QtGui import QImage, QColor
+    except Exception:
+        try:
+            from PySide2.QtGui import QImage, QColor
+        except Exception as exc:
+            raise RuntimeError("PySide QImage is required to compare image silhouettes in Maya.") from exc
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(value) for value in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(value) for value in values]
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return value
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _clamp(value, lower=0.0, upper=1.0):
+        return max(lower, min(upper, value))
+
+    def _normalize_color(values, arg_name):
+        color = _validate_vector(values, 3, arg_name)
+        if max(color) > 1.0:
+            color = [channel / 255.0 for channel in color]
+        return [_clamp(channel) for channel in color]
+
+    def _pixel_rgb_alpha(image, x, y):
+        color = image.pixelColor(int(x), int(y))
+        return color.redF(), color.greenF(), color.blueF(), color.alphaF()
+
+    def _color_distance(a, b):
+        dr = a[0] - b[0]
+        dg = a[1] - b[1]
+        db = a[2] - b[2]
+        return math.sqrt(dr * dr + dg * dg + db * db)
+
+    def _estimate_background(image, bbox):
+        x0, y0, x1, y1 = bbox
+        samples = []
+        inset_x = max(1, int((x1 - x0 + 1) * 0.03))
+        inset_y = max(1, int((y1 - y0 + 1) * 0.03))
+        radius = max(1, min(inset_x, inset_y, 8))
+        corners = [
+            (x0 + inset_x, y0 + inset_y),
+            (x1 - inset_x, y0 + inset_y),
+            (x0 + inset_x, y1 - inset_y),
+            (x1 - inset_x, y1 - inset_y),
+        ]
+        for corner_x, corner_y in corners:
+            for dy in range(-radius, radius + 1):
+                for dx in range(-radius, radius + 1):
+                    x = max(x0, min(x1, corner_x + dx))
+                    y = max(y0, min(y1, corner_y + dy))
+                    samples.append(_pixel_rgb_alpha(image, x, y)[:3])
+        if not samples:
+            return [1.0, 1.0, 1.0]
+        channels = []
+        for index in range(3):
+            values = sorted(sample[index] for sample in samples)
+            channels.append(values[len(values) // 2])
+        return channels
+
+    def _mask_stats(mask, width, height):
+        count = 0
+        foreground_bbox = None
+        for row in range(height):
+            for column in range(width):
+                if not mask[row][column]:
+                    continue
+                count += 1
+                if foreground_bbox is None:
+                    foreground_bbox = [column, row, column, row]
+                else:
+                    foreground_bbox[0] = min(foreground_bbox[0], column)
+                    foreground_bbox[1] = min(foreground_bbox[1], row)
+                    foreground_bbox[2] = max(foreground_bbox[2], column)
+                    foreground_bbox[3] = max(foreground_bbox[3], row)
+        return count, foreground_bbox
+
+    def _fill_mask_holes(mask, width, height):
+        visited = [bytearray(width) for _ in range(height)]
+        stack = []
+
+        def _add_background(column, row):
+            if column < 0 or column >= width or row < 0 or row >= height:
+                return
+            if visited[row][column] or mask[row][column]:
+                return
+            visited[row][column] = 1
+            stack.append((column, row))
+
+        for column in range(width):
+            _add_background(column, 0)
+            _add_background(column, height - 1)
+        for row in range(height):
+            _add_background(0, row)
+            _add_background(width - 1, row)
+
+        while stack:
+            column, row = stack.pop()
+            _add_background(column + 1, row)
+            _add_background(column - 1, row)
+            _add_background(column, row + 1)
+            _add_background(column, row - 1)
+
+        filled = [bytearray(row) for row in mask]
+        for row in range(height):
+            for column in range(width):
+                if not filled[row][column] and not visited[row][column]:
+                    filled[row][column] = 1
+        return filled
+
+    def _resolve_bbox(image, bbox_pixels, bbox_normalized, arg_prefix):
+        if bbox_pixels is not None and bbox_normalized is not None:
+            raise ValueError(f"Provide only one of {arg_prefix}_bbox_pixels or {arg_prefix}_bbox_normalized.")
+        width = image.width()
+        height = image.height()
+        if bbox_normalized is not None:
+            bbox = _validate_vector(bbox_normalized, 4, f"{arg_prefix}_bbox_normalized")
+            if bbox[2] <= bbox[0] or bbox[3] <= bbox[1]:
+                raise ValueError(f"{arg_prefix}_bbox_normalized must be [min_x, min_y, max_x, max_y].")
+            x0 = int(round(_clamp(bbox[0]) * (width - 1)))
+            y0 = int(round(_clamp(bbox[1]) * (height - 1)))
+            x1 = int(round(_clamp(bbox[2]) * (width - 1)))
+            y1 = int(round(_clamp(bbox[3]) * (height - 1)))
+        elif bbox_pixels is not None:
+            bbox = _validate_vector(bbox_pixels, 4, f"{arg_prefix}_bbox_pixels")
+            if bbox[2] <= bbox[0] or bbox[3] <= bbox[1]:
+                raise ValueError(f"{arg_prefix}_bbox_pixels must be [min_x, min_y, max_x, max_y].")
+            x0, y0, x1, y1 = [int(round(value)) for value in bbox]
+        else:
+            x0, y0, x1, y1 = 0, 0, width - 1, height - 1
+        x0 = max(0, min(width - 1, x0))
+        x1 = max(0, min(width - 1, x1))
+        y0 = max(0, min(height - 1, y0))
+        y1 = max(0, min(height - 1, y1))
+        if x1 <= x0 or y1 <= y0:
+            raise ValueError(f"Resolved {arg_prefix} crop bbox is empty.")
+        return [x0, y0, x1, y1]
+
+    def _mask_from_image(image, bbox, color):
+        x0, y0, x1, y1 = bbox
+        width = x1 - x0 + 1
+        height = y1 - y0 + 1
+        mask = [bytearray(width) for _ in range(height)]
+        for row in range(height):
+            source_y = y0 + row
+            for column in range(width):
+                source_x = x0 + column
+                red, green, blue, alpha = _pixel_rgb_alpha(image, source_x, source_y)
+                if alpha < alpha_threshold:
+                    is_foreground = False
+                elif mask_mode == "alpha":
+                    is_foreground = alpha >= alpha_threshold
+                elif mask_mode == "luminance":
+                    luminance = 0.2126 * red + 0.7152 * green + 0.0722 * blue
+                    is_foreground = luminance < luminance_threshold if invert_luminance else luminance >= luminance_threshold
+                else:
+                    is_foreground = _color_distance([red, green, blue], color) > background_tolerance
+                if not is_foreground:
+                    continue
+                mask[row][column] = 1
+        if fill_holes:
+            mask = _fill_mask_holes(mask, width, height)
+        count, foreground_bbox = _mask_stats(mask, width, height)
+        if count < min_foreground_pixels or foreground_bbox is None:
+            raise ValueError("Not enough foreground pixels were found. Adjust bbox, mask_mode, background, tolerance, or thresholds.")
+        return {
+            "mask": mask,
+            "width": width,
+            "height": height,
+            "foreground_pixels": count,
+            "foreground_bbox": foreground_bbox,
+        }
+
+    def _resample_mask(mask_data):
+        source = mask_data["mask"]
+        source_width = mask_data["width"]
+        source_height = mask_data["height"]
+        if align_mode == "bbox":
+            x0, y0, x1, y1 = mask_data["foreground_bbox"]
+        else:
+            x0, y0, x1, y1 = 0, 0, source_width - 1, source_height - 1
+        source_region_width = max(1, x1 - x0 + 1)
+        source_region_height = max(1, y1 - y0 + 1)
+        source_span_x = max(1, source_region_width - 1)
+        source_span_y = max(1, source_region_height - 1)
+
+        pad_x = int(round(compare_width * padding_fraction))
+        pad_y = int(round(compare_height * padding_fraction))
+        target_width = max(1, compare_width - pad_x * 2)
+        target_height = max(1, compare_height - pad_y * 2)
+        if scale_mode == "stretch":
+            mapped_width = target_width
+            mapped_height = target_height
+        else:
+            height_scale = target_height / float(source_region_height)
+            width_scale = target_width / float(source_region_width)
+            scale = min(height_scale, width_scale) if scale_mode == "fit" else height_scale
+            if source_region_width * scale > target_width:
+                scale = width_scale
+            mapped_width = max(1, int(round(source_region_width * scale)))
+            mapped_height = max(1, int(round(source_region_height * scale)))
+        target_x0 = max(0, min(compare_width - 1, int(round((compare_width - mapped_width) * 0.5))))
+        target_y0 = max(0, min(compare_height - 1, int(round((compare_height - mapped_height) * 0.5))))
+        target_x1 = max(target_x0, min(compare_width - 1, target_x0 + mapped_width - 1))
+        target_y1 = max(target_y0, min(compare_height - 1, target_y0 + mapped_height - 1))
+
+        result = [bytearray(compare_width) for _ in range(compare_height)]
+        count = 0
+        centroid_x = 0.0
+        centroid_y = 0.0
+        canvas_bbox = None
+        for y in range(target_y0, target_y1 + 1):
+            v = 0.0 if target_y1 == target_y0 else (y - target_y0) / float(target_y1 - target_y0)
+            source_y = int(round(y0 + v * source_span_y))
+            source_y = max(0, min(source_height - 1, source_y))
+            for x in range(target_x0, target_x1 + 1):
+                u = 0.0 if target_x1 == target_x0 else (x - target_x0) / float(target_x1 - target_x0)
+                source_x = int(round(x0 + u * source_span_x))
+                source_x = max(0, min(source_width - 1, source_x))
+                if not source[source_y][source_x]:
+                    continue
+                result[y][x] = 1
+                count += 1
+                centroid_x += x
+                centroid_y += y
+                if canvas_bbox is None:
+                    canvas_bbox = [x, y, x, y]
+                else:
+                    canvas_bbox[0] = min(canvas_bbox[0], x)
+                    canvas_bbox[1] = min(canvas_bbox[1], y)
+                    canvas_bbox[2] = max(canvas_bbox[2], x)
+                    canvas_bbox[3] = max(canvas_bbox[3], y)
+        centroid = [0.0, 0.0]
+        if count:
+            centroid = [
+                centroid_x / float(count) / max(1.0, compare_width - 1),
+                centroid_y / float(count) / max(1.0, compare_height - 1),
+            ]
+        return result, count, centroid, canvas_bbox or [0, 0, 0, 0]
+
+    def _row_width(mask, row):
+        xs = [index for index, value in enumerate(mask[row]) if value]
+        if not xs:
+            return 0.0
+        return (max(xs) - min(xs) + 1) / float(compare_width)
+
+    def _row_width_errors(reference_mask, candidate_mask):
+        errors = []
+        signed_errors = []
+        samples = []
+        for index in range(row_sample_count):
+            row = int(round(index * (compare_height - 1) / float(max(1, row_sample_count - 1))))
+            reference_width = _row_width(reference_mask, row)
+            candidate_width = _row_width(candidate_mask, row)
+            signed = candidate_width - reference_width
+            errors.append(abs(signed))
+            signed_errors.append(signed)
+            samples.append({
+                "row_normalized": 0.0 if compare_height == 1 else row / float(compare_height - 1),
+                "reference_width": reference_width,
+                "candidate_width": candidate_width,
+                "signed_error": signed,
+                "abs_error": abs(signed),
+            })
+        return {
+            "mean_abs_width_error": sum(errors) / float(len(errors)) if errors else 0.0,
+            "max_abs_width_error": max(errors) if errors else 0.0,
+            "mean_signed_width_error": sum(signed_errors) / float(len(signed_errors)) if signed_errors else 0.0,
+            "samples": samples,
+        }
+
+    def _write_overlay(path, reference_mask, candidate_mask):
+        image = QImage(compare_width, compare_height, QImage.Format_ARGB32)
+        for y in range(compare_height):
+            for x in range(compare_width):
+                reference_value = bool(reference_mask[y][x])
+                candidate_value = bool(candidate_mask[y][x])
+                if reference_value and candidate_value:
+                    color = QColor(245, 245, 245, 255)
+                elif reference_value:
+                    color = QColor(255, 64, 64, 255)
+                elif candidate_value:
+                    color = QColor(64, 144, 255, 255)
+                else:
+                    color = QColor(24, 24, 24, 255)
+                image.setPixelColor(x, y, color)
+        directory = os.path.dirname(path)
+        if directory and not os.path.isdir(directory):
+            os.makedirs(directory)
+        if not image.save(path):
+            raise RuntimeError(f"Failed to save silhouette comparison overlay: {path}")
+
+    if not reference_image_path:
+        raise ValueError("reference_image_path is required.")
+    if not candidate_image_path:
+        raise ValueError("candidate_image_path is required.")
+    reference_path = os.path.normpath(reference_image_path)
+    candidate_path = os.path.normpath(candidate_image_path)
+    if not os.path.isfile(reference_path):
+        raise ValueError(f"Reference image path does not exist: {reference_image_path}")
+    if not os.path.isfile(candidate_path):
+        raise ValueError(f"Candidate image path does not exist: {candidate_image_path}")
+
+    mask_mode = mask_mode.lower().strip()
+    if mask_mode not in {"foreground", "alpha", "luminance"}:
+        raise ValueError("mask_mode must be one of foreground, alpha, or luminance.")
+    if not isinstance(fill_holes, bool):
+        raise ValueError("fill_holes must be a boolean.")
+    background_tolerance = _validate_scalar(background_tolerance, "background_tolerance")
+    if background_tolerance > 1.0:
+        background_tolerance /= 255.0
+    if background_tolerance < 0.0:
+        raise ValueError("background_tolerance must be greater than or equal to zero.")
+    alpha_threshold = _clamp(_validate_scalar(alpha_threshold, "alpha_threshold"))
+    luminance_threshold = _clamp(_validate_scalar(luminance_threshold, "luminance_threshold"))
+    compare_width = _validate_int(compare_width, "compare_width", 8)
+    compare_height = _validate_int(compare_height, "compare_height", 8)
+    row_sample_count = _validate_int(row_sample_count, "row_sample_count", 2)
+    min_foreground_pixels = _validate_int(min_foreground_pixels, "min_foreground_pixels", 1)
+    padding_fraction = _validate_scalar(padding_fraction, "padding_fraction")
+    if padding_fraction < 0.0 or padding_fraction >= 0.45:
+        raise ValueError("padding_fraction must be greater than or equal to 0 and less than 0.45.")
+    align_mode = align_mode.lower().strip()
+    if align_mode not in {"bbox", "crop"}:
+        raise ValueError("align_mode must be one of bbox or crop.")
+    scale_mode = scale_mode.lower().strip()
+    if scale_mode not in {"height", "fit", "stretch"}:
+        raise ValueError("scale_mode must be one of height, fit, or stretch.")
+
+    reference_image = QImage(reference_path)
+    candidate_image = QImage(candidate_path)
+    if reference_image.isNull():
+        raise ValueError(f"Unable to load reference image: {reference_image_path}")
+    if candidate_image.isNull():
+        raise ValueError(f"Unable to load candidate image: {candidate_image_path}")
+
+    reference_bbox = _resolve_bbox(reference_image, reference_bbox_pixels, reference_bbox_normalized, "reference")
+    candidate_bbox = _resolve_bbox(candidate_image, candidate_bbox_pixels, candidate_bbox_normalized, "candidate")
+    clean_background_color = _normalize_color(background_color, "background_color") if background_color else None
+    reference_background = clean_background_color or _estimate_background(reference_image, reference_bbox)
+    candidate_background = clean_background_color or _estimate_background(candidate_image, candidate_bbox)
+
+    reference_data = _mask_from_image(reference_image, reference_bbox, reference_background)
+    candidate_data = _mask_from_image(candidate_image, candidate_bbox, candidate_background)
+    reference_mask, reference_count, reference_centroid, reference_canvas_bbox = _resample_mask(reference_data)
+    candidate_mask, candidate_count, candidate_centroid, candidate_canvas_bbox = _resample_mask(candidate_data)
+
+    intersection = 0
+    union = 0
+    false_positive = 0
+    false_negative = 0
+    for y in range(compare_height):
+        for x in range(compare_width):
+            reference_value = bool(reference_mask[y][x])
+            candidate_value = bool(candidate_mask[y][x])
+            if reference_value and candidate_value:
+                intersection += 1
+            if reference_value or candidate_value:
+                union += 1
+            if candidate_value and not reference_value:
+                false_positive += 1
+            if reference_value and not candidate_value:
+                false_negative += 1
+    iou = intersection / float(union) if union else 0.0
+    precision = intersection / float(candidate_count) if candidate_count else 0.0
+    recall = intersection / float(reference_count) if reference_count else 0.0
+    width_metrics = _row_width_errors(reference_mask, candidate_mask)
+
+    if output_path:
+        output_path = os.path.normpath(output_path)
+        if not os.path.splitext(output_path)[1]:
+            output_path += ".png"
+        _write_overlay(output_path, reference_mask, candidate_mask)
+
+    ref_bbox = reference_data["foreground_bbox"]
+    cand_bbox = candidate_data["foreground_bbox"]
+    ref_aspect = (ref_bbox[2] - ref_bbox[0] + 1) / float(max(1, ref_bbox[3] - ref_bbox[1] + 1))
+    cand_aspect = (cand_bbox[2] - cand_bbox[0] + 1) / float(max(1, cand_bbox[3] - cand_bbox[1] + 1))
+
+    return {
+        "success": True,
+        "reference_image_path": reference_path,
+        "candidate_image_path": candidate_path,
+        "output_path": output_path,
+        "mask_mode": mask_mode,
+        "fill_holes": fill_holes,
+        "align_mode": align_mode,
+        "scale_mode": scale_mode,
+        "padding_fraction": padding_fraction,
+        "compare_width": compare_width,
+        "compare_height": compare_height,
+        "reference_crop_bbox_pixels": reference_bbox,
+        "candidate_crop_bbox_pixels": candidate_bbox,
+        "reference_foreground_bbox_pixels": reference_data["foreground_bbox"],
+        "candidate_foreground_bbox_pixels": candidate_data["foreground_bbox"],
+        "reference_canvas_bbox_pixels": reference_canvas_bbox,
+        "candidate_canvas_bbox_pixels": candidate_canvas_bbox,
+        "reference_foreground_pixels": reference_data["foreground_pixels"],
+        "candidate_foreground_pixels": candidate_data["foreground_pixels"],
+        "reference_background_color": reference_background,
+        "candidate_background_color": candidate_background,
+        "reference_aspect": ref_aspect,
+        "candidate_aspect": cand_aspect,
+        "aspect_error": cand_aspect - ref_aspect,
+        "reference_centroid_normalized": reference_centroid,
+        "candidate_centroid_normalized": candidate_centroid,
+        "centroid_error": [
+            candidate_centroid[0] - reference_centroid[0],
+            candidate_centroid[1] - reference_centroid[1],
+        ],
+        "intersection_pixels": intersection,
+        "union_pixels": union,
+        "false_positive_pixels": false_positive,
+        "false_negative_pixels": false_negative,
+        "iou": iou,
+        "precision": precision,
+        "recall": recall,
+        "false_positive_rate_union": false_positive / float(union) if union else 0.0,
+        "false_negative_rate_union": false_negative / float(union) if union else 0.0,
+        "mean_abs_width_error": width_metrics["mean_abs_width_error"],
+        "max_abs_width_error": width_metrics["max_abs_width_error"],
+        "mean_signed_width_error": width_metrics["mean_signed_width_error"],
+        "row_width_samples": width_metrics["samples"],
+    }

--- a/src/mayatools/scene/compare_image_silhouettes.py
+++ b/src/mayatools/scene/compare_image_silhouettes.py
@@ -29,6 +29,9 @@ def compare_image_silhouettes(
     correction_profile_min_width: float = 0.02,
     correction_profile_scale_range: List[float] = None,
     min_foreground_pixels: int = 8,
+    auto_crop_reference: bool = False,
+    auto_crop_candidate: bool = False,
+    auto_crop_padding_pixels: int = 0,
 ) -> Dict[str, Any]:
     """Compare two image silhouettes and optionally write an overlap diagnostic.
 
@@ -44,6 +47,8 @@ def compare_image_silhouettes(
     optional width correction profiles that can drive generic profile-deform
     tools. This is useful for generic visual QA of modeled products, props,
     icons, sprites, masks, decals, or rendered assets against reference images.
+    Optional foreground auto-cropping is useful when renders are centered on a
+    larger preview canvas.
     """
     import math
     import os
@@ -136,6 +141,47 @@ def compare_image_silhouettes(
                     foreground_bbox[3] = max(foreground_bbox[3], row)
         return count, foreground_bbox
 
+    def _is_foreground_pixel(red, green, blue, alpha, color):
+        if alpha < alpha_threshold:
+            return False
+        if mask_mode == "alpha":
+            return alpha >= alpha_threshold
+        if mask_mode == "luminance":
+            luminance = 0.2126 * red + 0.7152 * green + 0.0722 * blue
+            return luminance < luminance_threshold if invert_luminance else luminance >= luminance_threshold
+        return _color_distance([red, green, blue], color) > background_tolerance
+
+    def _auto_crop_bbox(image, search_bbox, color, padding_pixels, arg_prefix):
+        x0, y0, x1, y1 = search_bbox
+        width = image.width()
+        height = image.height()
+        min_x = width
+        min_y = height
+        max_x = -1
+        max_y = -1
+        foreground_pixels = 0
+        for y in range(y0, y1 + 1):
+            for x in range(x0, x1 + 1):
+                red, green, blue, alpha = _pixel_rgb_alpha(image, x, y)
+                if not _is_foreground_pixel(red, green, blue, alpha, color):
+                    continue
+                min_x = min(min_x, x)
+                min_y = min(min_y, y)
+                max_x = max(max_x, x)
+                max_y = max(max_y, y)
+                foreground_pixels += 1
+        if foreground_pixels < min_foreground_pixels:
+            raise ValueError(
+                f"Unable to auto-crop {arg_prefix}: not enough foreground pixels. "
+                "Adjust background colors, tolerances, thresholds, or provide an explicit bbox."
+            )
+        return [
+            max(0, min_x - padding_pixels),
+            max(0, min_y - padding_pixels),
+            min(width - 1, max_x + padding_pixels),
+            min(height - 1, max_y + padding_pixels),
+        ]
+
     def _fill_mask_holes(mask, width, height):
         visited = [bytearray(width) for _ in range(height)]
         stack = []
@@ -207,16 +253,7 @@ def compare_image_silhouettes(
             for column in range(width):
                 source_x = x0 + column
                 red, green, blue, alpha = _pixel_rgb_alpha(image, source_x, source_y)
-                if alpha < alpha_threshold:
-                    is_foreground = False
-                elif mask_mode == "alpha":
-                    is_foreground = alpha >= alpha_threshold
-                elif mask_mode == "luminance":
-                    luminance = 0.2126 * red + 0.7152 * green + 0.0722 * blue
-                    is_foreground = luminance < luminance_threshold if invert_luminance else luminance >= luminance_threshold
-                else:
-                    is_foreground = _color_distance([red, green, blue], color) > background_tolerance
-                if not is_foreground:
+                if not _is_foreground_pixel(red, green, blue, alpha, color):
                     continue
                 mask[row][column] = 1
         if fill_holes:
@@ -501,6 +538,11 @@ def compare_image_silhouettes(
     correction_profile_min_width = _validate_scalar(correction_profile_min_width, "correction_profile_min_width")
     if correction_profile_min_width < 0.0:
         raise ValueError("correction_profile_min_width must be greater than or equal to zero.")
+    auto_crop_padding_pixels = _validate_int(auto_crop_padding_pixels, "auto_crop_padding_pixels", 0)
+    if not isinstance(auto_crop_reference, bool):
+        raise ValueError("auto_crop_reference must be a boolean.")
+    if not isinstance(auto_crop_candidate, bool):
+        raise ValueError("auto_crop_candidate must be a boolean.")
     clean_correction_scale_range = [0.75, 1.25]
     if correction_profile_scale_range is not None:
         clean_correction_scale_range = _validate_vector(correction_profile_scale_range, 2, "correction_profile_scale_range")
@@ -537,11 +579,31 @@ def compare_image_silhouettes(
     if candidate_image.isNull():
         raise ValueError(f"Unable to load candidate image: {candidate_image_path}")
 
-    reference_bbox = _resolve_bbox(reference_image, reference_bbox_pixels, reference_bbox_normalized, "reference")
-    candidate_bbox = _resolve_bbox(candidate_image, candidate_bbox_pixels, candidate_bbox_normalized, "candidate")
     clean_background_color = _normalize_color(background_color, "background_color") if background_color else None
-    reference_background = clean_background_color or _estimate_background(reference_image, reference_bbox)
-    candidate_background = clean_background_color or _estimate_background(candidate_image, candidate_bbox)
+    reference_search_bbox = _resolve_bbox(reference_image, reference_bbox_pixels, reference_bbox_normalized, "reference")
+    candidate_search_bbox = _resolve_bbox(candidate_image, candidate_bbox_pixels, candidate_bbox_normalized, "candidate")
+    reference_background = clean_background_color or _estimate_background(reference_image, reference_search_bbox)
+    candidate_background = clean_background_color or _estimate_background(candidate_image, candidate_search_bbox)
+    if auto_crop_reference and reference_bbox_pixels is None and reference_bbox_normalized is None:
+        reference_bbox = _auto_crop_bbox(
+            reference_image,
+            reference_search_bbox,
+            reference_background,
+            auto_crop_padding_pixels,
+            "reference_image_path",
+        )
+    else:
+        reference_bbox = reference_search_bbox
+    if auto_crop_candidate and candidate_bbox_pixels is None and candidate_bbox_normalized is None:
+        candidate_bbox = _auto_crop_bbox(
+            candidate_image,
+            candidate_search_bbox,
+            candidate_background,
+            auto_crop_padding_pixels,
+            "candidate_image_path",
+        )
+    else:
+        candidate_bbox = candidate_search_bbox
 
     reference_data = _mask_from_image(reference_image, reference_bbox, reference_background)
     candidate_data = _mask_from_image(candidate_image, candidate_bbox, candidate_background)
@@ -605,6 +667,9 @@ def compare_image_silhouettes(
         "correction_profile_smoothing_radius": correction_profile_smoothing_radius,
         "correction_profile_min_width": correction_profile_min_width,
         "correction_profile_scale_range": clean_correction_scale_range,
+        "auto_crop_reference": auto_crop_reference,
+        "auto_crop_candidate": auto_crop_candidate,
+        "auto_crop_padding_pixels": auto_crop_padding_pixels,
         "reference_crop_bbox_pixels": reference_bbox,
         "candidate_crop_bbox_pixels": candidate_bbox,
         "reference_foreground_bbox_pixels": reference_data["foreground_bbox"],

--- a/src/mayatools/scene/compare_image_silhouettes.py
+++ b/src/mayatools/scene/compare_image_silhouettes.py
@@ -24,6 +24,10 @@ def compare_image_silhouettes(
     row_sample_count: int = 64,
     band_edges_normalized: List[float] = None,
     band_sample_count: int = 64,
+    correction_profile_sample_count: int = 0,
+    correction_profile_smoothing_radius: int = 1,
+    correction_profile_min_width: float = 0.02,
+    correction_profile_scale_range: List[float] = None,
     min_foreground_pixels: int = 8,
 ) -> Dict[str, Any]:
     """Compare two image silhouettes and optionally write an overlap diagnostic.
@@ -36,9 +40,10 @@ def compare_image_silhouettes(
     by a full x/y stretch. Hole filling is enabled by default so transparent or
     outlined objects can be compared as solid silhouettes. Returned metrics
     include IoU, overlap counts, aspect/centroid differences, per-row
-    silhouette width error, and optional vertical band width summaries. This is
-    useful for generic visual QA of modeled products, props, icons, sprites,
-    masks, decals, or rendered assets against reference images.
+    silhouette width error, optional vertical band width summaries, and
+    optional width correction profiles that can drive generic profile-deform
+    tools. This is useful for generic visual QA of modeled products, props,
+    icons, sprites, masks, decals, or rendered assets against reference images.
     """
     import math
     import os
@@ -367,6 +372,76 @@ def compare_image_silhouettes(
             })
         return bands
 
+    def _smooth_values(values, radius):
+        if radius <= 0:
+            return values[:]
+        smoothed = []
+        for index in range(len(values)):
+            start = max(0, index - radius)
+            end = min(len(values) - 1, index + radius)
+            window = values[start:end + 1]
+            smoothed.append(sum(window) / float(len(window)))
+        return smoothed
+
+    def _width_correction_profile(reference_mask, candidate_mask, reference_bbox, candidate_bbox):
+        if correction_profile_sample_count <= 0:
+            return {
+                "samples_top_to_bottom": [],
+                "axis_scale_profile_points": [],
+                "image_scale_profile_points": [],
+            }
+
+        top = min(reference_bbox[1], candidate_bbox[1])
+        bottom = max(reference_bbox[3], candidate_bbox[3])
+        if bottom <= top:
+            return {
+                "samples_top_to_bottom": [],
+                "axis_scale_profile_points": [],
+                "image_scale_profile_points": [],
+            }
+
+        scale_min, scale_max = clean_correction_scale_range
+        samples = []
+        raw_scales = []
+        for index in range(correction_profile_sample_count):
+            t = index / float(max(1, correction_profile_sample_count - 1))
+            row = int(round(top + t * (bottom - top)))
+            reference_width = _row_width(reference_mask, row)
+            candidate_width = _row_width(candidate_mask, row)
+            valid = reference_width >= correction_profile_min_width and candidate_width >= correction_profile_min_width
+            scale = reference_width / candidate_width if valid else 1.0
+            scale = _clamp(scale, scale_min, scale_max)
+            raw_scales.append(scale)
+            samples.append({
+                "row": row,
+                "row_normalized_canvas": 0.0 if compare_height == 1 else row / float(compare_height - 1),
+                "row_normalized_profile": t,
+                "axis_normalized_profile": 1.0 - t,
+                "reference_width": reference_width,
+                "candidate_width": candidate_width,
+                "signed_width_error": candidate_width - reference_width,
+                "raw_scale": scale,
+                "valid": valid,
+            })
+
+        smoothed_scales = _smooth_values(raw_scales, correction_profile_smoothing_radius)
+        for index, sample in enumerate(samples):
+            sample["scale"] = smoothed_scales[index]
+
+        image_profile = [
+            [sample["row_normalized_profile"], sample["scale"]]
+            for sample in samples
+        ]
+        axis_profile = [
+            [sample["axis_normalized_profile"], sample["scale"]]
+            for sample in reversed(samples)
+        ]
+        return {
+            "samples_top_to_bottom": samples,
+            "axis_scale_profile_points": axis_profile,
+            "image_scale_profile_points": image_profile,
+        }
+
     def _write_overlay(path, reference_mask, candidate_mask):
         image = QImage(compare_width, compare_height, QImage.Format_ARGB32)
         for y in range(compare_height):
@@ -415,6 +490,22 @@ def compare_image_silhouettes(
     compare_height = _validate_int(compare_height, "compare_height", 8)
     row_sample_count = _validate_int(row_sample_count, "row_sample_count", 2)
     band_sample_count = _validate_int(band_sample_count, "band_sample_count", 2)
+    correction_profile_sample_count = _validate_int(correction_profile_sample_count, "correction_profile_sample_count", 0)
+    if correction_profile_sample_count == 1:
+        raise ValueError("correction_profile_sample_count must be 0 or an integer greater than or equal to 2.")
+    correction_profile_smoothing_radius = _validate_int(
+        correction_profile_smoothing_radius,
+        "correction_profile_smoothing_radius",
+        0,
+    )
+    correction_profile_min_width = _validate_scalar(correction_profile_min_width, "correction_profile_min_width")
+    if correction_profile_min_width < 0.0:
+        raise ValueError("correction_profile_min_width must be greater than or equal to zero.")
+    clean_correction_scale_range = [0.75, 1.25]
+    if correction_profile_scale_range is not None:
+        clean_correction_scale_range = _validate_vector(correction_profile_scale_range, 2, "correction_profile_scale_range")
+    if clean_correction_scale_range[0] <= 0.0 or clean_correction_scale_range[1] <= clean_correction_scale_range[0]:
+        raise ValueError("correction_profile_scale_range must be [min_scale, max_scale] with 0 < min < max.")
     min_foreground_pixels = _validate_int(min_foreground_pixels, "min_foreground_pixels", 1)
     clean_band_edges = None
     if band_edges_normalized is not None:
@@ -478,6 +569,12 @@ def compare_image_silhouettes(
     recall = intersection / float(reference_count) if reference_count else 0.0
     width_metrics = _row_width_errors(reference_mask, candidate_mask)
     band_metrics = _band_width_errors(reference_mask, candidate_mask, clean_band_edges) if clean_band_edges else []
+    correction_profile = _width_correction_profile(
+        reference_mask,
+        candidate_mask,
+        reference_canvas_bbox,
+        candidate_canvas_bbox,
+    )
 
     if output_path:
         output_path = os.path.normpath(output_path)
@@ -504,6 +601,10 @@ def compare_image_silhouettes(
         "compare_height": compare_height,
         "band_edges_normalized": clean_band_edges,
         "band_sample_count": band_sample_count,
+        "correction_profile_sample_count": correction_profile_sample_count,
+        "correction_profile_smoothing_radius": correction_profile_smoothing_radius,
+        "correction_profile_min_width": correction_profile_min_width,
+        "correction_profile_scale_range": clean_correction_scale_range,
         "reference_crop_bbox_pixels": reference_bbox,
         "candidate_crop_bbox_pixels": candidate_bbox,
         "reference_foreground_bbox_pixels": reference_data["foreground_bbox"],
@@ -537,4 +638,5 @@ def compare_image_silhouettes(
         "mean_signed_width_error": width_metrics["mean_signed_width_error"],
         "row_width_samples": width_metrics["samples"],
         "band_width_metrics": band_metrics,
+        "correction_profile": correction_profile,
     }

--- a/src/mayatools/scene/create_reference_image_plane.py
+++ b/src/mayatools/scene/create_reference_image_plane.py
@@ -1,0 +1,310 @@
+from typing import Dict, List, Any, Union
+
+
+def create_reference_image_plane(
+    image_path: str,
+    name: str = "reference_image_plane",
+    target_objects: Union[str, List[str]] = None,
+    center: List[float] = None,
+    width: float = None,
+    height: float = None,
+    image_aspect: float = 0.0,
+    fit_to_targets: bool = True,
+    fit_padding: float = 1.0,
+    plane_axis: str = "z",
+    offset: float = -0.05,
+    opacity: float = 0.45,
+    material_name: str = None,
+    subdivisions_x: int = 1,
+    subdivisions_y: int = 1,
+    lock_transform: bool = False,
+    replace_existing: bool = True,
+) -> Dict[str, Any]:
+    """Create a world-space textured reference image plane.
+
+    The plane can be fitted to one or more target objects so photographed or
+    concept-art references can be compared directly against modeled geometry.
+    plane_axis controls the plane normal: "z" creates an XY front plane, "x"
+    creates a YZ side plane, and "y" creates an XZ top/bottom plane.
+    """
+    import os
+    import struct
+    import maya.cmds as cmds
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(v) for v in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(v) for v in values]
+
+    def _validate_optional_scalar(value, arg_name):
+        if value is None:
+            return None
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric or None.")
+        value = float(value)
+        if value <= 0.0:
+            raise ValueError(f"{arg_name} must be greater than zero.")
+        return value
+
+    def _validate_segments(value, arg_name):
+        if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to 1.")
+        return value
+
+    def _normalize_targets(targets):
+        if targets is None:
+            return []
+        if isinstance(targets, str):
+            targets = [targets]
+        if not isinstance(targets, list) or not all(isinstance(item, str) for item in targets):
+            raise ValueError("target_objects must be a string, a list of strings, or None.")
+        for target in targets:
+            if not cmds.objExists(target):
+                raise ValueError(f"target object does not exist: {target}")
+        return targets
+
+    def _combined_bbox(objects):
+        first = cmds.exactWorldBoundingBox(objects[0])
+        bbox = list(first)
+        for obj in objects[1:]:
+            obj_bbox = cmds.exactWorldBoundingBox(obj)
+            bbox[0] = min(bbox[0], obj_bbox[0])
+            bbox[1] = min(bbox[1], obj_bbox[1])
+            bbox[2] = min(bbox[2], obj_bbox[2])
+            bbox[3] = max(bbox[3], obj_bbox[3])
+            bbox[4] = max(bbox[4], obj_bbox[4])
+            bbox[5] = max(bbox[5], obj_bbox[5])
+        return bbox
+
+    def _read_image_dimensions(path):
+        with open(path, "rb") as handle:
+            header = handle.read(32)
+            if header.startswith(b"\x89PNG\r\n\x1a\n"):
+                return struct.unpack(">II", header[16:24])
+            if header[:6] in {b"GIF87a", b"GIF89a"}:
+                return struct.unpack("<HH", header[6:10])
+            if header.startswith(b"\xff\xd8"):
+                handle.seek(2)
+                while True:
+                    byte = handle.read(1)
+                    while byte and byte != b"\xff":
+                        byte = handle.read(1)
+                    if not byte:
+                        break
+                    marker = handle.read(1)
+                    while marker == b"\xff":
+                        marker = handle.read(1)
+                    if not marker:
+                        break
+                    marker_code = marker[0]
+                    if marker_code in {0xD8, 0xD9}:
+                        continue
+                    length_bytes = handle.read(2)
+                    if len(length_bytes) != 2:
+                        break
+                    block_length = int.from_bytes(length_bytes, "big")
+                    if block_length < 2:
+                        break
+                    sof_markers = {0xC0, 0xC1, 0xC2, 0xC3, 0xC5, 0xC6, 0xC7, 0xC9, 0xCA, 0xCB, 0xCD, 0xCE, 0xCF}
+                    if marker_code in sof_markers:
+                        data = handle.read(block_length - 2)
+                        if len(data) >= 5:
+                            image_height = int.from_bytes(data[1:3], "big")
+                            image_width = int.from_bytes(data[3:5], "big")
+                            return image_width, image_height
+                        break
+                    handle.seek(block_length - 2, os.SEEK_CUR)
+        return None, None
+
+    def _safe_delete(node_name):
+        if node_name and cmds.objExists(node_name):
+            try:
+                cmds.delete(node_name)
+            except Exception:
+                pass
+
+    if not image_path:
+        raise ValueError("image_path is required.")
+    normalized_image_path = os.path.normpath(image_path)
+    if not os.path.isfile(normalized_image_path):
+        raise ValueError(f"Image path does not exist: {image_path}")
+    if not name:
+        base_name = os.path.splitext(os.path.basename(normalized_image_path))[0] or "reference"
+        name = f"{base_name}_reference_plane"
+
+    target_objects = _normalize_targets(target_objects)
+    width = _validate_optional_scalar(width, "width")
+    height = _validate_optional_scalar(height, "height")
+    if not _is_number(image_aspect):
+        raise ValueError("image_aspect must be numeric.")
+    image_aspect = float(image_aspect)
+    if image_aspect < 0.0:
+        raise ValueError("image_aspect must be greater than or equal to zero.")
+    if not _is_number(fit_padding) or fit_padding <= 0.0:
+        raise ValueError("fit_padding must be numeric and greater than zero.")
+    fit_padding = float(fit_padding)
+    if not _is_number(offset):
+        raise ValueError("offset must be numeric.")
+    offset = float(offset)
+    if not _is_number(opacity) or opacity < 0.0 or opacity > 1.0:
+        raise ValueError("opacity must be numeric in the 0..1 range.")
+    opacity = float(opacity)
+    subdivisions_x = _validate_segments(subdivisions_x, "subdivisions_x")
+    subdivisions_y = _validate_segments(subdivisions_y, "subdivisions_y")
+
+    plane_axis = plane_axis.lower().strip()
+    axis_data = {
+        "x": {"axis": [1, 0, 0], "width_index": 2, "height_index": 1, "normal_index": 0},
+        "y": {"axis": [0, 1, 0], "width_index": 0, "height_index": 2, "normal_index": 1},
+        "z": {"axis": [0, 0, 1], "width_index": 0, "height_index": 1, "normal_index": 2},
+    }
+    if plane_axis not in axis_data:
+        raise ValueError("plane_axis must be one of x, y, or z.")
+    plane_info = axis_data[plane_axis]
+
+    image_width_pixels, image_height_pixels = _read_image_dimensions(normalized_image_path)
+    if image_aspect == 0.0:
+        if image_width_pixels and image_height_pixels:
+            image_aspect = float(image_width_pixels) / float(image_height_pixels)
+        else:
+            image_aspect = 1.0
+
+    bbox = None
+    bbox_center = [0.0, 0.0, 0.0]
+    bbox_size = [1.0, 1.0, 1.0]
+    if target_objects:
+        bbox = _combined_bbox(target_objects)
+        bbox_center = [
+            (bbox[0] + bbox[3]) * 0.5,
+            (bbox[1] + bbox[4]) * 0.5,
+            (bbox[2] + bbox[5]) * 0.5,
+        ]
+        bbox_size = [
+            max(1e-6, bbox[3] - bbox[0]),
+            max(1e-6, bbox[4] - bbox[1]),
+            max(1e-6, bbox[5] - bbox[2]),
+        ]
+
+    if center is None:
+        center = bbox_center[:]
+    else:
+        center = _validate_vector(center, 3, "center")
+
+    if target_objects and fit_to_targets:
+        if height is None:
+            height = bbox_size[plane_info["height_index"]] * fit_padding
+        if width is None:
+            width = height * image_aspect
+    if height is None and width is None:
+        height = 1.0
+        width = height * image_aspect
+    elif height is None:
+        height = width / max(1e-9, image_aspect)
+    elif width is None:
+        width = height * image_aspect
+
+    if target_objects and center is not None:
+        normal_index = plane_info["normal_index"]
+        if offset < 0.0:
+            center[normal_index] = bbox[normal_index] + offset
+        else:
+            center[normal_index] = bbox[normal_index + 3] + offset
+    else:
+        center[plane_info["normal_index"]] += offset
+
+    if material_name is None:
+        material_name = f"{name}_mat"
+    shading_group = f"{material_name}SG"
+
+    if replace_existing:
+        for node_name in [name, shading_group, f"{material_name}_file", f"{material_name}_place2d", material_name]:
+            _safe_delete(node_name)
+
+    plane = cmds.polyPlane(
+        name=name,
+        width=width,
+        height=height,
+        subdivisionsX=subdivisions_x,
+        subdivisionsY=subdivisions_y,
+        axis=plane_info["axis"],
+        constructionHistory=False,
+    )[0]
+    cmds.xform(plane, translation=center, worldSpace=True)
+
+    shader = cmds.shadingNode("lambert", asShader=True, name=material_name)
+    file_node = cmds.shadingNode("file", asTexture=True, name=f"{material_name}_file")
+    place2d = cmds.shadingNode("place2dTexture", asUtility=True, name=f"{material_name}_place2d")
+    for attr in ["outUV", "outUvFilterSize"]:
+        destination = "uvCoord" if attr == "outUV" else "uvFilterSize"
+        cmds.connectAttr(f"{place2d}.{attr}", f"{file_node}.{destination}", force=True)
+    for attr in [
+        "coverage",
+        "translateFrame",
+        "rotateFrame",
+        "mirrorU",
+        "mirrorV",
+        "stagger",
+        "wrapU",
+        "wrapV",
+        "repeatUV",
+        "offset",
+        "rotateUV",
+        "noiseUV",
+        "vertexUvOne",
+        "vertexUvTwo",
+        "vertexUvThree",
+        "vertexCameraOne",
+    ]:
+        if cmds.attributeQuery(attr, node=place2d, exists=True) and cmds.attributeQuery(attr, node=file_node, exists=True):
+            cmds.connectAttr(f"{place2d}.{attr}", f"{file_node}.{attr}", force=True)
+
+    cmds.setAttr(f"{file_node}.fileTextureName", normalized_image_path, type="string")
+    cmds.connectAttr(f"{file_node}.outColor", f"{shader}.color", force=True)
+    cmds.setAttr(f"{shader}.ambientColor", 1.0, 1.0, 1.0, type="double3")
+    cmds.setAttr(f"{shader}.diffuse", 1.0)
+    cmds.setAttr(f"{shader}.transparency", 1.0 - opacity, 1.0 - opacity, 1.0 - opacity, type="double3")
+
+    shading_group = cmds.sets(name=shading_group, empty=True, renderable=True, noSurfaceShader=True)
+    cmds.connectAttr(f"{shader}.outColor", f"{shading_group}.surfaceShader", force=True)
+    cmds.sets(plane, edit=True, forceElement=shading_group)
+
+    shape_nodes = cmds.listRelatives(plane, shapes=True, fullPath=False) or []
+    for shape in shape_nodes:
+        for attr in ["castsShadows", "receiveShadows", "visibleInReflections", "visibleInRefractions"]:
+            if cmds.attributeQuery(attr, node=shape, exists=True):
+                try:
+                    cmds.setAttr(f"{shape}.{attr}", False)
+                except Exception:
+                    pass
+
+    if lock_transform:
+        for attr in ["tx", "ty", "tz", "rx", "ry", "rz", "sx", "sy", "sz"]:
+            try:
+                cmds.setAttr(f"{plane}.{attr}", lock=True, keyable=False, channelBox=False)
+            except Exception:
+                pass
+
+    return {
+        "success": True,
+        "plane": plane,
+        "shape_nodes": shape_nodes,
+        "material": shader,
+        "file_node": file_node,
+        "place2d": place2d,
+        "shading_group": shading_group,
+        "image_path": normalized_image_path,
+        "image_width_pixels": image_width_pixels,
+        "image_height_pixels": image_height_pixels,
+        "image_aspect": image_aspect,
+        "target_objects": target_objects,
+        "bounding_box": bbox,
+        "center": center,
+        "width": width,
+        "height": height,
+        "plane_axis": plane_axis,
+        "offset": offset,
+        "opacity": opacity,
+    }

--- a/src/mayatools/scene/create_reference_image_plane.py
+++ b/src/mayatools/scene/create_reference_image_plane.py
@@ -14,6 +14,7 @@ def create_reference_image_plane(
     plane_axis: str = "z",
     offset: float = -0.05,
     opacity: float = 0.45,
+    use_alpha: bool = False,
     material_name: str = None,
     subdivisions_x: int = 1,
     subdivisions_y: int = 1,
@@ -25,7 +26,8 @@ def create_reference_image_plane(
     The plane can be fitted to one or more target objects so photographed or
     concept-art references can be compared directly against modeled geometry.
     plane_axis controls the plane normal: "z" creates an XY front plane, "x"
-    creates a YZ side plane, and "y" creates an XZ top/bottom plane.
+    creates a YZ side plane, and "y" creates an XZ top/bottom plane. When
+    use_alpha is true, texture alpha is connected to material transparency.
     """
     import os
     import struct
@@ -220,7 +222,15 @@ def create_reference_image_plane(
     shading_group = f"{material_name}SG"
 
     if replace_existing:
-        for node_name in [name, shading_group, f"{material_name}_file", f"{material_name}_place2d", material_name]:
+        for node_name in [
+            name,
+            shading_group,
+            f"{material_name}_file",
+            f"{material_name}_place2d",
+            f"{material_name}_alpha_opacity",
+            f"{material_name}_alpha_reverse",
+            material_name,
+        ]:
             _safe_delete(node_name)
 
     plane = cmds.polyPlane(
@@ -266,6 +276,20 @@ def create_reference_image_plane(
     cmds.setAttr(f"{shader}.ambientColor", 1.0, 1.0, 1.0, type="double3")
     cmds.setAttr(f"{shader}.diffuse", 1.0)
     cmds.setAttr(f"{shader}.transparency", 1.0 - opacity, 1.0 - opacity, 1.0 - opacity, type="double3")
+    alpha_node = None
+    alpha_opacity_node = None
+    if use_alpha and cmds.attributeQuery("transparency", node=shader, exists=True):
+        if cmds.attributeQuery("outAlpha", node=file_node, exists=True):
+            alpha_opacity_node = cmds.shadingNode("multiplyDivide", asUtility=True, name=f"{material_name}_alpha_opacity")
+            cmds.setAttr(f"{alpha_opacity_node}.input2", opacity, opacity, opacity, type="double3")
+            for channel in ["X", "Y", "Z"]:
+                cmds.connectAttr(f"{file_node}.outAlpha", f"{alpha_opacity_node}.input1{channel}", force=True)
+            alpha_node = cmds.shadingNode("reverse", asUtility=True, name=f"{material_name}_alpha_reverse")
+            for channel in ["X", "Y", "Z"]:
+                cmds.connectAttr(f"{alpha_opacity_node}.output{channel}", f"{alpha_node}.input{channel}", force=True)
+            cmds.connectAttr(f"{alpha_node}.output", f"{shader}.transparency", force=True)
+        elif cmds.attributeQuery("outTransparency", node=file_node, exists=True):
+            cmds.connectAttr(f"{file_node}.outTransparency", f"{shader}.transparency", force=True)
 
     shading_group = cmds.sets(name=shading_group, empty=True, renderable=True, noSurfaceShader=True)
     cmds.connectAttr(f"{shader}.outColor", f"{shading_group}.surfaceShader", force=True)
@@ -294,6 +318,8 @@ def create_reference_image_plane(
         "material": shader,
         "file_node": file_node,
         "place2d": place2d,
+        "alpha_node": alpha_node,
+        "alpha_opacity_node": alpha_opacity_node,
         "shading_group": shading_group,
         "image_path": normalized_image_path,
         "image_width_pixels": image_width_pixels,
@@ -307,4 +333,5 @@ def create_reference_image_plane(
         "plane_axis": plane_axis,
         "offset": offset,
         "opacity": opacity,
+        "use_alpha": bool(use_alpha),
     }

--- a/src/mayatools/scene/generate_scene.py
+++ b/src/mayatools/scene/generate_scene.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Any, Optional, Union
+from typing import Dict, Any
 
 
 def generate_scene(
@@ -7,932 +7,162 @@ def generate_scene(
     parameters: Dict[str, Any] = None
 ) -> Dict[str, Any]:
     """Generate a complete 3D scene with multiple objects arranged according to a theme.
-    
-    Available scene types:
-    - city: Generate a city with buildings, streets, and cars
-    - forest: Generate a forest with trees, terrain, and optional paths
-    - living_room: Generate a living room with furniture and decorations
-    - office: Generate an office with desks, chairs, and office equipment
-    - park: Generate a park with trees, benches, and paths
-    
+
+    Available scene types are city, forest, living_room, office, and park.
     Parameters is a dictionary containing scene-specific settings.
-    Example for city: {'blocks': 3, 'building_density': 0.8, 'include_cars': True}
-    Example for forest: {'tree_count': 15, 'forest_size': 50.0, 'include_path': True}
-    
-    Returns a dictionary with information about the created scene and objects.
     """
-    import maya.cmds as cmds
-    import random
     import math
-    
-    # Set default parameters dict if none provided
+    import random
+    import maya.cmds as cmds
+
     if parameters is None:
         parameters = {}
-    
-    # Set default name if none provided
+
+    scene_type = scene_type.lower()
     if name is None:
         name = f"{scene_type}_scene_{int(random.random() * 1000)}"
-    
-    # Create a root group for the entire scene
+
     scene_group = cmds.group(empty=True, name=name)
-    created_objects = []
-    
-    # Import required Maya tools for advanced model creation
-    import sys
-    import os
-    
-    # Find the directory of this script
-    script_dir = os.path.dirname(os.path.abspath(__file__))
-    
-    # Navigate up to the mayatools directory
-    mayatools_dir = os.path.dirname(script_dir)
-    
-    # Add to sys.path if not already there
-    if mayatools_dir not in sys.path:
-        sys.path.append(mayatools_dir)
-    
-    # Import the relevant tools
-    from thirdparty.create_advanced_model import create_advanced_model
-    from thirdparty.create_material import create_material
-    from thirdparty.organize_objects import organize_objects
-    
-    def _create_and_track(func, **kwargs):
-        """Helper to call a function and track its created objects"""
-        result = func(**kwargs)
-        if "name" in result:
-            created_objects.append(cabinet)
-            cmds.parent(cabinet, scene_group)
-            
-            # Create cabinet material
-            cabinet_color = [0.8, 0.8, 0.8] if modern_style else [0.6, 0.4, 0.2]
-            _create_and_track(
-                create_material,
-                material_type="lambert" if modern_style else "wood",
-                name=f"{name}_cabinet_{i}_material",
-                color=cabinet_color,
-                assign_to=cabinet
-            )
-        
-        return {
-            "success": True,
-            "name": scene_group,
-            "scene_type": "office",
-            "objects_count": len(created_objects),
-            "desks_count": desk_count
-        }
-    
-    elif scene_type.lower() == "park":
-        # Get park parameters
-        park_size = parameters.get('park_size', 60.0)
-        tree_count = parameters.get('tree_count', 10)
-        include_benches = parameters.get('include_benches', True)
-        include_fountain = parameters.get('include_fountain', True)
-        
-        # Create ground
-        ground = cmds.polyPlane(
-            name=f"{name}_ground",
-            width=park_size,
-            height=park_size,
-            subdivisionsX=20,
-            subdivisionsY=20
-        )[0]
-        created_objects.append(ground)
-        cmds.parent(ground, scene_group)
-        
-        # Apply slight noise to terrain for natural look
-        cmds.select(f"{ground}.vtx[*]")
-        vertices = cmds.ls(selection=True, flatten=True)
-        for vertex in vertices:
-            if random.random() < 0.6:  # Don't displace every vertex
-                height = random.uniform(0, 0.2)
-                cmds.move(0, height, 0, vertex, relative=True)
-        
-        # Create grass material
-        _create_and_track(
-            create_material,
-            material_type="lambert",
-            name=f"{name}_grass_material",
-            color=[0.2, 0.6, 0.2],  # Green
-            assign_to=ground
-        )
-        
-        # Create central circular path
-        path_radius = park_size * 0.3
-        
-        # Create path circle curve
-        path_points = []
-        path_segments = 24
-        
-        for i in range(path_segments + 1):
-            angle = 2.0 * math.pi * i / path_segments
-            x = path_radius * math.cos(angle)
-            z = path_radius * math.sin(angle)
-            path_points.append([x, 0.1, z])  # Slightly above ground
-        
-        # Create the path as a nurbs curve
-        path_curve = cmds.curve(
-            name=f"{name}_path_curve",
-            p=path_points,
-            degree=3,
-            periodic=True
-        )
-        
-        # Create a profile for the path
-        path_profile = cmds.circle(
-            name=f"{name}_path_profile",
-            radius=1.5,
-            normal=[0, 1, 0]
-        )[0]
-        
-        # Extrude the profile along the curve
-        path = cmds.extrude(
-            path_profile,
-            path_curve,
-            name=f"{name}_path",
-            fixedPath=True
-        )[0]
-        
-        # Create path material
-        _create_and_track(
-            create_material,
-            material_type="lambert",
-            name=f"{name}_path_material",
-            color=[0.8, 0.8, 0.7],  # Light tan
-            assign_to=path
-        )
-        
-        created_objects.append(path)
-        cmds.parent(path, scene_group)
-        
-        # Clean up temporary curve and profile
-        cmds.delete(path_curve, path_profile)
-        
-        # Add trees around the park
-        tree_types = ["oak", "pine", "maple"]
-        
-        for t in range(tree_count):
-            # Place trees with some randomness, but avoiding the path
-            distance = random.uniform(path_radius + 5, park_size/2 * 0.9)
-            angle = random.uniform(0, 2 * math.pi)
-            
-            tree_x = distance * math.cos(angle)
-            tree_z = distance * math.sin(angle)
-            
-            # Get approximate ground height at this position
-            ground_height = 0
-            
-            # Randomize tree parameters
-            tree_type = random.choice(tree_types)
-            tree_scale = random.uniform(0.8, 1.5)
-            
-            # Create the tree
-            tree = _create_and_track(
-                create_advanced_model,
-                model_type="tree",
-                name=f"{name}_tree_{t}",
-                translate=[tree_x, ground_height, tree_z],
-                rotate=[0, random.uniform(0, 360), 0],
-                scale=tree_scale,
-                parameters={
-                    'type': tree_type,
-                    'trunk_height': random.uniform(4.0, 7.0),
-                    'branches': int(random.uniform(3, 6)),
-                    'leaf_density': random.uniform(0.6, 0.9)
-                }
-            )
-        
-        # Add benches around the path
-        if include_benches:
-            bench_count = int(path_radius / 5)  # Roughly one bench every 5 units
-            
-            for b in range(bench_count):
-                angle = 2.0 * math.pi * b / bench_count
-                
-                # Place benches slightly outside the path
-                bench_radius = path_radius + 3.0
-                bench_x = bench_radius * math.cos(angle)
-                bench_z = bench_radius * math.sin(angle)
-                
-                # Create bench seat
-                bench_seat = cmds.polyCube(
-                    name=f"{name}_bench_seat_{b}",
-                    width=3.0,
-                    height=0.2,
-                    depth=1.0
-                )[0]
-                
-                # Create bench back
-                bench_back = cmds.polyCube(
-                    name=f"{name}_bench_back_{b}",
-                    width=3.0,
-                    height=1.0,
-                    depth=0.2
-                )[0]
-                
-                # Position and orient the bench to face the center
-                cmds.move(bench_x, 0.6, bench_z, bench_seat)
-                cmds.move(bench_x, 1.2, bench_z - 0.4, bench_back)
-                
-                # Rotate to face center
-                bench_rot_y = math.degrees(angle) + 180
-                cmds.rotate(0, bench_rot_y, 0, bench_seat)
-                cmds.rotate(0, bench_rot_y, 0, bench_back)
-                
-                created_objects.extend([bench_seat, bench_back])
-                cmds.parent([bench_seat, bench_back], scene_group)
-                
-                # Create bench material
-                _create_and_track(
-                    create_material,
-                    material_type="wood",
-                    name=f"{name}_bench_material_{b}",
-                    color=[0.6, 0.4, 0.2],  # Brown
-                    assign_to=[bench_seat, bench_back]
-                )
-        
-        # Add central fountain
-        if include_fountain:
-            # Create fountain base
-            fountain_radius = 5.0
-            fountain_base = cmds.polyCylinder(
-                name=f"{name}_fountain_base",
-                radius=fountain_radius,
-                height=1.0
-            )[0]
-            cmds.move(0, 0.5, 0, fountain_base)
-            
-            # Create water pool
-            water_pool = cmds.polyCylinder(
-                name=f"{name}_water_pool",
-                radius=fountain_radius * 0.9,
-                height=0.8
-            )[0]
-            cmds.move(0, 0.5, 0, water_pool)
-            
-            # Create central column
-            fountain_column = cmds.polyCylinder(
-                name=f"{name}_fountain_column",
-                radius=fountain_radius * 0.2,
-                height=3.0
-            )[0]
-            cmds.move(0, 1.5, 0, fountain_column)
-            
-            # Create top bowl
-            top_bowl = cmds.polyCylinder(
-                name=f"{name}_top_bowl",
-                radius=fountain_radius * 0.5,
-                height=0.5
-            )[0]
-            cmds.move(0, 3.0, 0, top_bowl)
-            
-            created_objects.extend([fountain_base, water_pool, fountain_column, top_bowl])
-            cmds.parent([fountain_base, water_pool, fountain_column, top_bowl], scene_group)
-            
-            # Create materials
-            _create_and_track(
-                create_material,
-                material_type="stone",
-                name=f"{name}_fountain_material",
-                color=[0.7, 0.7, 0.7],  # Gray stone
-                assign_to=[fountain_base, fountain_column, top_bowl]
-            )
-            
-            _create_and_track(
-                create_material,
-                material_type="glass",
-                name=f"{name}_water_material",
-                color=[0.2, 0.4, 0.8],  # Blue water
-                assign_to=water_pool
-            )
-        
-        return {
-            "success": True,
-            "name": scene_group,
-            "scene_type": "park",
-            "objects_count": len(created_objects),
-            "trees_count": tree_count,
-            "has_benches": include_benches,
-            "has_fountain": include_fountain
-        }
-    
-    else:
-        raise ValueError(f"Unknown scene type: {scene_type}. Use city, forest, living_room, office, or park")
-.append(result["name"])
-            # Parent to scene group
-            try:
-                cmds.parent(result["name"], scene_group)
-            except:
-                # May already be parented if the function does grouping internally
-                pass
-        return result
-    
-    # Generate scene based on type
-    if scene_type.lower() == "city":
-        # Get city parameters
-        blocks = parameters.get('blocks', 3)
-        building_density = parameters.get('building_density', 0.8)
-        include_cars = parameters.get('include_cars', True)
-        street_width = parameters.get('street_width', 10.0)
-        block_size = parameters.get('block_size', 30.0)
-        
-        # Create ground plane
-        city_size = blocks * (block_size + street_width)
-        ground = cmds.polyPlane(name=f"{name}_ground", width=city_size, height=city_size, subdivisionsX=blocks*2, subdivisionsY=blocks*2)[0]
-        created_objects.append(ground)
-        cmds.parent(ground, scene_group)
-        
-        # Create buildings for each block
+    created = []
+
+    def _mat(mat_name, color):
+        shader = cmds.shadingNode("lambert", asShader=True, name=mat_name)
+        cmds.setAttr(f"{shader}.color", color[0], color[1], color[2], type="double3")
+        sg = cmds.sets(empty=True, renderable=True, noSurfaceShader=True, name=f"{shader}SG")
+        cmds.connectAttr(f"{shader}.outColor", f"{sg}.surfaceShader", force=True)
+        return sg
+
+    def _assign(obj, sg):
+        if obj:
+            cmds.sets(obj, edit=True, forceElement=sg)
+
+    def _cube(obj_name, width, height, depth, pos, color):
+        obj = cmds.polyCube(name=obj_name, width=width, height=height, depth=depth)[0]
+        cmds.move(pos[0], pos[1], pos[2], obj)
+        obj = cmds.parent(obj, scene_group)[0]
+        _assign(obj, _mat(f"{obj_name}_mat", color))
+        created.append(obj)
+        return obj
+
+    def _cylinder(obj_name, radius, height, pos, color, subdivisions=24):
+        obj = cmds.polyCylinder(name=obj_name, radius=radius, height=height, subdivisionsAxis=subdivisions)[0]
+        cmds.move(pos[0], pos[1], pos[2], obj)
+        obj = cmds.parent(obj, scene_group)[0]
+        _assign(obj, _mat(f"{obj_name}_mat", color))
+        created.append(obj)
+        return obj
+
+    def _cone(obj_name, radius, height, pos, color, subdivisions=20):
+        obj = cmds.polyCone(name=obj_name, radius=radius, height=height, subdivisionsAxis=subdivisions)[0]
+        cmds.move(pos[0], pos[1], pos[2], obj)
+        obj = cmds.parent(obj, scene_group)[0]
+        _assign(obj, _mat(f"{obj_name}_mat", color))
+        created.append(obj)
+        return obj
+
+    if scene_type == "city":
+        blocks = int(parameters.get("blocks", 2))
+        include_cars = bool(parameters.get("include_cars", True))
+        block_size = float(parameters.get("block_size", 20.0))
+        street_width = float(parameters.get("street_width", 8.0))
+        city_size = blocks * block_size + (blocks + 1) * street_width
+
+        ground = cmds.polyPlane(name=f"{name}_ground", width=city_size, height=city_size)[0]
+        ground = cmds.parent(ground, scene_group)[0]
+        _assign(ground, _mat(f"{name}_asphalt_mat", [0.18, 0.18, 0.18]))
+        created.append(ground)
+
         building_count = 0
-        for block_x in range(blocks):
-            for block_z in range(blocks):
-                # Calculate block position
-                block_center_x = (block_x - blocks/2 + 0.5) * (block_size + street_width)
-                block_center_z = (block_z - blocks/2 + 0.5) * (block_size + street_width)
-                
-                # Determine number of buildings for this block
-                buildings_per_block = int(random.uniform(1, 4))
-                
-                for b in range(buildings_per_block):
-                    # Skip some buildings based on density
-                    if random.random() > building_density:
-                        continue
-                    
-                    # Calculate building position within block
-                    offset_x = random.uniform(-block_size/3, block_size/3)
-                    offset_z = random.uniform(-block_size/3, block_size/3)
-                    building_x = block_center_x + offset_x
-                    building_z = block_center_z + offset_z
-                    
-                    # Randomize building parameters
-                    building_height = random.uniform(10.0, 50.0)
-                    building_width = random.uniform(5.0, 15.0)
-                    building_depth = random.uniform(5.0, 15.0)
-                    
-                    # Create the building
-                    building = _create_and_track(
-                        create_advanced_model,
-                        model_type="building",
-                        name=f"{name}_building_{building_count}",
-                        translate=[building_x, 0, building_z],
-                        parameters={
-                            'height': building_height,
-                            'width': building_width, 
-                            'depth': building_depth,
-                            'floors': int(building_height / 4),
-                            'windows_per_floor': int(max(building_width, building_depth) / 2)
-                        }
-                    )
-                    
+        for bx in range(blocks):
+            for bz in range(blocks):
+                base_x = -city_size / 2 + street_width + bx * (block_size + street_width)
+                base_z = -city_size / 2 + street_width + bz * (block_size + street_width)
+                for i in range(3):
+                    width = random.uniform(4.0, 7.0)
+                    depth = random.uniform(4.0, 7.0)
+                    height = random.uniform(8.0, 28.0)
+                    x = base_x + random.uniform(0, block_size)
+                    z = base_z + random.uniform(0, block_size)
+                    _cube(f"{name}_building_{building_count}", width, height, depth, [x, height / 2, z], [0.35, 0.38, 0.42])
                     building_count += 1
-        
-        # Add cars if requested
+
+        car_count = 0
         if include_cars:
-            car_count = int(blocks * blocks * 0.5)  # Fewer cars than buildings
-            
-            for c in range(car_count):
-                # Place cars on the street grid
-                street_x = random.randint(0, blocks) * (block_size + street_width) - city_size/2
-                street_z = random.randint(0, blocks) * (block_size + street_width) - city_size/2
-                
-                # Small random offset to avoid perfect alignment
-                street_x += random.uniform(-2.0, 2.0)
-                street_z += random.uniform(-2.0, 2.0)
-                
-                # Randomize car parameters
-                car_type = random.choice(["sporty", "standard"])
-                car_color = [random.random(), random.random(), random.random()]
-                
-                # Create the car
-                car = _create_and_track(
-                    create_advanced_model,
-                    model_type="car",
-                    name=f"{name}_car_{c}",
-                    translate=[street_x, 0, street_z],
-                    rotate=[0, random.uniform(0, 360), 0],
-                    color=car_color,
-                    scale=random.uniform(0.8, 1.2),
-                    parameters={
-                        'sporty': car_type == "sporty",
-                        'convertible': random.random() > 0.7
-                    }
-                )
-        
-        return {
-            "success": True,
-            "name": scene_group,
-            "scene_type": "city",
-            "objects_count": len(created_objects),
-            "buildings_count": building_count,
-            "cars_count": car_count if include_cars else 0
-        }
-    
-    elif scene_type.lower() == "forest":
-        # Get forest parameters
-        tree_count = parameters.get('tree_count', 15)
-        forest_size = parameters.get('forest_size', 50.0)
-        include_path = parameters.get('include_path', True)
-        terrain_roughness = parameters.get('terrain_roughness', 0.3)
-        
-        # Create ground/terrain
-        ground = cmds.polyPlane(
-            name=f"{name}_ground", 
-            width=forest_size, 
-            height=forest_size, 
-            subdivisionsX=20, 
-            subdivisionsY=20
-        )[0]
-        created_objects.append(ground)
-        cmds.parent(ground, scene_group)
-        
-        # Apply some random noise to the terrain
-        if terrain_roughness > 0:
-            # Select all vertices
-            cmds.select(f"{ground}.vtx[*]")
-            
-            # Apply random displacement
-            vertices = cmds.ls(selection=True, flatten=True)
-            for vertex in vertices:
-                if random.random() < 0.7:  # Don't displace every vertex
-                    height = random.uniform(0, terrain_roughness * 5) 
-                    cmds.move(0, height, 0, vertex, relative=True)
-        
-        # Create a nice terrain material
-        _create_and_track(
-            create_material,
-            material_type="lambert",
-            name=f"{name}_ground_material",
-            color=[0.3, 0.5, 0.2],  # Green-brown
-            assign_to=ground
-        )
-        
-        # Add trees
-        tree_types = ["oak", "pine", "maple"]
-        for t in range(tree_count):
-            # Randomize tree position within forest
-            tree_x = random.uniform(-forest_size/2 * 0.9, forest_size/2 * 0.9)
-            tree_z = random.uniform(-forest_size/2 * 0.9, forest_size/2 * 0.9)
-            
-            # Get ground height at this position (approximate)
-            # This is a simple approximation - in a real tool, we'd do a proper raycast
-            ground_height = 0
-            if terrain_roughness > 0:
-                ground_height = random.uniform(0, terrain_roughness * 3)
-            
-            # Randomize tree parameters
-            tree_type = random.choice(tree_types)
-            tree_scale = random.uniform(0.8, 1.5)
-            trunk_height = random.uniform(4.0, 8.0)
-            
-            # Create the tree
-            tree = _create_and_track(
-                create_advanced_model,
-                model_type="tree",
-                name=f"{name}_tree_{t}",
-                translate=[tree_x, ground_height, tree_z],
-                rotate=[0, random.uniform(0, 360), 0],
-                scale=tree_scale,
-                parameters={
-                    'type': tree_type,
-                    'trunk_height': trunk_height,
-                    'branches': int(random.uniform(3, 7)),
-                    'leaf_density': random.uniform(0.6, 0.9)
-                }
-            )
-        
-        # Add a path if requested
-        if include_path:
-            # Create a simple curved path through the forest
-            path_points = []
-            path_segments = 10
-            
-            # Generate a meandering path from one side to the other
-            for i in range(path_segments + 1):
-                t = i / path_segments
-                x = (t - 0.5) * forest_size
-                z = math.sin(t * math.pi * 2) * forest_size * 0.3
-                path_points.append([x, 0.1, z])  # Slightly above ground
-            
-            # Create the path as a nurbs curve
-            path_curve = cmds.curve(
-                name=f"{name}_path_curve",
-                p=path_points,
-                degree=3
-            )
-            
-            # Extrude a circle along the path to create a 3D path
-            path_profile = cmds.circle(
-                name=f"{name}_path_profile",
-                radius=1.0,
-                normal=[0, 1, 0]
-            )[0]
-            
-            path = cmds.extrude(
-                path_profile,
-                path_curve,
-                name=f"{name}_path",
-                fixedPath=True
-            )[0]
-            
-            # Create path material
-            _create_and_track(
-                create_material,
-                material_type="lambert",
-                name=f"{name}_path_material",
-                color=[0.7, 0.6, 0.5],  # Tan/brown
-                assign_to=path
-            )
-            
-            created_objects.append(path)
-            cmds.parent(path, scene_group)
-            
-            # Clean up temporary curve and profile
-            cmds.delete(path_curve, path_profile)
-        
-        return {
-            "success": True,
-            "name": scene_group,
-            "scene_type": "forest",
-            "objects_count": len(created_objects),
-            "trees_count": tree_count,
-            "has_path": include_path
-        }
-    
-    elif scene_type.lower() == "living_room":
-        # Get living room parameters
-        room_size = parameters.get('room_size', 25.0)
-        furniture_density = parameters.get('furniture_density', 1.0)
-        modern_style = parameters.get('modern_style', True)
-        
-        # Create room (floor, walls, ceiling)
-        floor = cmds.polyPlane(name=f"{name}_floor", width=room_size, height=room_size)[0]
-        created_objects.append(floor)
-        cmds.parent(floor, scene_group)
-        
-        wall_height = 12.0
-        
-        # Create 4 walls
-        for i, (pos, rot) in enumerate([
-            ([0, wall_height/2, -room_size/2], [0, 0, 0]),      # Back wall
-            ([0, wall_height/2, room_size/2], [0, 180, 0]),     # Front wall
-            ([-room_size/2, wall_height/2, 0], [0, 90, 0]),     # Left wall
-            ([room_size/2, wall_height/2, 0], [0, -90, 0])      # Right wall
-        ]):
-            wall = cmds.polyPlane(
-                name=f"{name}_wall_{i}",
-                width=room_size,
-                height=wall_height
-            )[0]
-            cmds.move(pos[0], pos[1], pos[2], wall)
-            cmds.rotate(rot[0], rot[1], rot[2], wall)
-            created_objects.append(wall)
-            cmds.parent(wall, scene_group)
-        
-        # Create ceiling
-        ceiling = cmds.polyPlane(name=f"{name}_ceiling", width=room_size, height=room_size)[0]
-        cmds.move(0, wall_height, 0, ceiling)
-        cmds.rotate(180, 0, 0, ceiling)
-        created_objects.append(ceiling)
-        cmds.parent(ceiling, scene_group)
-        
-        # Create wall and floor materials
-        _create_and_track(
-            create_material,
-            material_type="lambert",
-            name=f"{name}_wall_material",
-            color=[0.9, 0.9, 0.85],  # Off-white
-            assign_to=[f"{name}_wall_0", f"{name}_wall_1", f"{name}_wall_2", f"{name}_wall_3", f"{name}_ceiling"]
-        )
-        
-        _create_and_track(
-            create_material,
-            material_type="wood",
-            name=f"{name}_floor_material",
-            color=[0.7, 0.5, 0.3],  # Medium brown
-            parameters={'veinSpread': 0.3},
-            assign_to=floor
-        )
-        
-        # Add furniture
-        
-        # Sofa
-        sofa_z = room_size * 0.3
-        sofa = _create_and_track(
-            create_advanced_model,
-            model_type="chair",  # Using chair model for now, but scaled to sofa size
-            name=f"{name}_sofa",
-            translate=[0, 0, sofa_z],
-            scale=3.0,
-            parameters={
-                'seat_width': 6.0,
-                'seat_depth': 2.5,
-                'seat_height': 1.0,
-                'back_height': 2.0
-            }
-        )
-        
-        # Coffee table
-        table_z = sofa_z - 3.0
-        coffee_table = cmds.polyCube(
-            name=f"{name}_coffee_table",
-            width=4.0,
-            height=1.0,
-            depth=2.0
-        )[0]
-        cmds.move(0, 0.5, table_z, coffee_table)
-        created_objects.append(coffee_table)
-        cmds.parent(coffee_table, scene_group)
-        
-        # Table material
-        _create_and_track(
-            create_material,
-            material_type="wood",
-            name=f"{name}_table_material",
-            color=[0.6, 0.4, 0.3],
-            assign_to=coffee_table
-        )
-        
-        # TV and stand
-        tv_z = -room_size * 0.4
-        tv_stand = cmds.polyCube(
-            name=f"{name}_tv_stand",
-            width=5.0,
-            height=1.5,
-            depth=1.5
-        )[0]
-        cmds.move(0, 0.75, tv_z, tv_stand)
-        created_objects.append(tv_stand)
-        cmds.parent(tv_stand, scene_group)
-        
-        tv = cmds.polyCube(
-            name=f"{name}_tv",
-            width=4.5,
-            height=2.5,
-            depth=0.2
-        )[0]
-        cmds.move(0, 2.5, tv_z - 0.1, tv)
-        created_objects.append(tv)
-        cmds.parent(tv, scene_group)
-        
-        # TV materials
-        _create_and_track(
-            create_material,
-            material_type="wood",
-            name=f"{name}_tv_stand_material",
-            color=[0.3, 0.2, 0.15],  # Dark wood
-            assign_to=tv_stand
-        )
-        
-        _create_and_track(
-            create_material,
-            material_type="lambert",
-            name=f"{name}_tv_material",
-            color=[0.05, 0.05, 0.05],  # Near black
-            assign_to=tv
-        )
-        
-        # Add some chairs if room is big enough
-        if room_size >= 20 and furniture_density > 0.5:
-            chair_positions = [
-                [-room_size * 0.25, 0, sofa_z - 2.0],  # Left of sofa
-                [room_size * 0.25, 0, sofa_z - 2.0]    # Right of sofa
-            ]
-            
-            for i, pos in enumerate(chair_positions):
-                chair = _create_and_track(
-                    create_advanced_model,
-                    model_type="chair",
-                    name=f"{name}_chair_{i}",
-                    translate=pos,
-                    rotate=[0, 180, 0],  # Facing sofa
-                    parameters={
-                        'seat_width': 2.0,
-                        'seat_depth': 2.0,
-                        'seat_height': 1.0,
-                        'back_height': 2.0
-                    }
-                )
-        
-        # Add a rug under the coffee table
-        rug = cmds.polyPlane(
-            name=f"{name}_rug",
-            width=8.0,
-            height=5.0
-        )[0]
-        cmds.move(0, 0.05, sofa_z - 1.0, rug)
-        created_objects.append(rug)
-        cmds.parent(rug, scene_group)
-        
-        # Rug material
-        rug_colors = [
-            [0.8, 0.2, 0.2],  # Red
-            [0.2, 0.4, 0.8],  # Blue
-            [0.8, 0.7, 0.2]   # Gold
-        ]
-        _create_and_track(
-            create_material,
-            material_type="lambert",
-            name=f"{name}_rug_material",
-            color=random.choice(rug_colors),
-            assign_to=rug
-        )
-        
-        return {
-            "success": True,
-            "name": scene_group,
-            "scene_type": "living_room",
-            "objects_count": len(created_objects)
-        }
-    
-    elif scene_type.lower() == "office":
-        # Get office parameters
-        office_size = parameters.get('office_size', 30.0)
-        desks_count = parameters.get('desks_count', 4)
-        modern_style = parameters.get('modern_style', True)
-        
-        # Create office room (floor, walls, ceiling)
-        floor = cmds.polyPlane(name=f"{name}_floor", width=office_size, height=office_size)[0]
-        created_objects.append(floor)
-        cmds.parent(floor, scene_group)
-        
-        wall_height = 10.0
-        
-        # Create 4 walls
-        for i, (pos, rot) in enumerate([
-            ([0, wall_height/2, -office_size/2], [0, 0, 0]),      # Back wall
-            ([0, wall_height/2, office_size/2], [0, 180, 0]),     # Front wall
-            ([-office_size/2, wall_height/2, 0], [0, 90, 0]),     # Left wall
-            ([office_size/2, wall_height/2, 0], [0, -90, 0])      # Right wall
-        ]):
-            wall = cmds.polyPlane(
-                name=f"{name}_wall_{i}",
-                width=office_size,
-                height=wall_height
-            )[0]
-            cmds.move(pos[0], pos[1], pos[2], wall)
-            cmds.rotate(rot[0], rot[1], rot[2], wall)
-            created_objects.append(wall)
-            cmds.parent(wall, scene_group)
-        
-        # Create ceiling
-        ceiling = cmds.polyPlane(name=f"{name}_ceiling", width=office_size, height=office_size)[0]
-        cmds.move(0, wall_height, 0, ceiling)
-        cmds.rotate(180, 0, 0, ceiling)
-        created_objects.append(ceiling)
-        cmds.parent(ceiling, scene_group)
-        
-        # Create wall and floor materials
-        _create_and_track(
-            create_material,
-            material_type="lambert",
-            name=f"{name}_wall_material",
-            color=[0.85, 0.85, 0.85],  # Light gray
-            assign_to=[f"{name}_wall_0", f"{name}_wall_1", f"{name}_wall_2", f"{name}_wall_3", f"{name}_ceiling"]
-        )
-        
-        _create_and_track(
-            create_material,
-            material_type="lambert",
-            name=f"{name}_floor_material",
-            color=[0.7, 0.7, 0.7],  # Gray for office carpet
-            assign_to=floor
-        )
-        
-        # Add office desks in a grid pattern
-        desk_grid_size = math.ceil(math.sqrt(desks_count))
-        desk_spacing = office_size * 0.7 / desk_grid_size
-        
-        desk_start_x = -desk_spacing * (desk_grid_size - 1) / 2
-        desk_start_z = -desk_spacing * (desk_grid_size - 1) / 2
-        
-        desk_count = 0
-        for row in range(desk_grid_size):
-            for col in range(desk_grid_size):
-                if desk_count >= desks_count:
-                    break
-                
-                desk_x = desk_start_x + col * desk_spacing
-                desk_z = desk_start_z + row * desk_spacing
-                
-                # Randomize orientation
-                desk_rot_y = random.choice([0, 90, 180, 270])
-                
-                # Create desk (simple cube for now)
-                desk_width = 4.0
-                desk_depth = 2.0
-                desk_height = 0.75
-                
-                desk = cmds.polyCube(
-                    name=f"{name}_desk_{desk_count}",
-                    width=desk_width,
-                    height=desk_height,
-                    depth=desk_depth
-                )[0]
-                cmds.move(desk_x, desk_height/2, desk_z, desk)
-                cmds.rotate(0, desk_rot_y, 0, desk)
-                created_objects.append(desk)
-                cmds.parent(desk, scene_group)
-                
-                # Create desk material
-                desk_color = [0.8, 0.8, 0.8] if modern_style else [0.6, 0.4, 0.2]
-                _create_and_track(
-                    create_material,
-                    material_type="lambert" if modern_style else "wood",
-                    name=f"{name}_desk_{desk_count}_material",
-                    color=desk_color,
-                    assign_to=desk
-                )
-                
-                # Create chair for this desk
-                chair_offset_x = 0
-                chair_offset_z = 1.5
-                
-                # Adjust chair position based on desk rotation
-                if desk_rot_y == 0:
-                    chair_offset_z = 1.5
-                elif desk_rot_y == 90:
-                    chair_offset_x = -1.5
-                    chair_offset_z = 0
-                elif desk_rot_y == 180:
-                    chair_offset_z = -1.5
-                elif desk_rot_y == 270:
-                    chair_offset_x = 1.5
-                    chair_offset_z = 0
-                
-                chair = _create_and_track(
-                    create_advanced_model,
-                    model_type="chair",
-                    name=f"{name}_chair_{desk_count}",
-                    translate=[desk_x + chair_offset_x, 0, desk_z + chair_offset_z],
-                    rotate=[0, desk_rot_y, 0],
-                    parameters={
-                        'seat_width': 1.5,
-                        'seat_depth': 1.5,
-                        'seat_height': 1.0,
-                        'back_height': 1.8
-                    }
-                )
-                
-                # Create computer monitor on desk
-                monitor_height = 0.7
-                monitor_width = 1.2
-                monitor_depth = 0.1
-                
-                monitor_offset_x = 0
-                monitor_offset_z = -0.7
-                
-                # Adjust monitor position based on desk rotation
-                if desk_rot_y == 0:
-                    monitor_offset_z = -0.7
-                elif desk_rot_y == 90:
-                    monitor_offset_x = 0.7
-                    monitor_offset_z = 0
-                elif desk_rot_y == 180:
-                    monitor_offset_z = 0.7
-                elif desk_rot_y == 270:
-                    monitor_offset_x = -0.7
-                    monitor_offset_z = 0
-                
-                monitor = cmds.polyCube(
-                    name=f"{name}_monitor_{desk_count}",
-                    width=monitor_width,
-                    height=monitor_height,
-                    depth=monitor_depth
-                )[0]
-                cmds.move(
-                    desk_x + monitor_offset_x,
-                    desk_height + monitor_height/2,
-                    desk_z + monitor_offset_z,
-                    monitor
-                )
-                cmds.rotate(0, desk_rot_y, 0, monitor)
-                created_objects.append(monitor)
-                cmds.parent(monitor, scene_group)
-                
-                # Create monitor material
-                _create_and_track(
-                    create_material,
-                    material_type="lambert",
-                    name=f"{name}_monitor_{desk_count}_material",
-                    color=[0.1, 0.1, 0.1],  # Dark gray/black
-                    assign_to=monitor
-                )
-                
-                desk_count += 1
-        
-        # Add some office cabinets along the back wall
-        cabinet_count = desks_count // 2
-        cabinet_width = office_size * 0.8 / cabinet_count
-        cabinet_start_x = -office_size * 0.4 + cabinet_width/2
-        
-        for i in range(cabinet_count):
-            cabinet_x = cabinet_start_x + i * cabinet_width
-            cabinet_z = -office_size * 0.45  # Near back wall
-            
-            cabinet = cmds.polyCube(
-                name=f"{name}_cabinet_{i}",
-                width=cabinet_width * 0.9,
-                height=2.0,
-                depth=0.8
-            )[0]
-            cmds.move(cabinet_x, 1.0, cabinet_z, cabinet)
-            created_objects
+            for i in range(max(1, blocks * blocks)):
+                x = random.uniform(-city_size / 2, city_size / 2)
+                z = random.choice([-city_size / 4, 0.0, city_size / 4])
+                car = _cube(f"{name}_car_{i}", 2.4, 0.7, 4.0, [x, 0.35, z], [0.8, 0.1 + random.random() * 0.4, 0.1])
+                cmds.rotate(0, random.choice([0, 90]), 0, car)
+                car_count += 1
+
+        stats = {"buildings_count": building_count, "cars_count": car_count}
+
+    elif scene_type == "forest":
+        tree_count = int(parameters.get("tree_count", 12))
+        forest_size = float(parameters.get("forest_size", 40.0))
+
+        ground = cmds.polyPlane(name=f"{name}_ground", width=forest_size, height=forest_size, subdivisionsX=12, subdivisionsY=12)[0]
+        ground = cmds.parent(ground, scene_group)[0]
+        _assign(ground, _mat(f"{name}_ground_mat", [0.22, 0.38, 0.18]))
+        created.append(ground)
+
+        for i in range(tree_count):
+            x = random.uniform(-forest_size / 2, forest_size / 2)
+            z = random.uniform(-forest_size / 2, forest_size / 2)
+            trunk_h = random.uniform(3.0, 6.0)
+            _cylinder(f"{name}_tree_{i}_trunk", 0.22, trunk_h, [x, trunk_h / 2, z], [0.32, 0.18, 0.08], 12)
+            _cone(f"{name}_tree_{i}_crown", random.uniform(1.1, 1.8), random.uniform(2.5, 4.0), [x, trunk_h + 1.4, z], [0.05, 0.32, 0.12], 16)
+
+        stats = {"trees_count": tree_count}
+
+    elif scene_type == "living_room":
+        room_size = float(parameters.get("room_size", 18.0))
+        _cube(f"{name}_floor", room_size, 0.15, room_size, [0, 0, 0], [0.55, 0.38, 0.22])
+        _cube(f"{name}_sofa", 6.0, 1.4, 2.2, [0, 0.75, 4.0], [0.18, 0.28, 0.55])
+        _cube(f"{name}_coffee_table", 4.0, 0.7, 2.0, [0, 0.45, 1.0], [0.45, 0.26, 0.13])
+        _cube(f"{name}_tv_stand", 5.0, 1.0, 1.0, [0, 0.55, -5.5], [0.2, 0.16, 0.14])
+        _cube(f"{name}_tv", 5.4, 3.0, 0.2, [0, 2.4, -6.1], [0.02, 0.02, 0.025])
+        stats = {"furniture_count": 4}
+
+    elif scene_type == "office":
+        desks_count = int(parameters.get("desks_count", 4))
+        office_size = float(parameters.get("office_size", 24.0))
+        _cube(f"{name}_floor", office_size, 0.12, office_size, [0, 0, 0], [0.48, 0.48, 0.5])
+        grid = int(math.ceil(math.sqrt(desks_count)))
+        spacing = office_size * 0.65 / max(1, grid)
+        for i in range(desks_count):
+            row = i // grid
+            col = i % grid
+            x = (col - (grid - 1) / 2) * spacing
+            z = (row - (grid - 1) / 2) * spacing
+            _cube(f"{name}_desk_{i}", 4.0, 0.7, 2.0, [x, 0.45, z], [0.74, 0.74, 0.7])
+            _cube(f"{name}_monitor_{i}", 1.6, 0.9, 0.15, [x, 1.25, z - 0.55], [0.02, 0.02, 0.025])
+            _cube(f"{name}_chair_{i}", 1.2, 1.2, 1.2, [x, 0.65, z + 1.6], [0.12, 0.15, 0.18])
+        stats = {"desks_count": desks_count}
+
+    elif scene_type == "park":
+        park_size = float(parameters.get("park_size", 36.0))
+        tree_count = int(parameters.get("tree_count", 8))
+        ground = cmds.polyPlane(name=f"{name}_grass", width=park_size, height=park_size)[0]
+        ground = cmds.parent(ground, scene_group)[0]
+        _assign(ground, _mat(f"{name}_grass_mat", [0.18, 0.52, 0.18]))
+        created.append(ground)
+        _cylinder(f"{name}_fountain", 2.2, 0.8, [0, 0.4, 0], [0.6, 0.62, 0.64], 32)
+        for i in range(tree_count):
+            angle = 2 * math.pi * i / tree_count
+            x = math.cos(angle) * park_size * 0.35
+            z = math.sin(angle) * park_size * 0.35
+            _cylinder(f"{name}_tree_{i}_trunk", 0.18, 3.0, [x, 1.5, z], [0.3, 0.18, 0.08], 10)
+            _cone(f"{name}_tree_{i}_crown", 1.2, 2.5, [x, 3.4, z], [0.05, 0.34, 0.13], 16)
+        stats = {"trees_count": tree_count, "has_fountain": True}
+
+    else:
+        raise ValueError("Unknown scene type. Use city, forest, living_room, office, or park")
+
+    return {
+        "success": True,
+        "name": scene_group,
+        "scene_type": scene_type,
+        "objects_count": len(created),
+        **stats,
+    }

--- a/src/mayatools/scene/map_silhouette_errors_to_components.py
+++ b/src/mayatools/scene/map_silhouette_errors_to_components.py
@@ -1,0 +1,375 @@
+from typing import Dict, List, Any
+
+
+def map_silhouette_errors_to_components(
+    target_objects: List[str],
+    row_width_samples: List[Dict[str, Any]],
+    candidate_canvas_bbox_pixels: List[float],
+    candidate_crop_bbox_pixels: List[float],
+    candidate_foreground_bbox_pixels: List[float],
+    view_direction: List[float] = None,
+    up_axis: List[float] = None,
+    camera_center: List[float] = None,
+    orthographic_width: float = None,
+    image_width: int = 640,
+    image_height: int = 960,
+    compare_width: int = 256,
+    compare_height: int = 512,
+    align_mode: str = "bbox",
+    padding_fraction: float = 0.04,
+    min_abs_error: float = 0.02,
+    max_rows: int = 12,
+    row_band_pixels: float = 8.0,
+    extreme_count: int = 3,
+    select_components: bool = False,
+    selection_mode: str = "replace",
+    max_preview: int = 200,
+) -> Dict[str, Any]:
+    """Map image silhouette width errors back to Maya mesh components.
+
+    This is a generic bridge between visual QA and component modeling. It takes
+    row samples from compare_image_silhouettes plus the candidate playblast
+    framing, converts high-error rows back to world-space view bands, and
+    reports the left/right projected extreme vertices on the target meshes. It
+    helps an artist decide which vertices, support loops, lips, bevels, or
+    profile areas to edit after comparing any product, prop, character, vehicle,
+    bottle, or other mesh silhouette against a reference image.
+    """
+    import maya.cmds as cmds
+    import maya.api.OpenMaya as om
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _validate_int(value, arg_name, minimum):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to {minimum}.")
+        return int(value)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(item) for item in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(item) for item in values]
+
+    def _normalize_vector(values, arg_name):
+        vector = om.MVector(*_validate_vector(values, 3, arg_name))
+        if vector.length() <= 1.0e-12:
+            raise ValueError(f"{arg_name} must not be a zero vector.")
+        vector.normalize()
+        return vector
+
+    def _projection_frame(view, up):
+        clean_up = up - view * (up * view)
+        if clean_up.length() <= 1.0e-12:
+            raise ValueError("up_axis must not be parallel to view_direction.")
+        clean_up.normalize()
+        right = view ^ clean_up
+        if right.length() <= 1.0e-12:
+            raise ValueError("Unable to build a projection frame.")
+        right.normalize()
+        return right, clean_up
+
+    def _mesh_shape(node):
+        if not cmds.objExists(node):
+            raise ValueError(f"Target object does not exist: {node}")
+        if cmds.objectType(node) == "mesh":
+            return node
+        shapes = cmds.listRelatives(node, shapes=True, fullPath=True) or []
+        meshes = []
+        for shape in shapes:
+            if cmds.objectType(shape) != "mesh":
+                continue
+            try:
+                if cmds.attributeQuery("intermediateObject", node=shape, exists=True) and cmds.getAttr(f"{shape}.intermediateObject"):
+                    continue
+            except Exception:
+                pass
+            meshes.append(shape)
+        if not meshes:
+            raise ValueError(f"Target object has no visible polygon mesh shape: {node}")
+        return meshes[0]
+
+    def _dag_path(node):
+        selection = om.MSelectionList()
+        selection.add(node)
+        return selection.getDagPath(0)
+
+    def _mesh_fn(shape):
+        return om.MFnMesh(_dag_path(shape))
+
+    def _component_prefix(shape, fallback):
+        parents = cmds.listRelatives(shape, parent=True, fullPath=False) or []
+        return parents[0] if parents else fallback
+
+    def _combined_bbox(objects):
+        bbox = list(cmds.exactWorldBoundingBox(objects[0]))
+        for obj in objects[1:]:
+            item = cmds.exactWorldBoundingBox(obj)
+            bbox[0] = min(bbox[0], item[0])
+            bbox[1] = min(bbox[1], item[1])
+            bbox[2] = min(bbox[2], item[2])
+            bbox[3] = max(bbox[3], item[3])
+            bbox[4] = max(bbox[4], item[4])
+            bbox[5] = max(bbox[5], item[5])
+        return bbox
+
+    def _bbox_corners(bbox):
+        return [
+            [bbox[xi], bbox[yi], bbox[zi]]
+            for xi in (0, 3)
+            for yi in (1, 4)
+            for zi in (2, 5)
+        ]
+
+    def _camera_width_from_bbox(bbox):
+        projected_x = []
+        projected_y = []
+        for corner in _bbox_corners(bbox):
+            point = om.MVector(*corner)
+            projected_x.append(float(point * right_axis))
+            projected_y.append(float(point * up_vector))
+        width = max(1.0e-6, max(projected_x) - min(projected_x))
+        height = max(1.0e-6, max(projected_y) - min(projected_y))
+        aspect_value = clean_image_width / float(clean_image_height)
+        clean_padding = max(0.0, clean_padding_fraction)
+        return max(height, width / max(1.0e-6, aspect_value)) * (1.0 + clean_padding * 2.0)
+
+    def _row_value(sample, key, fallback=None):
+        value = sample.get(key)
+        if value is None:
+            return fallback
+        return value
+
+    def _source_y_for_row(row_normalized):
+        row_canvas = int(round(row_normalized * float(clean_compare_height - 1)))
+        canvas_y0, canvas_y1 = clean_candidate_canvas_bbox[1], clean_candidate_canvas_bbox[3]
+        if row_canvas < canvas_y0 - 1.0e-9 or row_canvas > canvas_y1 + 1.0e-9:
+            return row_canvas, None
+        canvas_span = max(1.0e-9, canvas_y1 - canvas_y0)
+        t = (row_canvas - canvas_y0) / canvas_span
+        if clean_align_mode == "bbox":
+            source_y0 = clean_candidate_crop_bbox[1] + clean_candidate_foreground_bbox[1]
+            source_y1 = clean_candidate_crop_bbox[1] + clean_candidate_foreground_bbox[3]
+        else:
+            source_y0 = clean_candidate_crop_bbox[1]
+            source_y1 = clean_candidate_crop_bbox[3]
+        return row_canvas, source_y0 + t * (source_y1 - source_y0)
+
+    def _world_row_from_source_y(source_y):
+        aspect_value = clean_image_width / float(clean_image_height)
+        vertical_span = resolved_orthographic_width / max(1.0e-9, aspect_value)
+        source_t = source_y / float(max(1, clean_image_height - 1))
+        vertical_offset = vertical_span * 0.5 - source_t * vertical_span
+        center_vector = om.MVector(*resolved_camera_center)
+        return center_vector + up_vector * vertical_offset, vertical_span
+
+    def _world_width_error(signed_error):
+        if clean_align_mode == "bbox":
+            source_y0 = clean_candidate_foreground_bbox[1]
+            source_y1 = clean_candidate_foreground_bbox[3]
+        else:
+            source_y0 = 0.0
+            source_y1 = clean_candidate_crop_bbox[3] - clean_candidate_crop_bbox[1]
+        source_region_height = max(1.0, source_y1 - source_y0 + 1.0)
+        canvas_height = max(1.0, clean_candidate_canvas_bbox[3] - clean_candidate_canvas_bbox[1] + 1.0)
+        compare_pixels = signed_error * float(clean_compare_width)
+        source_pixels = compare_pixels * source_region_height / canvas_height
+        return source_pixels * resolved_orthographic_width / float(max(1, clean_image_width - 1))
+
+    def _component_records_for_band(shape, prefix, center_screen_y, band_world):
+        mesh_fn = _mesh_fn(shape)
+        points = mesh_fn.getPoints(om.MSpace.kWorld)
+        lower = center_screen_y - band_world
+        upper = center_screen_y + band_world
+        records = []
+        for vertex_id, point in enumerate(points):
+            vector = om.MVector(point.x, point.y, point.z)
+            screen_y = float(vector * up_vector)
+            if screen_y < lower or screen_y > upper:
+                continue
+            records.append({
+                "index": int(vertex_id),
+                "component": f"{prefix}.vtx[{vertex_id}]",
+                "position": [float(point.x), float(point.y), float(point.z)],
+                "screen_x": float(vector * right_axis),
+                "screen_y": screen_y,
+            })
+        if not records:
+            return {"candidate_count": 0, "left": [], "right": []}
+        left = sorted(records, key=lambda item: (item["screen_x"], item["index"]))[:clean_extreme_count]
+        right = sorted(records, key=lambda item: (-item["screen_x"], item["index"]))[:clean_extreme_count]
+        return {
+            "candidate_count": len(records),
+            "left": left,
+            "right": right,
+        }
+
+    if not target_objects or not isinstance(target_objects, list) or not all(isinstance(item, str) for item in target_objects):
+        raise ValueError("target_objects must be a non-empty list of object names.")
+    if not isinstance(row_width_samples, list):
+        raise ValueError("row_width_samples must be a list of row sample dictionaries.")
+    clean_candidate_canvas_bbox = _validate_vector(candidate_canvas_bbox_pixels, 4, "candidate_canvas_bbox_pixels")
+    clean_candidate_crop_bbox = _validate_vector(candidate_crop_bbox_pixels, 4, "candidate_crop_bbox_pixels")
+    clean_candidate_foreground_bbox = _validate_vector(candidate_foreground_bbox_pixels, 4, "candidate_foreground_bbox_pixels")
+    clean_view = _normalize_vector(view_direction if view_direction is not None else [0.0, 0.0, -1.0], "view_direction")
+    clean_up = _normalize_vector(up_axis if up_axis is not None else [0.0, 1.0, 0.0], "up_axis")
+    right_axis, up_vector = _projection_frame(clean_view, clean_up)
+    clean_image_width = _validate_int(image_width, "image_width", 1)
+    clean_image_height = _validate_int(image_height, "image_height", 1)
+    clean_compare_width = _validate_int(compare_width, "compare_width", 1)
+    clean_compare_height = _validate_int(compare_height, "compare_height", 1)
+    clean_padding_fraction = _validate_scalar(padding_fraction, "padding_fraction")
+    clean_min_abs_error = _validate_scalar(min_abs_error, "min_abs_error")
+    clean_max_rows = _validate_int(max_rows, "max_rows", 1)
+    clean_row_band_pixels = _validate_scalar(row_band_pixels, "row_band_pixels")
+    clean_extreme_count = _validate_int(extreme_count, "extreme_count", 1)
+    max_preview = _validate_int(max_preview, "max_preview", 0)
+    clean_align_mode = (align_mode or "").lower().strip()
+    if clean_align_mode not in {"bbox", "crop"}:
+        raise ValueError("align_mode must be bbox or crop.")
+    clean_selection_mode = (selection_mode or "").lower().strip()
+    if clean_selection_mode not in {"replace", "add", "toggle", "deselect"}:
+        raise ValueError("selection_mode must be replace, add, toggle, or deselect.")
+
+    shapes = []
+    resolved_targets = []
+    seen = set()
+    for obj in target_objects:
+        if obj in seen:
+            continue
+        seen.add(obj)
+        shape = _mesh_shape(obj)
+        shapes.append({"object_name": obj, "shape_name": shape, "prefix": _component_prefix(shape, obj)})
+        resolved_targets.append(obj)
+    bbox = _combined_bbox(resolved_targets)
+    if camera_center is None:
+        resolved_camera_center = [
+            (bbox[0] + bbox[3]) * 0.5,
+            (bbox[1] + bbox[4]) * 0.5,
+            (bbox[2] + bbox[5]) * 0.5,
+        ]
+    else:
+        resolved_camera_center = _validate_vector(camera_center, 3, "camera_center")
+    if orthographic_width is None:
+        resolved_orthographic_width = _camera_width_from_bbox(bbox)
+    else:
+        resolved_orthographic_width = _validate_scalar(orthographic_width, "orthographic_width")
+        if resolved_orthographic_width <= 0.0:
+            raise ValueError("orthographic_width must be greater than zero.")
+
+    rows = []
+    for sample in row_width_samples:
+        if not isinstance(sample, dict):
+            continue
+        row_normalized = _row_value(sample, "row_normalized", sample.get("row_fraction"))
+        if row_normalized is None:
+            continue
+        signed_error = _row_value(sample, "signed_error", sample.get("signed_width_error"))
+        if signed_error is None:
+            reference_width = sample.get("reference_width")
+            candidate_width = sample.get("candidate_width")
+            if reference_width is None or candidate_width is None:
+                continue
+            signed_error = float(candidate_width) - float(reference_width)
+        row_normalized = float(row_normalized)
+        signed_error = float(signed_error)
+        abs_error = abs(float(sample.get("abs_error", abs(signed_error))))
+        if abs_error < clean_min_abs_error:
+            continue
+        rows.append({
+            "row_normalized": row_normalized,
+            "reference_width": sample.get("reference_width"),
+            "candidate_width": sample.get("candidate_width"),
+            "signed_error": signed_error,
+            "abs_error": abs_error,
+        })
+    rows = sorted(rows, key=lambda item: item["abs_error"], reverse=True)[:clean_max_rows]
+
+    world_units_per_image_pixel = resolved_orthographic_width / float(max(1, clean_image_width - 1))
+    band_world = max(0.0, clean_row_band_pixels) * world_units_per_image_pixel
+    mapped_rows = []
+    selected_components = []
+    for row in rows:
+        row_canvas, source_y = _source_y_for_row(row["row_normalized"])
+        if source_y is None:
+            mapped_rows.append({
+                **row,
+                "row_canvas_pixel": row_canvas,
+                "mapped": False,
+                "reason": "row is outside candidate_canvas_bbox_pixels",
+            })
+            continue
+        world_point, vertical_span = _world_row_from_source_y(source_y)
+        center_screen_y = float(world_point * up_vector)
+        width_error_world = _world_width_error(row["signed_error"])
+        side_offset_world = -0.5 * width_error_world
+        object_reports = []
+        for shape_info in shapes:
+            report = _component_records_for_band(shape_info["shape_name"], shape_info["prefix"], center_screen_y, band_world)
+            if max_preview == 0:
+                report["left"] = []
+                report["right"] = []
+            else:
+                report["left"] = report["left"][:max_preview]
+                report["right"] = report["right"][:max_preview]
+            selected_components.extend(item["component"] for item in report["left"])
+            selected_components.extend(item["component"] for item in report["right"])
+            object_reports.append({
+                "object_name": shape_info["object_name"],
+                "shape_name": shape_info["shape_name"],
+                **report,
+            })
+        mapped_rows.append({
+            **row,
+            "mapped": True,
+            "row_canvas_pixel": row_canvas,
+            "candidate_source_y_pixel": float(source_y),
+            "world_row_center": [float(world_point.x), float(world_point.y), float(world_point.z)],
+            "screen_y": center_screen_y,
+            "screen_y_band": [center_screen_y - band_world, center_screen_y + band_world],
+            "world_width_error_estimate": float(width_error_world),
+            "suggested_symmetric_side_offset_world": float(side_offset_world),
+            "object_reports": object_reports,
+        })
+
+    unique_selected = list(dict.fromkeys(selected_components))
+    if select_components:
+        if unique_selected:
+            cmds.select(unique_selected, **{clean_selection_mode: True})
+        elif clean_selection_mode == "replace":
+            cmds.select(clear=True)
+
+    return {
+        "success": True,
+        "target_objects": resolved_targets,
+        "view_direction": [float(clean_view.x), float(clean_view.y), float(clean_view.z)],
+        "up_axis": [float(up_vector.x), float(up_vector.y), float(up_vector.z)],
+        "right_axis": [float(right_axis.x), float(right_axis.y), float(right_axis.z)],
+        "camera_center": resolved_camera_center,
+        "orthographic_width": float(resolved_orthographic_width),
+        "image_width": clean_image_width,
+        "image_height": clean_image_height,
+        "compare_width": clean_compare_width,
+        "compare_height": clean_compare_height,
+        "candidate_canvas_bbox_pixels": clean_candidate_canvas_bbox,
+        "candidate_crop_bbox_pixels": clean_candidate_crop_bbox,
+        "candidate_foreground_bbox_pixels": clean_candidate_foreground_bbox,
+        "align_mode": clean_align_mode,
+        "min_abs_error": clean_min_abs_error,
+        "row_band_pixels": clean_row_band_pixels,
+        "row_band_world": float(band_world),
+        "world_units_per_image_pixel": float(world_units_per_image_pixel),
+        "error_row_count": len(rows),
+        "mapped_row_count": sum(1 for row in mapped_rows if row.get("mapped")),
+        "selected_component_count": len(unique_selected),
+        "selected_components": unique_selected[:max_preview],
+        "selection_truncated": len(unique_selected) > max_preview,
+        "selected": bool(select_components),
+        "selection_mode": clean_selection_mode if select_components else None,
+        "rows": mapped_rows,
+    }

--- a/src/mayatools/scene/playblast_object_silhouette.py
+++ b/src/mayatools/scene/playblast_object_silhouette.py
@@ -1,0 +1,436 @@
+from typing import Dict, List, Any, Union
+
+
+def playblast_object_silhouette(
+    name: str = "object_silhouette",
+    target_objects: Union[str, List[str]] = None,
+    output_path: str = None,
+    view_direction: List[float] = None,
+    up_axis: List[float] = None,
+    silhouette_color: List[float] = None,
+    background_color: List[float] = None,
+    orthographic_width: float = None,
+    padding_fraction: float = 0.08,
+    image_width: int = 640,
+    image_height: int = 960,
+    use_isolate_select: bool = True,
+    hide_non_target_transforms: bool = True,
+) -> Dict[str, Any]:
+    """Playblast a clean orthographic silhouette of target mesh objects.
+
+    The tool duplicates the target mesh transforms into temporary proxy objects,
+    assigns the proxies a flat high-contrast material, isolates them in a model
+    panel, hides non-mesh viewport categories such as cameras and locators, and
+    writes a single-frame playblast. It then removes all temporary proxy nodes.
+    This gives repeatable silhouette QA without modifying the user's real
+    materials, face assignments, selection, or scene geometry.
+    """
+    import math
+    import os
+    import re
+    import maya.cmds as cmds
+    import maya.api.OpenMaya as om
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(item) for item in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(item) for item in values]
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _validate_image_size(value, arg_name):
+        if not isinstance(value, int) or isinstance(value, bool) or value < 64:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to 64.")
+        return int(value)
+
+    def _safe_name(value, fallback):
+        text = str(value or fallback).strip()
+        text = re.sub(r"[^A-Za-z0-9_]+", "_", text).strip("_")
+        return text or fallback
+
+    def _normalize_vector(values, arg_name):
+        vector = om.MVector(*_validate_vector(values, 3, arg_name))
+        if vector.length() <= 1.0e-12:
+            raise ValueError(f"{arg_name} must not be a zero vector.")
+        vector.normalize()
+        return vector
+
+    def _is_visible(node):
+        current = node
+        while current:
+            try:
+                if cmds.attributeQuery("visibility", node=current, exists=True) and not cmds.getAttr(f"{current}.visibility"):
+                    return False
+            except Exception:
+                pass
+            parents = cmds.listRelatives(current, parent=True, fullPath=True) or []
+            current = parents[0] if parents else None
+        return True
+
+    def _mesh_parent_targets():
+        targets = []
+        seen = set()
+        for shape in cmds.ls(type="mesh", long=True) or []:
+            try:
+                if cmds.attributeQuery("intermediateObject", node=shape, exists=True) and cmds.getAttr(f"{shape}.intermediateObject"):
+                    continue
+            except Exception:
+                pass
+            parents = cmds.listRelatives(shape, parent=True, fullPath=True) or []
+            if not parents:
+                continue
+            parent = parents[0]
+            if parent in seen or not _is_visible(shape) or not _is_visible(parent):
+                continue
+            seen.add(parent)
+            targets.append(parent)
+        return targets
+
+    def _normalize_targets(value):
+        if value is None:
+            resolved = _mesh_parent_targets()
+        elif isinstance(value, str):
+            resolved = [value]
+        elif isinstance(value, list) and all(isinstance(item, str) for item in value):
+            resolved = value[:]
+        else:
+            raise ValueError("target_objects must be a string, list of strings, or None.")
+        if not resolved:
+            raise ValueError("No target mesh objects found.")
+        result = []
+        seen = set()
+        for target in resolved:
+            if not cmds.objExists(target):
+                raise ValueError(f"Target object does not exist: {target}")
+            if target in seen:
+                continue
+            shapes = cmds.listRelatives(target, shapes=True, fullPath=True) or []
+            if not any(cmds.objectType(shape) == "mesh" for shape in shapes):
+                raise ValueError(f"Target object has no mesh shape: {target}")
+            seen.add(target)
+            result.append(target)
+        return result
+
+    def _bbox_corners(bbox):
+        return [
+            [bbox[xi], bbox[yi], bbox[zi]]
+            for xi in (0, 3)
+            for yi in (1, 4)
+            for zi in (2, 5)
+        ]
+
+    def _combined_bbox(objects):
+        bbox = list(cmds.exactWorldBoundingBox(objects[0]))
+        for obj in objects[1:]:
+            item = cmds.exactWorldBoundingBox(obj)
+            bbox[0] = min(bbox[0], item[0])
+            bbox[1] = min(bbox[1], item[1])
+            bbox[2] = min(bbox[2], item[2])
+            bbox[3] = max(bbox[3], item[3])
+            bbox[4] = max(bbox[4], item[4])
+            bbox[5] = max(bbox[5], item[5])
+        return bbox
+
+    def _projection_frame(view, up):
+        clean_up = up - view * (up * view)
+        if clean_up.length() <= 1.0e-12:
+            raise ValueError("up_axis must not be parallel to view_direction.")
+        clean_up.normalize()
+        right = view ^ clean_up
+        if right.length() <= 1.0e-12:
+            raise ValueError("Unable to build camera projection frame.")
+        right.normalize()
+        return right, clean_up
+
+    def _camera_width_from_bbox(bbox, view, right, up):
+        corners = _bbox_corners(bbox)
+        projected_x = []
+        projected_y = []
+        projected_z = []
+        for corner in corners:
+            vector = om.MVector(*corner)
+            projected_x.append(float(vector * right))
+            projected_y.append(float(vector * up))
+            projected_z.append(float(vector * view))
+        width = max(1.0e-6, max(projected_x) - min(projected_x))
+        height = max(1.0e-6, max(projected_y) - min(projected_y))
+        depth = max(1.0e-6, max(projected_z) - min(projected_z))
+        aspect = float(clean_image_width) / float(clean_image_height)
+        vertical_for_width = width / max(1.0e-6, aspect)
+        clean_padding = max(0.0, clean_padding_fraction)
+        return max(height, vertical_for_width) * (1.0 + clean_padding * 2.0), depth
+
+    def _aim_camera(camera_transform, target):
+        locator = cmds.spaceLocator(name=f"{safe_prefix}_aim_tmp")[0]
+        cmds.xform(locator, translation=target, worldSpace=True)
+        constraint = cmds.aimConstraint(
+            locator,
+            camera_transform,
+            aimVector=[0, 0, -1],
+            upVector=[0, 1, 0],
+            worldUpType="scene",
+        )
+        cmds.delete(constraint)
+        cmds.delete(locator)
+
+    def _set_model_editor_flag(panel, **kwargs):
+        try:
+            cmds.modelEditor(panel, edit=True, **kwargs)
+        except Exception:
+            pass
+
+    def _configure_panel(panel, camera):
+        cmds.lookThru(panel, camera)
+        _set_model_editor_flag(panel, rendererName="vp2Renderer")
+        _set_model_editor_flag(
+            panel,
+            allObjects=False,
+            polymeshes=True,
+            displayAppearance="smoothShaded",
+            displayTextures=False,
+            useDefaultMaterial=False,
+            wireframeOnShaded=False,
+            grid=False,
+            manipulators=False,
+            hud=False,
+            selectionHiliteDisplay=False,
+        )
+        for flag in [
+            "cameras",
+            "lights",
+            "locators",
+            "nurbsCurves",
+            "nurbsSurfaces",
+            "joints",
+            "ikHandles",
+            "deformers",
+            "dynamics",
+            "fluids",
+            "hairSystems",
+            "follicles",
+            "nCloths",
+            "pluginShapes",
+            "dimensions",
+            "handles",
+            "strokes",
+        ]:
+            _set_model_editor_flag(panel, **{flag: False})
+
+    def _create_material():
+        shader = cmds.shadingNode("surfaceShader", asShader=True, name=f"{safe_prefix}_material")
+        shading_group = cmds.sets(name=f"{safe_prefix}_materialSG", empty=True, renderable=True, noSurfaceShader=True)
+        cmds.setAttr(f"{shader}.outColor", clean_silhouette_color[0], clean_silhouette_color[1], clean_silhouette_color[2], type="double3")
+        cmds.connectAttr(f"{shader}.outColor", f"{shading_group}.surfaceShader", force=True)
+        return shader, shading_group
+
+    def _long_name(node):
+        matches = cmds.ls(node, long=True) or []
+        return matches[0] if matches else node
+
+    def _hide_unwanted_transforms(keep_nodes):
+        if not hide_non_target_transforms:
+            return []
+        keep = {_long_name(node) for node in keep_nodes if cmds.objExists(node)}
+        hidden = []
+        for transform in cmds.ls(type="transform", long=True) or []:
+            if transform in keep:
+                continue
+            try:
+                if not cmds.attributeQuery("visibility", node=transform, exists=True):
+                    continue
+                previous = bool(cmds.getAttr(f"{transform}.visibility"))
+                if previous:
+                    cmds.setAttr(f"{transform}.visibility", False)
+                    hidden.append({"node": transform, "visibility": previous})
+            except Exception:
+                pass
+        return hidden
+
+    if not name:
+        raise ValueError("name is required.")
+    if not output_path:
+        raise ValueError("output_path is required.")
+    safe_prefix = _safe_name(name, "object_silhouette")
+    clean_image_width = _validate_image_size(image_width, "image_width")
+    clean_image_height = _validate_image_size(image_height, "image_height")
+    clean_padding_fraction = _validate_scalar(padding_fraction, "padding_fraction")
+    if clean_padding_fraction < 0.0:
+        raise ValueError("padding_fraction must be greater than or equal to zero.")
+    clean_view = _normalize_vector(view_direction if view_direction is not None else [0.0, 0.0, -1.0], "view_direction")
+    clean_up = _normalize_vector(up_axis if up_axis is not None else [0.0, 1.0, 0.0], "up_axis")
+    right_axis, up_vector = _projection_frame(clean_view, clean_up)
+    clean_silhouette_color = _validate_vector(silhouette_color if silhouette_color is not None else [0.0, 0.0, 0.0], 3, "silhouette_color")
+    clean_background_color = _validate_vector(background_color if background_color is not None else [1.0, 1.0, 1.0], 3, "background_color")
+    if orthographic_width is not None:
+        clean_orthographic_width = _validate_scalar(orthographic_width, "orthographic_width")
+        if clean_orthographic_width <= 0.0:
+            raise ValueError("orthographic_width must be greater than zero.")
+    else:
+        clean_orthographic_width = None
+
+    targets = _normalize_targets(target_objects)
+    original_selection = cmds.ls(selection=True, long=True) or []
+    original_background = {}
+    for color_name in ["background", "backgroundTop", "backgroundBottom"]:
+        try:
+            original_background[color_name] = cmds.displayRGBColor(color_name, query=True)
+        except Exception:
+            pass
+
+    panels = cmds.getPanel(type="modelPanel") or [cmds.modelPanel()]
+    panel = panels[0]
+    isolate_states = {}
+    proxies = []
+    temp_nodes = []
+    hidden_visibility = []
+    playblast_result = None
+
+    try:
+        target_bbox = _combined_bbox(targets)
+        target_center = [
+            (target_bbox[0] + target_bbox[3]) * 0.5,
+            (target_bbox[1] + target_bbox[4]) * 0.5,
+            (target_bbox[2] + target_bbox[5]) * 0.5,
+        ]
+        auto_width, target_depth = _camera_width_from_bbox(target_bbox, clean_view, right_axis, up_vector)
+        resolved_orthographic_width = clean_orthographic_width or auto_width
+        camera_distance = max(10.0, target_depth + resolved_orthographic_width * 2.0)
+        camera_position = [
+            target_center[0] - clean_view.x * camera_distance,
+            target_center[1] - clean_view.y * camera_distance,
+            target_center[2] - clean_view.z * camera_distance,
+        ]
+
+        shader, shading_group = _create_material()
+        temp_nodes.extend([shader, shading_group])
+
+        group = cmds.group(empty=True, name=f"{safe_prefix}_proxy_GRP")
+        temp_nodes.append(group)
+        for index, target in enumerate(targets):
+            duplicate_name = f"{safe_prefix}_{index}_{_safe_name(target.rsplit('|', 1)[-1], 'target')}_proxy"
+            duplicate = cmds.duplicate(target, name=duplicate_name, returnRootsOnly=True)[0]
+            cmds.parent(duplicate, group)
+            proxies.append(duplicate)
+        if proxies:
+            cmds.sets(proxies, edit=True, forceElement=shading_group)
+
+        camera, camera_shape = cmds.camera(name=f"{safe_prefix}_camera")
+        temp_nodes.extend([camera])
+        cmds.xform(camera, translation=camera_position, worldSpace=True)
+        cmds.setAttr(f"{camera_shape}.orthographic", True)
+        cmds.setAttr(f"{camera_shape}.orthographicWidth", resolved_orthographic_width)
+        cmds.setAttr(f"{camera_shape}.nearClipPlane", 0.01)
+        cmds.setAttr(f"{camera_shape}.farClipPlane", 10000.0)
+        _aim_camera(camera, target_center)
+
+        hidden_visibility = _hide_unwanted_transforms([group] + proxies + [camera])
+
+        for color_name in ["background", "backgroundTop", "backgroundBottom"]:
+            try:
+                cmds.displayRGBColor(color_name, clean_background_color[0], clean_background_color[1], clean_background_color[2])
+            except Exception:
+                pass
+
+        for model_panel in panels:
+            _configure_panel(model_panel, camera)
+        if use_isolate_select:
+            try:
+                cmds.select(proxies, replace=True)
+                for model_panel in panels:
+                    try:
+                        isolate_states[model_panel] = bool(cmds.isolateSelect(model_panel, query=True, state=True))
+                    except Exception:
+                        isolate_states[model_panel] = False
+                    cmds.isolateSelect(model_panel, state=True)
+                    cmds.isolateSelect(model_panel, addSelected=True)
+            except Exception:
+                pass
+
+        try:
+            cmds.select(clear=True)
+        except Exception:
+            pass
+        try:
+            cmds.setFocus(panel)
+        except Exception:
+            pass
+
+        try:
+            cmds.refresh(force=True)
+        except Exception:
+            pass
+
+        normalized_output_path = os.path.normpath(output_path)
+        output_dir = os.path.dirname(normalized_output_path)
+        if output_dir and not os.path.exists(output_dir):
+            os.makedirs(output_dir)
+        playblast_result = cmds.playblast(
+            completeFilename=normalized_output_path,
+            format="image",
+            compression="png",
+            frame=[1],
+            widthHeight=[clean_image_width, clean_image_height],
+            percent=100,
+            quality=95,
+            viewer=False,
+            showOrnaments=False,
+            forceOverwrite=True,
+            offScreen=True,
+        )
+    finally:
+        if use_isolate_select:
+            for model_panel, previous_state in isolate_states.items():
+                try:
+                    cmds.isolateSelect(model_panel, state=previous_state)
+                except Exception:
+                    pass
+        for node in reversed(temp_nodes):
+            if cmds.objExists(node):
+                try:
+                    cmds.delete(node)
+                except Exception:
+                    pass
+        for item in hidden_visibility:
+            try:
+                if cmds.objExists(item["node"]):
+                    cmds.setAttr(f"{item['node']}.visibility", item["visibility"])
+            except Exception:
+                pass
+        for color_name, color in original_background.items():
+            try:
+                cmds.displayRGBColor(color_name, color[0], color[1], color[2])
+            except Exception:
+                pass
+        try:
+            if original_selection:
+                cmds.select(original_selection, replace=True)
+            else:
+                cmds.select(clear=True)
+        except Exception:
+            pass
+
+    return {
+        "success": True,
+        "name": name,
+        "target_objects": targets,
+        "output_path": playblast_result or os.path.normpath(output_path),
+        "view_direction": [float(clean_view.x), float(clean_view.y), float(clean_view.z)],
+        "up_axis": [float(up_vector.x), float(up_vector.y), float(up_vector.z)],
+        "right_axis": [float(right_axis.x), float(right_axis.y), float(right_axis.z)],
+        "silhouette_color": clean_silhouette_color,
+        "background_color": clean_background_color,
+        "bounding_box": target_bbox,
+        "camera_position": camera_position,
+        "orthographic_width": resolved_orthographic_width,
+        "image_width": clean_image_width,
+        "image_height": clean_image_height,
+        "proxy_count": len(proxies),
+        "isolated": bool(use_isolate_select),
+        "hide_non_target_transforms": bool(hide_non_target_transforms),
+    }

--- a/src/mayatools/scene/scene_open.py
+++ b/src/mayatools/scene/scene_open.py
@@ -2,16 +2,20 @@
 import os
 from typing import Dict, Any, Optional
 
-def scene_open(filename:str, namespace:Optional[str]=None) -> Dict[str, Any]:
-    """ Load in a scene into Maya. If namespace is specified, the scene will be loaded into the current
-        scene as a reference in the given namespace name. """
+def scene_open(filename: str, namespace: Optional[str] = None, force: bool = False) -> Dict[str, Any]:
+    """Load a scene into Maya.
+
+    If namespace is specified, the scene will be loaded into the current scene as
+    a reference in the given namespace name. Use force to discard unsaved scene
+    changes when opening a normal scene file.
+    """
     import maya.cmds as cmds
     file_type = None
     _, ext = os.path.splitext(filename)
     if ext == ".mb":
-        file_type = "mayabinary"
+        file_type = "mayaBinary"
     elif ext == ".ma":
-        file_type = "mayaascii"
+        file_type = "mayaAscii"
     elif not ext:
         # no extension
         raise ValueError(f"Error: Unable to open a scene without knowning the file format from the file extension")
@@ -23,7 +27,7 @@ def scene_open(filename:str, namespace:Optional[str]=None) -> Dict[str, Any]:
         if namespace:
             cmds.file(filename, open=True, reference=True, namespace=namespace)
         else:
-            cmds.file(filename, open=True)
+            cmds.file(filename, open=True, force=force)
         results = { "success": True }
             
     return results

--- a/src/mayatools/scene/scene_save.py
+++ b/src/mayatools/scene/scene_save.py
@@ -15,9 +15,9 @@ def scene_save(filename:str=None) -> Dict[str, Any]:
     file_type = None
     _, ext = os.path.splitext(filename)
     if ext == ".mb":
-        file_type = "mayabinary"
+        file_type = "mayaBinary"
     elif ext == ".ma":
-        file_type = "mayaascii"
+        file_type = "mayaAscii"
     elif not ext:
         # no extension
         file_type = cmds.file(query=True, type=True)
@@ -26,7 +26,7 @@ def scene_save(filename:str=None) -> Dict[str, Any]:
                 file_type = file_type[0]
             else:
                 raise RuntimeError("Unable to determine the file type of the current scene")
-        ext = ".mb" if file_type == "mayabinary" else ".ma"
+        ext = ".mb" if file_type == "mayaBinary" else ".ma"
         filename += ext
     else:
         # trying to save a format that should be export

--- a/src/mayatools/scene/setup_product_preview_scene.py
+++ b/src/mayatools/scene/setup_product_preview_scene.py
@@ -266,7 +266,9 @@ def setup_product_preview_scene(
     except Exception:
         pass
 
-    refreshed_textures = _prepare_file_textures(refresh_textures)
+    refreshed_textures = []
+    if not refresh_textures:
+        _prepare_file_textures(False)
     panels = cmds.getPanel(type="modelPanel") or []
     configured_panels = []
     for panel in panels:
@@ -295,6 +297,8 @@ def setup_product_preview_scene(
             continue
 
     viewport_cache_reset = _reset_viewport_cache() if refresh_textures else {"panels": []}
+    if refresh_textures:
+        refreshed_textures = _prepare_file_textures(True)
 
     try:
         cmds.refresh(force=True)

--- a/src/mayatools/scene/setup_product_preview_scene.py
+++ b/src/mayatools/scene/setup_product_preview_scene.py
@@ -159,6 +159,13 @@ def setup_product_preview_scene(
                 if cmds.attributeQuery("disableFileLoad", node=file_node, exists=True):
                     cmds.setAttr(f"{file_node}.disableFileLoad", 0)
                 if force_refresh:
+                    if path:
+                        try:
+                            cmds.setAttr(f"{file_node}.fileTextureName", "", type="string")
+                            cmds.setAttr(f"{file_node}.fileTextureName", path, type="string")
+                            item["path_reloaded"] = True
+                        except Exception as exc:
+                            item["reload_error"] = str(exc)
                     try:
                         cmds.dgdirty(file_node)
                     except Exception:

--- a/src/mayatools/scene/setup_product_preview_scene.py
+++ b/src/mayatools/scene/setup_product_preview_scene.py
@@ -56,9 +56,47 @@ def setup_product_preview_scene(
             except Exception:
                 pass
 
+    def _is_visible(node):
+        current = node
+        while current:
+            try:
+                if cmds.attributeQuery("visibility", node=current, exists=True) and not cmds.getAttr(f"{current}.visibility"):
+                    return False
+            except Exception:
+                pass
+            parents = cmds.listRelatives(current, parent=True, fullPath=True) or []
+            current = parents[0] if parents else None
+        return True
+
+    def _shape_parent_targets(shape_types):
+        targets = []
+        seen = set()
+        for shape_type in shape_types:
+            for shape in cmds.ls(type=shape_type, long=True) or []:
+                try:
+                    if cmds.attributeQuery("intermediateObject", node=shape, exists=True) and cmds.getAttr(f"{shape}.intermediateObject"):
+                        continue
+                except Exception:
+                    pass
+                parents = cmds.listRelatives(shape, parent=True, fullPath=True) or []
+                if not parents:
+                    continue
+                parent = parents[0]
+                if parent in seen or not _is_visible(shape) or not _is_visible(parent):
+                    continue
+                seen.add(parent)
+                targets.append(parent)
+        return targets
+
+    def _default_targets():
+        mesh_targets = _shape_parent_targets(["mesh"])
+        if mesh_targets:
+            return mesh_targets
+        return _shape_parent_targets(["nurbsCurve", "bezierCurve"])
+
     def _normalize_targets(targets):
         if targets is None:
-            return []
+            return _default_targets()
         if isinstance(targets, str):
             targets = [targets]
         if not isinstance(targets, list) or not all(isinstance(item, str) for item in targets):
@@ -82,6 +120,18 @@ def setup_product_preview_scene(
             bbox[4] = max(bbox[4], obj_bbox[4])
             bbox[5] = max(bbox[5], obj_bbox[5])
         return bbox
+
+    def _frame_distance(size, focal_length_value, distance_multiplier_value):
+        max_size = max(size)
+        horizontal_aperture_mm = 36.0
+        vertical_aperture_mm = 24.0
+        horizontal_fov = 2.0 * math.atan(horizontal_aperture_mm / (2.0 * focal_length_value))
+        vertical_fov = 2.0 * math.atan(vertical_aperture_mm / (2.0 * focal_length_value))
+        distance_for_width = (size[0] * 0.5) / max(1e-6, math.tan(horizontal_fov * 0.5))
+        distance_for_height = (size[1] * 0.5) / max(1e-6, math.tan(vertical_fov * 0.5))
+        fov_distance = max(distance_for_width, distance_for_height) * 1.15 + size[2] * 0.5
+        multiplier_distance = max_size * distance_multiplier_value
+        return max(2.0, fov_distance, multiplier_distance)
 
     def _aim_camera(camera_transform, target):
         locator = cmds.spaceLocator(name=f"{name}_camera_target_tmp")[0]
@@ -129,11 +179,11 @@ def setup_product_preview_scene(
     else:
         target_position = _validate_vector(target_position, 3, "target_position")
     if camera_position is None:
-        max_size = max(bbox_size)
+        camera_distance = _frame_distance(bbox_size, focal_length, distance_multiplier)
         camera_position = [
             target_position[0],
             target_position[1] + bbox_size[1] * 0.05,
-            target_position[2] + max(2.0, max_size * distance_multiplier),
+            target_position[2] + camera_distance,
         ]
     else:
         camera_position = _validate_vector(camera_position, 3, "camera_position")

--- a/src/mayatools/scene/setup_product_preview_scene.py
+++ b/src/mayatools/scene/setup_product_preview_scene.py
@@ -1,0 +1,242 @@
+from typing import Dict, List, Any, Union
+
+
+def setup_product_preview_scene(
+    name: str = "product_preview",
+    target_objects: Union[str, List[str]] = None,
+    camera_position: List[float] = None,
+    target_position: List[float] = None,
+    focal_length: float = 85.0,
+    distance_multiplier: float = 3.0,
+    background_color: List[float] = [0.45, 0.45, 0.45],
+    key_light_intensity: float = 1.1,
+    fill_light_intensity: float = 0.35,
+    rim_light_intensity: float = 0.65,
+    display_textures: bool = True,
+    transparency_algorithm: str = "depthPeeling",
+    playblast_path: str = None,
+    image_width: int = 1200,
+    image_height: int = 1600,
+) -> Dict[str, Any]:
+    """Set up a generic product-preview camera, lights, viewport, and snapshot.
+
+    This is intended for evaluating modeled products, packaging, props, and
+    transparent materials in a repeatable studio-like viewport. It can frame
+    target objects from their bounding box, create simple three-point lighting,
+    set a neutral background, configure model panels for shaded/textured display,
+    and optionally write a playblast image.
+    """
+    import math
+    import os
+    import maya.cmds as cmds
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(v) for v in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(v) for v in values]
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _validate_image_size(value, arg_name):
+        if not isinstance(value, int) or isinstance(value, bool) or value < 64:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to 64.")
+        return value
+
+    def _safe_delete(node_name):
+        if cmds.objExists(node_name):
+            try:
+                cmds.delete(node_name)
+            except Exception:
+                pass
+
+    def _normalize_targets(targets):
+        if targets is None:
+            return []
+        if isinstance(targets, str):
+            targets = [targets]
+        if not isinstance(targets, list) or not all(isinstance(item, str) for item in targets):
+            raise ValueError("target_objects must be a string, a list of strings, or None.")
+        for target in targets:
+            if not cmds.objExists(target):
+                raise ValueError(f"target object does not exist: {target}")
+        return targets
+
+    def _combined_bbox(objects):
+        if not objects:
+            return [-0.5, 0.0, -0.5, 0.5, 1.0, 0.5]
+        first = cmds.exactWorldBoundingBox(objects[0])
+        bbox = list(first)
+        for obj in objects[1:]:
+            obj_bbox = cmds.exactWorldBoundingBox(obj)
+            bbox[0] = min(bbox[0], obj_bbox[0])
+            bbox[1] = min(bbox[1], obj_bbox[1])
+            bbox[2] = min(bbox[2], obj_bbox[2])
+            bbox[3] = max(bbox[3], obj_bbox[3])
+            bbox[4] = max(bbox[4], obj_bbox[4])
+            bbox[5] = max(bbox[5], obj_bbox[5])
+        return bbox
+
+    def _aim_camera(camera_transform, target):
+        locator = cmds.spaceLocator(name=f"{name}_camera_target_tmp")[0]
+        cmds.xform(locator, translation=target, worldSpace=True)
+        constraint = cmds.aimConstraint(
+            locator,
+            camera_transform,
+            aimVector=[0, 0, -1],
+            upVector=[0, 1, 0],
+            worldUpType="scene",
+        )
+        cmds.delete(constraint)
+        cmds.delete(locator)
+
+    if not name:
+        raise ValueError("name is required.")
+    target_objects = _normalize_targets(target_objects)
+    focal_length = _validate_scalar(focal_length, "focal_length")
+    distance_multiplier = _validate_scalar(distance_multiplier, "distance_multiplier")
+    if focal_length <= 0.0:
+        raise ValueError("focal_length must be greater than zero.")
+    if distance_multiplier <= 0.0:
+        raise ValueError("distance_multiplier must be greater than zero.")
+    background_color = _validate_vector(background_color, 3, "background_color")
+    key_light_intensity = _validate_scalar(key_light_intensity, "key_light_intensity")
+    fill_light_intensity = _validate_scalar(fill_light_intensity, "fill_light_intensity")
+    rim_light_intensity = _validate_scalar(rim_light_intensity, "rim_light_intensity")
+    image_width = _validate_image_size(image_width, "image_width")
+    image_height = _validate_image_size(image_height, "image_height")
+    transparency_algorithm = transparency_algorithm.strip()
+
+    bbox = _combined_bbox(target_objects)
+    bbox_center = [
+        (bbox[0] + bbox[3]) * 0.5,
+        (bbox[1] + bbox[4]) * 0.5,
+        (bbox[2] + bbox[5]) * 0.5,
+    ]
+    bbox_size = [
+        max(1e-6, bbox[3] - bbox[0]),
+        max(1e-6, bbox[4] - bbox[1]),
+        max(1e-6, bbox[5] - bbox[2]),
+    ]
+    if target_position is None:
+        target_position = bbox_center
+    else:
+        target_position = _validate_vector(target_position, 3, "target_position")
+    if camera_position is None:
+        max_size = max(bbox_size)
+        camera_position = [
+            target_position[0],
+            target_position[1] + bbox_size[1] * 0.05,
+            target_position[2] + max(2.0, max_size * distance_multiplier),
+        ]
+    else:
+        camera_position = _validate_vector(camera_position, 3, "camera_position")
+
+    for suffix in ["camera", "key_light", "fill_light", "rim_light"]:
+        _safe_delete(f"{name}_{suffix}")
+
+    camera, camera_shape = cmds.camera(name=f"{name}_camera")
+    cmds.xform(camera, translation=camera_position, worldSpace=True)
+    cmds.setAttr(f"{camera_shape}.focalLength", focal_length)
+    cmds.setAttr(f"{camera_shape}.nearClipPlane", 0.01)
+    cmds.setAttr(f"{camera_shape}.farClipPlane", 10000.0)
+    _aim_camera(camera, target_position)
+
+    key_shape = cmds.directionalLight(name=f"{name}_key_light", intensity=key_light_intensity)
+    key_light = cmds.listRelatives(key_shape, parent=True)[0]
+    cmds.xform(key_light, rotation=[-35.0, 30.0, 0.0], worldSpace=True)
+
+    fill_shape = cmds.ambientLight(name=f"{name}_fill_light", intensity=fill_light_intensity)
+    fill_light = cmds.listRelatives(fill_shape, parent=True)[0]
+
+    rim_shape = cmds.directionalLight(name=f"{name}_rim_light", intensity=rim_light_intensity)
+    rim_light = cmds.listRelatives(rim_shape, parent=True)[0]
+    cmds.xform(rim_light, rotation=[-15.0, -145.0, 0.0], worldSpace=True)
+
+    try:
+        cmds.displayRGBColor("background", background_color[0], background_color[1], background_color[2])
+        cmds.displayRGBColor("backgroundTop", background_color[0], background_color[1], background_color[2])
+        cmds.displayRGBColor("backgroundBottom", background_color[0], background_color[1], background_color[2])
+    except Exception:
+        pass
+
+    for file_node in cmds.ls(type="file") or []:
+        try:
+            if cmds.attributeQuery("disableFileLoad", node=file_node, exists=True):
+                cmds.setAttr(f"{file_node}.disableFileLoad", 0)
+        except Exception:
+            pass
+    panels = cmds.getPanel(type="modelPanel") or []
+    configured_panels = []
+    for panel in panels:
+        try:
+            cmds.lookThru(panel, camera)
+            try:
+                cmds.modelEditor(panel, edit=True, rendererName="vp2Renderer")
+            except Exception:
+                pass
+            cmds.modelEditor(
+                panel,
+                edit=True,
+                displayAppearance="smoothShaded",
+                displayTextures=bool(display_textures),
+                useDefaultMaterial=False,
+                wireframeOnShaded=False,
+                grid=False,
+            )
+            cmds.modelEditor(panel, edit=True, nurbsCurves=False, locators=False, cameras=False, lights=False, joints=False)
+            try:
+                cmds.modelEditor(panel, edit=True, transparencyAlgorithm=transparency_algorithm)
+            except Exception:
+                pass
+            configured_panels.append(panel)
+        except Exception:
+            continue
+
+    try:
+        cmds.refresh(force=True)
+    except Exception:
+        pass
+
+    playblast_result = None
+    if playblast_path:
+        normalized_path = os.path.normpath(playblast_path)
+        directory = os.path.dirname(normalized_path)
+        if directory and not os.path.exists(directory):
+            os.makedirs(directory)
+        playblast_result = cmds.playblast(
+            completeFilename=normalized_path,
+            format="image",
+            compression="png",
+            frame=[1],
+            widthHeight=[image_width, image_height],
+            percent=100,
+            quality=95,
+            viewer=False,
+            showOrnaments=False,
+            forceOverwrite=True,
+        )
+
+    return {
+        "success": True,
+        "name": name,
+        "target_objects": target_objects,
+        "bounding_box": bbox,
+        "target_position": target_position,
+        "camera": camera,
+        "camera_shape": camera_shape,
+        "camera_position": camera_position,
+        "focal_length": focal_length,
+        "lights": [key_light, fill_light, rim_light],
+        "background_color": background_color,
+        "transparency_algorithm": transparency_algorithm,
+        "image_width": image_width,
+        "image_height": image_height,
+        "configured_panels": configured_panels,
+        "playblast_path": playblast_result,
+    }

--- a/src/mayatools/scene/setup_product_preview_scene.py
+++ b/src/mayatools/scene/setup_product_preview_scene.py
@@ -26,8 +26,8 @@ def setup_product_preview_scene(
     transparent materials in a repeatable studio-like viewport. It can frame
     target objects from their bounding box, create simple three-point lighting,
     set a neutral background, configure model panels for shaded/textured display,
-    optionally soft-refresh file texture nodes, and optionally write a playblast
-    image.
+    optionally soft-refresh file texture nodes and reset the viewport cache,
+    and optionally write a playblast image.
     """
     import math
     import os
@@ -174,6 +174,19 @@ def setup_product_preview_scene(
                 pass
         return prepared
 
+    def _reset_viewport_cache():
+        try:
+            panels = cmds.ogs(reset=True) or []
+            if isinstance(panels, str):
+                panels = [panels]
+            try:
+                cmds.refresh(force=True)
+            except Exception:
+                pass
+            return {"panels": panels}
+        except Exception as exc:
+            return {"error": str(exc), "panels": []}
+
     if not name:
         raise ValueError("name is required.")
     target_objects = _normalize_targets(target_objects)
@@ -274,6 +287,8 @@ def setup_product_preview_scene(
         except Exception:
             continue
 
+    viewport_cache_reset = _reset_viewport_cache() if refresh_textures else {"panels": []}
+
     try:
         cmds.refresh(force=True)
     except Exception:
@@ -314,6 +329,7 @@ def setup_product_preview_scene(
         "display_curves": bool(display_curves),
         "refresh_textures": bool(refresh_textures),
         "refreshed_textures": refreshed_textures if refresh_textures else [],
+        "viewport_cache_reset": viewport_cache_reset,
         "image_width": image_width,
         "image_height": image_height,
         "configured_panels": configured_panels,

--- a/src/mayatools/scene/setup_product_preview_scene.py
+++ b/src/mayatools/scene/setup_product_preview_scene.py
@@ -15,6 +15,7 @@ def setup_product_preview_scene(
     display_textures: bool = True,
     transparency_algorithm: str = "depthPeeling",
     display_curves: bool = False,
+    refresh_textures: bool = False,
     playblast_path: str = None,
     image_width: int = 1200,
     image_height: int = 1600,
@@ -25,7 +26,8 @@ def setup_product_preview_scene(
     transparent materials in a repeatable studio-like viewport. It can frame
     target objects from their bounding box, create simple three-point lighting,
     set a neutral background, configure model panels for shaded/textured display,
-    and optionally write a playblast image.
+    optionally soft-refresh file texture nodes, and optionally write a playblast
+    image.
     """
     import math
     import os
@@ -146,6 +148,32 @@ def setup_product_preview_scene(
         cmds.delete(constraint)
         cmds.delete(locator)
 
+    def _prepare_file_textures(force_refresh):
+        prepared = []
+        for file_node in cmds.ls(type="file") or []:
+            item = {"node": file_node}
+            try:
+                path = cmds.getAttr(f"{file_node}.fileTextureName") or ""
+                item["path"] = path
+                item["exists"] = bool(path and os.path.exists(os.path.normpath(path)))
+                if cmds.attributeQuery("disableFileLoad", node=file_node, exists=True):
+                    cmds.setAttr(f"{file_node}.disableFileLoad", 0)
+                if force_refresh:
+                    try:
+                        cmds.dgdirty(file_node)
+                    except Exception:
+                        pass
+                prepared.append(item)
+            except Exception as exc:
+                item["error"] = str(exc)
+                prepared.append(item)
+        if force_refresh:
+            try:
+                cmds.refresh(force=True)
+            except Exception:
+                pass
+        return prepared
+
     if not name:
         raise ValueError("name is required.")
     target_objects = _normalize_targets(target_objects)
@@ -161,6 +189,8 @@ def setup_product_preview_scene(
     rim_light_intensity = _validate_scalar(rim_light_intensity, "rim_light_intensity")
     image_width = _validate_image_size(image_width, "image_width")
     image_height = _validate_image_size(image_height, "image_height")
+    if not isinstance(refresh_textures, bool):
+        raise ValueError("refresh_textures must be a boolean.")
     transparency_algorithm = transparency_algorithm.strip()
 
     bbox = _combined_bbox(target_objects)
@@ -216,12 +246,7 @@ def setup_product_preview_scene(
     except Exception:
         pass
 
-    for file_node in cmds.ls(type="file") or []:
-        try:
-            if cmds.attributeQuery("disableFileLoad", node=file_node, exists=True):
-                cmds.setAttr(f"{file_node}.disableFileLoad", 0)
-        except Exception:
-            pass
+    refreshed_textures = _prepare_file_textures(refresh_textures)
     panels = cmds.getPanel(type="modelPanel") or []
     configured_panels = []
     for panel in panels:
@@ -287,6 +312,8 @@ def setup_product_preview_scene(
         "background_color": background_color,
         "transparency_algorithm": transparency_algorithm,
         "display_curves": bool(display_curves),
+        "refresh_textures": bool(refresh_textures),
+        "refreshed_textures": refreshed_textures if refresh_textures else [],
         "image_width": image_width,
         "image_height": image_height,
         "configured_panels": configured_panels,

--- a/src/mayatools/scene/setup_product_preview_scene.py
+++ b/src/mayatools/scene/setup_product_preview_scene.py
@@ -32,6 +32,7 @@ def setup_product_preview_scene(
     import math
     import os
     import maya.cmds as cmds
+    import maya.mel as mel
 
     def _is_number(value):
         return isinstance(value, (int, float)) and not isinstance(value, bool)
@@ -149,8 +150,60 @@ def setup_product_preview_scene(
         cmds.delete(locator)
 
     def _prepare_file_textures(force_refresh):
+        def _mel_quote(value):
+            return '"' + str(value).replace("\\", "/").replace('"', '\\"') + '"'
+
+        def _reload_texture_callbacks(file_node, texture_path):
+            actions = []
+            if not texture_path:
+                return actions
+            try:
+                mel.eval("source AEfileTemplate.mel")
+            except Exception as exc:
+                actions.append({"action": "source_AEfileTemplate", "error": str(exc)})
+            try:
+                mel.eval("AEfileTextureReloadCmd " + _mel_quote(f"{file_node}.fileTextureName"))
+                actions.append({"action": "AEfileTextureReloadCmd"})
+            except Exception as exc:
+                actions.append({"action": "AEfileTextureReloadCmd", "error": str(exc)})
+                try:
+                    mel.eval("callbacks -executeCallbacks -hook textureReload " + _mel_quote(texture_path))
+                    actions.append({"action": "textureReload_callback"})
+                except Exception as callback_exc:
+                    actions.append({"action": "textureReload_callback", "error": str(callback_exc)})
+            return actions
+
+        def _placeholder_texture_path():
+            import base64
+            placeholder_path = os.path.join(cmds.internalVar(userTmpDir=True) or os.getcwd(), "maya_mcp_texture_reload_placeholder.png")
+            if not os.path.exists(placeholder_path):
+                png_bytes = base64.b64decode(
+                    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
+                )
+                with open(placeholder_path, "wb") as handle:
+                    handle.write(png_bytes)
+            return placeholder_path
+
+        placeholder_texture = _placeholder_texture_path() if force_refresh else None
+        file_nodes = cmds.ls(type="file") or []
+        scene_texture_paths = []
+        for node in file_nodes:
+            try:
+                node_path = cmds.getAttr(f"{node}.fileTextureName") or ""
+                if node_path and os.path.exists(os.path.normpath(node_path)):
+                    scene_texture_paths.append(node_path)
+            except Exception:
+                pass
+
+        def _alternate_texture_path(original_path):
+            original_norm = os.path.normcase(os.path.normpath(original_path))
+            for candidate in scene_texture_paths:
+                if os.path.normcase(os.path.normpath(candidate)) != original_norm:
+                    return candidate
+            return placeholder_texture
+
         prepared = []
-        for file_node in cmds.ls(type="file") or []:
+        for file_node in file_nodes:
             item = {"node": file_node}
             try:
                 path = cmds.getAttr(f"{file_node}.fileTextureName") or ""
@@ -161,9 +214,12 @@ def setup_product_preview_scene(
                 if force_refresh:
                     if path:
                         try:
-                            cmds.setAttr(f"{file_node}.fileTextureName", "", type="string")
+                            reload_path = _alternate_texture_path(path) or ""
+                            cmds.setAttr(f"{file_node}.fileTextureName", reload_path, type="string")
                             cmds.setAttr(f"{file_node}.fileTextureName", path, type="string")
                             item["path_reloaded"] = True
+                            item["reload_placeholder"] = reload_path
+                            item["reload_actions"] = _reload_texture_callbacks(file_node, path)
                         except Exception as exc:
                             item["reload_error"] = str(exc)
                     try:

--- a/src/mayatools/scene/setup_product_preview_scene.py
+++ b/src/mayatools/scene/setup_product_preview_scene.py
@@ -150,58 +150,16 @@ def setup_product_preview_scene(
         cmds.delete(locator)
 
     def _prepare_file_textures(force_refresh):
-        def _mel_quote(value):
-            return '"' + str(value).replace("\\", "/").replace('"', '\\"') + '"'
-
-        def _reload_texture_callbacks(file_node, texture_path):
+        def _reload_viewport_textures():
             actions = []
-            if not texture_path:
-                return actions
             try:
-                mel.eval("source AEfileTemplate.mel")
+                mel.eval("ogs -reloadTextures;")
+                actions.append({"action": "ogs_reloadTextures"})
             except Exception as exc:
-                actions.append({"action": "source_AEfileTemplate", "error": str(exc)})
-            try:
-                mel.eval("AEfileTextureReloadCmd " + _mel_quote(f"{file_node}.fileTextureName"))
-                actions.append({"action": "AEfileTextureReloadCmd"})
-            except Exception as exc:
-                actions.append({"action": "AEfileTextureReloadCmd", "error": str(exc)})
-                try:
-                    mel.eval("callbacks -executeCallbacks -hook textureReload " + _mel_quote(texture_path))
-                    actions.append({"action": "textureReload_callback"})
-                except Exception as callback_exc:
-                    actions.append({"action": "textureReload_callback", "error": str(callback_exc)})
+                actions.append({"action": "ogs_reloadTextures", "error": str(exc)})
             return actions
 
-        def _placeholder_texture_path():
-            import base64
-            placeholder_path = os.path.join(cmds.internalVar(userTmpDir=True) or os.getcwd(), "maya_mcp_texture_reload_placeholder.png")
-            if not os.path.exists(placeholder_path):
-                png_bytes = base64.b64decode(
-                    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
-                )
-                with open(placeholder_path, "wb") as handle:
-                    handle.write(png_bytes)
-            return placeholder_path
-
-        placeholder_texture = _placeholder_texture_path() if force_refresh else None
         file_nodes = cmds.ls(type="file") or []
-        scene_texture_paths = []
-        for node in file_nodes:
-            try:
-                node_path = cmds.getAttr(f"{node}.fileTextureName") or ""
-                if node_path and os.path.exists(os.path.normpath(node_path)):
-                    scene_texture_paths.append(node_path)
-            except Exception:
-                pass
-
-        def _alternate_texture_path(original_path):
-            original_norm = os.path.normcase(os.path.normpath(original_path))
-            for candidate in scene_texture_paths:
-                if os.path.normcase(os.path.normpath(candidate)) != original_norm:
-                    return candidate
-            return placeholder_texture
-
         prepared = []
         for file_node in file_nodes:
             item = {"node": file_node}
@@ -214,12 +172,9 @@ def setup_product_preview_scene(
                 if force_refresh:
                     if path:
                         try:
-                            reload_path = _alternate_texture_path(path) or ""
-                            cmds.setAttr(f"{file_node}.fileTextureName", reload_path, type="string")
                             cmds.setAttr(f"{file_node}.fileTextureName", path, type="string")
                             item["path_reloaded"] = True
-                            item["reload_placeholder"] = reload_path
-                            item["reload_actions"] = _reload_texture_callbacks(file_node, path)
+                            item["reload_actions"] = [{"action": "fileTextureName_touch"}]
                         except Exception as exc:
                             item["reload_error"] = str(exc)
                     try:
@@ -231,6 +186,9 @@ def setup_product_preview_scene(
                 item["error"] = str(exc)
                 prepared.append(item)
         if force_refresh:
+            viewport_reload_actions = _reload_viewport_textures()
+            for item in prepared:
+                item["viewport_reload_actions"] = viewport_reload_actions
             try:
                 cmds.refresh(force=True)
             except Exception:
@@ -239,16 +197,14 @@ def setup_product_preview_scene(
 
     def _reset_viewport_cache():
         try:
-            panels = cmds.ogs(reset=True) or []
-            if isinstance(panels, str):
-                panels = [panels]
+            mel.eval("ogs -reset;")
             try:
                 cmds.refresh(force=True)
             except Exception:
                 pass
-            return {"panels": panels}
+            return {"actions": [{"action": "ogs_reset"}]}
         except Exception as exc:
-            return {"error": str(exc), "panels": []}
+            return {"error": str(exc), "actions": []}
 
     if not name:
         raise ValueError("name is required.")
@@ -294,6 +250,14 @@ def setup_product_preview_scene(
     else:
         camera_position = _validate_vector(camera_position, 3, "camera_position")
 
+    refreshed_textures = []
+    if not refresh_textures:
+        _prepare_file_textures(False)
+        viewport_cache_reset = {"panels": []}
+    else:
+        viewport_cache_reset = _reset_viewport_cache()
+        refreshed_textures = _prepare_file_textures(True)
+
     for suffix in ["camera", "key_light", "fill_light", "rim_light"]:
         _safe_delete(f"{name}_{suffix}")
 
@@ -322,9 +286,6 @@ def setup_product_preview_scene(
     except Exception:
         pass
 
-    refreshed_textures = []
-    if not refresh_textures:
-        _prepare_file_textures(False)
     panels = cmds.getPanel(type="modelPanel") or []
     configured_panels = []
     for panel in panels:
@@ -352,9 +313,11 @@ def setup_product_preview_scene(
         except Exception:
             continue
 
-    viewport_cache_reset = _reset_viewport_cache() if refresh_textures else {"panels": []}
     if refresh_textures:
-        refreshed_textures = _prepare_file_textures(True)
+        try:
+            mel.eval("ogs -reloadTextures;")
+        except Exception:
+            pass
 
     try:
         cmds.refresh(force=True)

--- a/src/mayatools/scene/setup_product_preview_scene.py
+++ b/src/mayatools/scene/setup_product_preview_scene.py
@@ -14,6 +14,7 @@ def setup_product_preview_scene(
     rim_light_intensity: float = 0.65,
     display_textures: bool = True,
     transparency_algorithm: str = "depthPeeling",
+    display_curves: bool = False,
     playblast_path: str = None,
     image_width: int = 1200,
     image_height: int = 1600,
@@ -189,7 +190,7 @@ def setup_product_preview_scene(
                 wireframeOnShaded=False,
                 grid=False,
             )
-            cmds.modelEditor(panel, edit=True, nurbsCurves=False, locators=False, cameras=False, lights=False, joints=False)
+            cmds.modelEditor(panel, edit=True, nurbsCurves=bool(display_curves), locators=False, cameras=False, lights=False, joints=False)
             try:
                 cmds.modelEditor(panel, edit=True, transparencyAlgorithm=transparency_algorithm)
             except Exception:
@@ -235,6 +236,7 @@ def setup_product_preview_scene(
         "lights": [key_light, fill_light, rim_light],
         "background_color": background_color,
         "transparency_algorithm": transparency_algorithm,
+        "display_curves": bool(display_curves),
         "image_width": image_width,
         "image_height": image_height,
         "configured_panels": configured_panels,

--- a/src/mayatools/scene/setup_turntable_preview_scene.py
+++ b/src/mayatools/scene/setup_turntable_preview_scene.py
@@ -405,7 +405,7 @@ def setup_turntable_preview_scene(
     except Exception:
         pass
 
-    refreshed_textures = _refresh_file_textures() if refresh_textures else []
+    refreshed_textures = []
 
     panels = cmds.getPanel(type="modelPanel") or []
     configured_panels = []
@@ -435,6 +435,8 @@ def setup_turntable_preview_scene(
             continue
 
     viewport_cache_reset = _reset_viewport_cache() if refresh_textures else {"panels": []}
+    if refresh_textures:
+        refreshed_textures = _refresh_file_textures()
 
     frame_results = []
     image_paths = []

--- a/src/mayatools/scene/setup_turntable_preview_scene.py
+++ b/src/mayatools/scene/setup_turntable_preview_scene.py
@@ -165,58 +165,16 @@ def setup_turntable_preview_scene(
         return re.sub(r"[^A-Za-z0-9_\\-]", "_", label)
 
     def _refresh_file_textures():
-        def _mel_quote(value):
-            return '"' + str(value).replace("\\", "/").replace('"', '\\"') + '"'
-
-        def _reload_texture_callbacks(file_node, texture_path):
+        def _reload_viewport_textures():
             actions = []
-            if not texture_path:
-                return actions
             try:
-                mel.eval("source AEfileTemplate.mel")
+                mel.eval("ogs -reloadTextures;")
+                actions.append({"action": "ogs_reloadTextures"})
             except Exception as exc:
-                actions.append({"action": "source_AEfileTemplate", "error": str(exc)})
-            try:
-                mel.eval("AEfileTextureReloadCmd " + _mel_quote(f"{file_node}.fileTextureName"))
-                actions.append({"action": "AEfileTextureReloadCmd"})
-            except Exception as exc:
-                actions.append({"action": "AEfileTextureReloadCmd", "error": str(exc)})
-                try:
-                    mel.eval("callbacks -executeCallbacks -hook textureReload " + _mel_quote(texture_path))
-                    actions.append({"action": "textureReload_callback"})
-                except Exception as callback_exc:
-                    actions.append({"action": "textureReload_callback", "error": str(callback_exc)})
+                actions.append({"action": "ogs_reloadTextures", "error": str(exc)})
             return actions
 
-        def _placeholder_texture_path():
-            import base64
-            placeholder_path = os.path.join(cmds.internalVar(userTmpDir=True) or os.getcwd(), "maya_mcp_texture_reload_placeholder.png")
-            if not os.path.exists(placeholder_path):
-                png_bytes = base64.b64decode(
-                    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
-                )
-                with open(placeholder_path, "wb") as handle:
-                    handle.write(png_bytes)
-            return placeholder_path
-
-        placeholder_texture = _placeholder_texture_path()
         file_nodes = cmds.ls(type="file") or []
-        scene_texture_paths = []
-        for node in file_nodes:
-            try:
-                node_path = cmds.getAttr(f"{node}.fileTextureName") or ""
-                if node_path and os.path.exists(os.path.normpath(node_path)):
-                    scene_texture_paths.append(node_path)
-            except Exception:
-                pass
-
-        def _alternate_texture_path(original_path):
-            original_norm = os.path.normcase(os.path.normpath(original_path))
-            for candidate in scene_texture_paths:
-                if os.path.normcase(os.path.normpath(candidate)) != original_norm:
-                    return candidate
-            return placeholder_texture
-
         refreshed = []
         for file_node in file_nodes:
             try:
@@ -226,12 +184,9 @@ def setup_turntable_preview_scene(
                     cmds.setAttr(f"{file_node}.disableFileLoad", 0)
                 if path:
                     try:
-                        reload_path = _alternate_texture_path(path) or ""
-                        cmds.setAttr(f"{file_node}.fileTextureName", reload_path, type="string")
                         cmds.setAttr(f"{file_node}.fileTextureName", path, type="string")
                         item["path_reloaded"] = True
-                        item["reload_placeholder"] = reload_path
-                        item["reload_actions"] = _reload_texture_callbacks(file_node, path)
+                        item["reload_actions"] = [{"action": "fileTextureName_touch"}]
                     except Exception as exc:
                         item["reload_error"] = str(exc)
                 try:
@@ -242,6 +197,9 @@ def setup_turntable_preview_scene(
             except Exception as exc:
                 refreshed.append({"node": file_node, "error": str(exc)})
         try:
+            viewport_reload_actions = _reload_viewport_textures()
+            for item in refreshed:
+                item["viewport_reload_actions"] = viewport_reload_actions
             cmds.refresh(force=True)
         except Exception:
             pass
@@ -249,16 +207,14 @@ def setup_turntable_preview_scene(
 
     def _reset_viewport_cache():
         try:
-            panels = cmds.ogs(reset=True) or []
-            if isinstance(panels, str):
-                panels = [panels]
+            mel.eval("ogs -reset;")
             try:
                 cmds.refresh(force=True)
             except Exception:
                 pass
-            return {"panels": panels}
+            return {"actions": [{"action": "ogs_reset"}]}
         except Exception as exc:
-            return {"error": str(exc), "panels": []}
+            return {"error": str(exc), "actions": []}
 
     def _make_contact_sheet(frame_items, destination, columns):
         try:
@@ -437,6 +393,13 @@ def setup_turntable_preview_scene(
     if image_prefix is None:
         image_prefix = name
 
+    refreshed_textures = []
+    if refresh_textures:
+        viewport_cache_reset = _reset_viewport_cache()
+        refreshed_textures = _refresh_file_textures()
+    else:
+        viewport_cache_reset = {"panels": []}
+
     for suffix in ["camera", "key_light", "fill_light", "rim_light"]:
         _safe_delete(f"{name}_{suffix}")
 
@@ -460,8 +423,6 @@ def setup_turntable_preview_scene(
         cmds.displayRGBColor("backgroundBottom", background_color[0], background_color[1], background_color[2])
     except Exception:
         pass
-
-    refreshed_textures = []
 
     panels = cmds.getPanel(type="modelPanel") or []
     configured_panels = []
@@ -490,9 +451,11 @@ def setup_turntable_preview_scene(
         except Exception:
             continue
 
-    viewport_cache_reset = _reset_viewport_cache() if refresh_textures else {"panels": []}
     if refresh_textures:
-        refreshed_textures = _refresh_file_textures()
+        try:
+            mel.eval("ogs -reloadTextures;")
+        except Exception:
+            pass
 
     frame_results = []
     image_paths = []
@@ -506,8 +469,6 @@ def setup_turntable_preview_scene(
         cmds.xform(camera, translation=camera_position, worldSpace=True)
         _aim_camera(camera, target_position)
         frame_refreshed_textures = []
-        if refresh_textures:
-            frame_refreshed_textures = _refresh_file_textures()
         try:
             cmds.refresh(force=True)
         except Exception:

--- a/src/mayatools/scene/setup_turntable_preview_scene.py
+++ b/src/mayatools/scene/setup_turntable_preview_scene.py
@@ -43,6 +43,7 @@ def setup_turntable_preview_scene(
     import os
     import re
     import maya.cmds as cmds
+    import maya.mel as mel
 
     def _is_number(value):
         return isinstance(value, (int, float)) and not isinstance(value, bool)
@@ -164,8 +165,60 @@ def setup_turntable_preview_scene(
         return re.sub(r"[^A-Za-z0-9_\\-]", "_", label)
 
     def _refresh_file_textures():
+        def _mel_quote(value):
+            return '"' + str(value).replace("\\", "/").replace('"', '\\"') + '"'
+
+        def _reload_texture_callbacks(file_node, texture_path):
+            actions = []
+            if not texture_path:
+                return actions
+            try:
+                mel.eval("source AEfileTemplate.mel")
+            except Exception as exc:
+                actions.append({"action": "source_AEfileTemplate", "error": str(exc)})
+            try:
+                mel.eval("AEfileTextureReloadCmd " + _mel_quote(f"{file_node}.fileTextureName"))
+                actions.append({"action": "AEfileTextureReloadCmd"})
+            except Exception as exc:
+                actions.append({"action": "AEfileTextureReloadCmd", "error": str(exc)})
+                try:
+                    mel.eval("callbacks -executeCallbacks -hook textureReload " + _mel_quote(texture_path))
+                    actions.append({"action": "textureReload_callback"})
+                except Exception as callback_exc:
+                    actions.append({"action": "textureReload_callback", "error": str(callback_exc)})
+            return actions
+
+        def _placeholder_texture_path():
+            import base64
+            placeholder_path = os.path.join(cmds.internalVar(userTmpDir=True) or os.getcwd(), "maya_mcp_texture_reload_placeholder.png")
+            if not os.path.exists(placeholder_path):
+                png_bytes = base64.b64decode(
+                    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
+                )
+                with open(placeholder_path, "wb") as handle:
+                    handle.write(png_bytes)
+            return placeholder_path
+
+        placeholder_texture = _placeholder_texture_path()
+        file_nodes = cmds.ls(type="file") or []
+        scene_texture_paths = []
+        for node in file_nodes:
+            try:
+                node_path = cmds.getAttr(f"{node}.fileTextureName") or ""
+                if node_path and os.path.exists(os.path.normpath(node_path)):
+                    scene_texture_paths.append(node_path)
+            except Exception:
+                pass
+
+        def _alternate_texture_path(original_path):
+            original_norm = os.path.normcase(os.path.normpath(original_path))
+            for candidate in scene_texture_paths:
+                if os.path.normcase(os.path.normpath(candidate)) != original_norm:
+                    return candidate
+            return placeholder_texture
+
         refreshed = []
-        for file_node in cmds.ls(type="file") or []:
+        for file_node in file_nodes:
             try:
                 path = cmds.getAttr(f"{file_node}.fileTextureName") or ""
                 item = {"node": file_node, "path": path, "exists": bool(path and os.path.exists(os.path.normpath(path)))}
@@ -173,9 +226,12 @@ def setup_turntable_preview_scene(
                     cmds.setAttr(f"{file_node}.disableFileLoad", 0)
                 if path:
                     try:
-                        cmds.setAttr(f"{file_node}.fileTextureName", "", type="string")
+                        reload_path = _alternate_texture_path(path) or ""
+                        cmds.setAttr(f"{file_node}.fileTextureName", reload_path, type="string")
                         cmds.setAttr(f"{file_node}.fileTextureName", path, type="string")
                         item["path_reloaded"] = True
+                        item["reload_placeholder"] = reload_path
+                        item["reload_actions"] = _reload_texture_callbacks(file_node, path)
                     except Exception as exc:
                         item["reload_error"] = str(exc)
                 try:
@@ -449,6 +505,9 @@ def setup_turntable_preview_scene(
         ]
         cmds.xform(camera, translation=camera_position, worldSpace=True)
         _aim_camera(camera, target_position)
+        frame_refreshed_textures = []
+        if refresh_textures:
+            frame_refreshed_textures = _refresh_file_textures()
         try:
             cmds.refresh(force=True)
         except Exception:
@@ -485,6 +544,7 @@ def setup_turntable_preview_scene(
                 "angle_degrees": angle,
                 "camera_position": camera_position,
                 "playblast_path": playblast_result or frame_path,
+                "refreshed_textures": frame_refreshed_textures,
                 "foreground_metrics": foreground_metrics,
             }
         )

--- a/src/mayatools/scene/setup_turntable_preview_scene.py
+++ b/src/mayatools/scene/setup_turntable_preview_scene.py
@@ -37,6 +37,7 @@ def setup_turntable_preview_scene(
     view. It can soft-refresh file texture nodes before the sequence when
     requested. Optional annotations label contact-sheet angles, and optional
     foreground analysis reports each frame's bbox, aspect, and coverage.
+    Texture refresh also resets the viewport cache when available.
     """
     import math
     import os
@@ -181,6 +182,19 @@ def setup_turntable_preview_scene(
         except Exception:
             pass
         return refreshed
+
+    def _reset_viewport_cache():
+        try:
+            panels = cmds.ogs(reset=True) or []
+            if isinstance(panels, str):
+                panels = [panels]
+            try:
+                cmds.refresh(force=True)
+            except Exception:
+                pass
+            return {"panels": panels}
+        except Exception as exc:
+            return {"error": str(exc), "panels": []}
 
     def _make_contact_sheet(frame_items, destination, columns):
         try:
@@ -412,6 +426,8 @@ def setup_turntable_preview_scene(
         except Exception:
             continue
 
+    viewport_cache_reset = _reset_viewport_cache() if refresh_textures else {"panels": []}
+
     frame_results = []
     image_paths = []
     for index, angle in enumerate(angles_degrees):
@@ -485,6 +501,7 @@ def setup_turntable_preview_scene(
         "display_curves": bool(display_curves),
         "refresh_textures": bool(refresh_textures),
         "refreshed_textures": refreshed_textures,
+        "viewport_cache_reset": viewport_cache_reset,
         "annotate_contact_sheet": bool(annotate_contact_sheet),
         "analyze_foreground": bool(analyze_foreground),
         "foreground_tolerance": foreground_tolerance,

--- a/src/mayatools/scene/setup_turntable_preview_scene.py
+++ b/src/mayatools/scene/setup_turntable_preview_scene.py
@@ -1,0 +1,374 @@
+from typing import Dict, List, Any, Union
+
+
+def setup_turntable_preview_scene(
+    name: str = "turntable_preview",
+    target_objects: Union[str, List[str]] = None,
+    angles_degrees: List[float] = None,
+    target_position: List[float] = None,
+    focal_length: float = 85.0,
+    distance_multiplier: float = 3.0,
+    elevation_fraction: float = 0.05,
+    background_color: List[float] = [0.45, 0.45, 0.45],
+    key_light_intensity: float = 1.1,
+    fill_light_intensity: float = 0.35,
+    rim_light_intensity: float = 0.65,
+    display_textures: bool = True,
+    transparency_algorithm: str = "depthPeeling",
+    display_curves: bool = False,
+    output_directory: str = None,
+    image_prefix: str = None,
+    contact_sheet_path: str = None,
+    contact_sheet_columns: int = 0,
+    image_width: int = 900,
+    image_height: int = 1200,
+) -> Dict[str, Any]:
+    """Render a generic multi-angle product preview turntable.
+
+    The tool frames one or more target objects from their combined bounding box,
+    configures a simple viewport preview scene, renders one playblast per yaw
+    angle, and can optionally combine the frames into a contact sheet. It is a
+    generic visual QA utility for checking whether product, prop, packaging,
+    decal, transparent-material, or relief work holds up beyond a single front
+    view.
+    """
+    import math
+    import os
+    import re
+    import maya.cmds as cmds
+
+    def _is_number(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    def _validate_vector(values, length, arg_name):
+        if not isinstance(values, list) or len(values) != length or not all(_is_number(v) for v in values):
+            raise ValueError(f"{arg_name} must be a list of {length} numeric values.")
+        return [float(v) for v in values]
+
+    def _validate_scalar(value, arg_name):
+        if not _is_number(value):
+            raise ValueError(f"{arg_name} must be numeric.")
+        return float(value)
+
+    def _validate_image_size(value, arg_name):
+        if not isinstance(value, int) or isinstance(value, bool) or value < 64:
+            raise ValueError(f"{arg_name} must be an integer greater than or equal to 64.")
+        return value
+
+    def _safe_delete(node_name):
+        if cmds.objExists(node_name):
+            try:
+                cmds.delete(node_name)
+            except Exception:
+                pass
+
+    def _is_visible(node):
+        current = node
+        while current:
+            try:
+                if cmds.attributeQuery("visibility", node=current, exists=True) and not cmds.getAttr(f"{current}.visibility"):
+                    return False
+            except Exception:
+                pass
+            parents = cmds.listRelatives(current, parent=True, fullPath=True) or []
+            current = parents[0] if parents else None
+        return True
+
+    def _shape_parent_targets(shape_types):
+        targets = []
+        seen = set()
+        for shape_type in shape_types:
+            for shape in cmds.ls(type=shape_type, long=True) or []:
+                try:
+                    if cmds.attributeQuery("intermediateObject", node=shape, exists=True) and cmds.getAttr(f"{shape}.intermediateObject"):
+                        continue
+                except Exception:
+                    pass
+                parents = cmds.listRelatives(shape, parent=True, fullPath=True) or []
+                if not parents:
+                    continue
+                parent = parents[0]
+                if parent in seen or not _is_visible(shape) or not _is_visible(parent):
+                    continue
+                seen.add(parent)
+                targets.append(parent)
+        return targets
+
+    def _default_targets():
+        mesh_targets = _shape_parent_targets(["mesh"])
+        if mesh_targets:
+            return mesh_targets
+        return _shape_parent_targets(["nurbsCurve", "bezierCurve"])
+
+    def _normalize_targets(targets):
+        if targets is None:
+            return _default_targets()
+        if isinstance(targets, str):
+            targets = [targets]
+        if not isinstance(targets, list) or not all(isinstance(item, str) for item in targets):
+            raise ValueError("target_objects must be a string, a list of strings, or None.")
+        for target in targets:
+            if not cmds.objExists(target):
+                raise ValueError(f"target object does not exist: {target}")
+        return targets
+
+    def _combined_bbox(objects):
+        if not objects:
+            return [-0.5, 0.0, -0.5, 0.5, 1.0, 0.5]
+        bbox = list(cmds.exactWorldBoundingBox(objects[0]))
+        for obj in objects[1:]:
+            obj_bbox = cmds.exactWorldBoundingBox(obj)
+            bbox[0] = min(bbox[0], obj_bbox[0])
+            bbox[1] = min(bbox[1], obj_bbox[1])
+            bbox[2] = min(bbox[2], obj_bbox[2])
+            bbox[3] = max(bbox[3], obj_bbox[3])
+            bbox[4] = max(bbox[4], obj_bbox[4])
+            bbox[5] = max(bbox[5], obj_bbox[5])
+        return bbox
+
+    def _frame_distance(size, focal_length_value, distance_multiplier_value):
+        max_size = max(size)
+        horizontal_aperture_mm = 36.0
+        vertical_aperture_mm = 24.0
+        horizontal_fov = 2.0 * math.atan(horizontal_aperture_mm / (2.0 * focal_length_value))
+        vertical_fov = 2.0 * math.atan(vertical_aperture_mm / (2.0 * focal_length_value))
+        distance_for_width = (size[0] * 0.5) / max(1e-6, math.tan(horizontal_fov * 0.5))
+        distance_for_height = (size[1] * 0.5) / max(1e-6, math.tan(vertical_fov * 0.5))
+        fov_distance = max(distance_for_width, distance_for_height) * 1.15 + size[2] * 0.5
+        multiplier_distance = max_size * distance_multiplier_value
+        return max(2.0, fov_distance, multiplier_distance)
+
+    def _aim_camera(camera_transform, target):
+        locator = cmds.spaceLocator(name=f"{name}_camera_target_tmp")[0]
+        cmds.xform(locator, translation=target, worldSpace=True)
+        constraint = cmds.aimConstraint(
+            locator,
+            camera_transform,
+            aimVector=[0, 0, -1],
+            upVector=[0, 1, 0],
+            worldUpType="scene",
+        )
+        cmds.delete(constraint)
+        cmds.delete(locator)
+
+    def _safe_filename_angle(angle):
+        label = f"{float(angle):.3f}".rstrip("0").rstrip(".")
+        label = label.replace("-", "m").replace(".", "p")
+        return re.sub(r"[^A-Za-z0-9_\\-]", "_", label)
+
+    def _make_contact_sheet(image_paths, destination, columns):
+        try:
+            from PySide6.QtGui import QImage, QPainter, QColor
+        except Exception:
+            try:
+                from PySide2.QtGui import QImage, QPainter, QColor
+            except Exception as exc:
+                raise RuntimeError("PySide QImage is required to write a contact sheet in Maya.") from exc
+
+        if not image_paths:
+            return None
+        columns = max(1, columns)
+        rows = int(math.ceil(len(image_paths) / float(columns)))
+        sheet = QImage(image_width * columns, image_height * rows, QImage.Format_ARGB32)
+        color = QColor()
+        color.setRgbF(background_color[0], background_color[1], background_color[2], 1.0)
+        sheet.fill(color)
+        painter = QPainter(sheet)
+        for index, path in enumerate(image_paths):
+            image = QImage(path)
+            if image.isNull():
+                continue
+            x = (index % columns) * image_width
+            y = (index // columns) * image_height
+            painter.drawImage(x, y, image)
+        painter.end()
+        directory = os.path.dirname(destination)
+        if directory and not os.path.exists(directory):
+            os.makedirs(directory)
+        if not sheet.save(destination):
+            raise RuntimeError(f"Unable to write contact sheet: {destination}")
+        return destination
+
+    if not name:
+        raise ValueError("name is required.")
+    target_objects = _normalize_targets(target_objects)
+    if angles_degrees is None:
+        angles_degrees = [0.0, 45.0, 90.0, 135.0, 180.0, 225.0, 270.0, 315.0]
+    if not isinstance(angles_degrees, list) or not angles_degrees or not all(_is_number(value) for value in angles_degrees):
+        raise ValueError("angles_degrees must be a non-empty list of numeric values.")
+    angles_degrees = [float(value) for value in angles_degrees]
+
+    focal_length = _validate_scalar(focal_length, "focal_length")
+    distance_multiplier = _validate_scalar(distance_multiplier, "distance_multiplier")
+    elevation_fraction = _validate_scalar(elevation_fraction, "elevation_fraction")
+    if focal_length <= 0.0:
+        raise ValueError("focal_length must be greater than zero.")
+    if distance_multiplier <= 0.0:
+        raise ValueError("distance_multiplier must be greater than zero.")
+    background_color = _validate_vector(background_color, 3, "background_color")
+    key_light_intensity = _validate_scalar(key_light_intensity, "key_light_intensity")
+    fill_light_intensity = _validate_scalar(fill_light_intensity, "fill_light_intensity")
+    rim_light_intensity = _validate_scalar(rim_light_intensity, "rim_light_intensity")
+    image_width = _validate_image_size(image_width, "image_width")
+    image_height = _validate_image_size(image_height, "image_height")
+    if not isinstance(contact_sheet_columns, int) or isinstance(contact_sheet_columns, bool) or contact_sheet_columns < 0:
+        raise ValueError("contact_sheet_columns must be an integer greater than or equal to zero.")
+    transparency_algorithm = transparency_algorithm.strip()
+
+    bbox = _combined_bbox(target_objects)
+    bbox_center = [
+        (bbox[0] + bbox[3]) * 0.5,
+        (bbox[1] + bbox[4]) * 0.5,
+        (bbox[2] + bbox[5]) * 0.5,
+    ]
+    bbox_size = [
+        max(1e-6, bbox[3] - bbox[0]),
+        max(1e-6, bbox[4] - bbox[1]),
+        max(1e-6, bbox[5] - bbox[2]),
+    ]
+    if target_position is None:
+        target_position = bbox_center
+    else:
+        target_position = _validate_vector(target_position, 3, "target_position")
+    camera_distance = _frame_distance(bbox_size, focal_length, distance_multiplier)
+    camera_y = target_position[1] + bbox_size[1] * elevation_fraction
+
+    if output_directory is None and contact_sheet_path:
+        output_directory = os.path.dirname(os.path.normpath(contact_sheet_path))
+    if output_directory:
+        output_directory = os.path.normpath(output_directory)
+        if not os.path.exists(output_directory):
+            os.makedirs(output_directory)
+    if image_prefix is None:
+        image_prefix = name
+
+    for suffix in ["camera", "key_light", "fill_light", "rim_light"]:
+        _safe_delete(f"{name}_{suffix}")
+
+    camera, camera_shape = cmds.camera(name=f"{name}_camera")
+    cmds.setAttr(f"{camera_shape}.focalLength", focal_length)
+    cmds.setAttr(f"{camera_shape}.nearClipPlane", 0.01)
+    cmds.setAttr(f"{camera_shape}.farClipPlane", 10000.0)
+
+    key_shape = cmds.directionalLight(name=f"{name}_key_light", intensity=key_light_intensity)
+    key_light = cmds.listRelatives(key_shape, parent=True)[0]
+    cmds.xform(key_light, rotation=[-35.0, 30.0, 0.0], worldSpace=True)
+    fill_shape = cmds.ambientLight(name=f"{name}_fill_light", intensity=fill_light_intensity)
+    fill_light = cmds.listRelatives(fill_shape, parent=True)[0]
+    rim_shape = cmds.directionalLight(name=f"{name}_rim_light", intensity=rim_light_intensity)
+    rim_light = cmds.listRelatives(rim_shape, parent=True)[0]
+    cmds.xform(rim_light, rotation=[-15.0, -145.0, 0.0], worldSpace=True)
+
+    try:
+        cmds.displayRGBColor("background", background_color[0], background_color[1], background_color[2])
+        cmds.displayRGBColor("backgroundTop", background_color[0], background_color[1], background_color[2])
+        cmds.displayRGBColor("backgroundBottom", background_color[0], background_color[1], background_color[2])
+    except Exception:
+        pass
+
+    for file_node in cmds.ls(type="file") or []:
+        try:
+            if cmds.attributeQuery("disableFileLoad", node=file_node, exists=True):
+                cmds.setAttr(f"{file_node}.disableFileLoad", 0)
+        except Exception:
+            pass
+
+    panels = cmds.getPanel(type="modelPanel") or []
+    configured_panels = []
+    for panel in panels:
+        try:
+            cmds.lookThru(panel, camera)
+            try:
+                cmds.modelEditor(panel, edit=True, rendererName="vp2Renderer")
+            except Exception:
+                pass
+            cmds.modelEditor(
+                panel,
+                edit=True,
+                displayAppearance="smoothShaded",
+                displayTextures=bool(display_textures),
+                useDefaultMaterial=False,
+                wireframeOnShaded=False,
+                grid=False,
+            )
+            cmds.modelEditor(panel, edit=True, nurbsCurves=bool(display_curves), locators=False, cameras=False, lights=False, joints=False)
+            try:
+                cmds.modelEditor(panel, edit=True, transparencyAlgorithm=transparency_algorithm)
+            except Exception:
+                pass
+            configured_panels.append(panel)
+        except Exception:
+            continue
+
+    frame_results = []
+    image_paths = []
+    for index, angle in enumerate(angles_degrees):
+        radians = math.radians(angle)
+        camera_position = [
+            target_position[0] + math.sin(radians) * camera_distance,
+            camera_y,
+            target_position[2] + math.cos(radians) * camera_distance,
+        ]
+        cmds.xform(camera, translation=camera_position, worldSpace=True)
+        _aim_camera(camera, target_position)
+        try:
+            cmds.refresh(force=True)
+        except Exception:
+            pass
+
+        frame_path = None
+        playblast_result = None
+        if output_directory:
+            frame_path = os.path.join(
+                output_directory,
+                f"{image_prefix}_{index:02d}_{_safe_filename_angle(angle)}.png",
+            )
+            playblast_result = cmds.playblast(
+                completeFilename=frame_path,
+                format="image",
+                compression="png",
+                frame=[1],
+                widthHeight=[image_width, image_height],
+                percent=100,
+                quality=95,
+                viewer=False,
+                showOrnaments=False,
+                forceOverwrite=True,
+            )
+            image_paths.append(playblast_result or frame_path)
+
+        frame_results.append(
+            {
+                "index": index,
+                "angle_degrees": angle,
+                "camera_position": camera_position,
+                "playblast_path": playblast_result or frame_path,
+            }
+        )
+
+    written_contact_sheet = None
+    if contact_sheet_path:
+        normalized_contact_sheet_path = os.path.normpath(contact_sheet_path)
+        columns = contact_sheet_columns if contact_sheet_columns > 0 else int(math.ceil(math.sqrt(len(image_paths))))
+        written_contact_sheet = _make_contact_sheet(image_paths, normalized_contact_sheet_path, columns)
+
+    return {
+        "success": True,
+        "name": name,
+        "target_objects": target_objects,
+        "bounding_box": bbox,
+        "target_position": target_position,
+        "camera": camera,
+        "camera_shape": camera_shape,
+        "camera_distance": camera_distance,
+        "focal_length": focal_length,
+        "lights": [key_light, fill_light, rim_light],
+        "background_color": background_color,
+        "transparency_algorithm": transparency_algorithm,
+        "display_curves": bool(display_curves),
+        "image_width": image_width,
+        "image_height": image_height,
+        "configured_panels": configured_panels,
+        "frames": frame_results,
+        "contact_sheet_path": written_contact_sheet,
+    }

--- a/src/mayatools/scene/setup_turntable_preview_scene.py
+++ b/src/mayatools/scene/setup_turntable_preview_scene.py
@@ -168,13 +168,21 @@ def setup_turntable_preview_scene(
         for file_node in cmds.ls(type="file") or []:
             try:
                 path = cmds.getAttr(f"{file_node}.fileTextureName") or ""
+                item = {"node": file_node, "path": path, "exists": bool(path and os.path.exists(os.path.normpath(path)))}
                 if cmds.attributeQuery("disableFileLoad", node=file_node, exists=True):
                     cmds.setAttr(f"{file_node}.disableFileLoad", 0)
+                if path:
+                    try:
+                        cmds.setAttr(f"{file_node}.fileTextureName", "", type="string")
+                        cmds.setAttr(f"{file_node}.fileTextureName", path, type="string")
+                        item["path_reloaded"] = True
+                    except Exception as exc:
+                        item["reload_error"] = str(exc)
                 try:
                     cmds.dgdirty(file_node)
                 except Exception:
                     pass
-                refreshed.append({"node": file_node, "path": path, "exists": bool(path and os.path.exists(os.path.normpath(path)))})
+                refreshed.append(item)
             except Exception as exc:
                 refreshed.append({"node": file_node, "error": str(exc)})
         try:

--- a/src/mayatools/scene/setup_turntable_preview_scene.py
+++ b/src/mayatools/scene/setup_turntable_preview_scene.py
@@ -16,10 +16,14 @@ def setup_turntable_preview_scene(
     display_textures: bool = True,
     transparency_algorithm: str = "depthPeeling",
     display_curves: bool = False,
+    refresh_textures: bool = False,
     output_directory: str = None,
     image_prefix: str = None,
     contact_sheet_path: str = None,
     contact_sheet_columns: int = 0,
+    annotate_contact_sheet: bool = False,
+    analyze_foreground: bool = False,
+    foreground_tolerance: float = 0.16,
     image_width: int = 900,
     image_height: int = 1200,
 ) -> Dict[str, Any]:
@@ -30,7 +34,9 @@ def setup_turntable_preview_scene(
     angle, and can optionally combine the frames into a contact sheet. It is a
     generic visual QA utility for checking whether product, prop, packaging,
     decal, transparent-material, or relief work holds up beyond a single front
-    view.
+    view. It can soft-refresh file texture nodes before the sequence when
+    requested. Optional annotations label contact-sheet angles, and optional
+    foreground analysis reports each frame's bbox, aspect, and coverage.
     """
     import math
     import os
@@ -156,31 +162,62 @@ def setup_turntable_preview_scene(
         label = label.replace("-", "m").replace(".", "p")
         return re.sub(r"[^A-Za-z0-9_\\-]", "_", label)
 
-    def _make_contact_sheet(image_paths, destination, columns):
+    def _refresh_file_textures():
+        refreshed = []
+        for file_node in cmds.ls(type="file") or []:
+            try:
+                path = cmds.getAttr(f"{file_node}.fileTextureName") or ""
+                if cmds.attributeQuery("disableFileLoad", node=file_node, exists=True):
+                    cmds.setAttr(f"{file_node}.disableFileLoad", 0)
+                try:
+                    cmds.dgdirty(file_node)
+                except Exception:
+                    pass
+                refreshed.append({"node": file_node, "path": path, "exists": bool(path and os.path.exists(os.path.normpath(path)))})
+            except Exception as exc:
+                refreshed.append({"node": file_node, "error": str(exc)})
         try:
-            from PySide6.QtGui import QImage, QPainter, QColor
+            cmds.refresh(force=True)
+        except Exception:
+            pass
+        return refreshed
+
+    def _make_contact_sheet(frame_items, destination, columns):
+        try:
+            from PySide6.QtGui import QImage, QPainter, QColor, QFont
         except Exception:
             try:
-                from PySide2.QtGui import QImage, QPainter, QColor
+                from PySide2.QtGui import QImage, QPainter, QColor, QFont
             except Exception as exc:
                 raise RuntimeError("PySide QImage is required to write a contact sheet in Maya.") from exc
 
-        if not image_paths:
+        if not frame_items:
             return None
         columns = max(1, columns)
-        rows = int(math.ceil(len(image_paths) / float(columns)))
+        rows = int(math.ceil(len(frame_items) / float(columns)))
         sheet = QImage(image_width * columns, image_height * rows, QImage.Format_ARGB32)
         color = QColor()
         color.setRgbF(background_color[0], background_color[1], background_color[2], 1.0)
         sheet.fill(color)
         painter = QPainter(sheet)
-        for index, path in enumerate(image_paths):
+        if annotate_contact_sheet:
+            font = QFont()
+            font.setPointSize(max(8, int(min(image_width, image_height) * 0.025)))
+            font.setBold(True)
+            painter.setFont(font)
+        for index, frame_item in enumerate(frame_items):
+            path = frame_item.get("playblast_path")
             image = QImage(path)
             if image.isNull():
                 continue
             x = (index % columns) * image_width
             y = (index // columns) * image_height
             painter.drawImage(x, y, image)
+            if annotate_contact_sheet:
+                label = f"{index:02d} angle {frame_item.get('angle_degrees', 0.0):.1f} deg"
+                painter.fillRect(x, y, image_width, max(24, int(image_height * 0.05)), QColor(0, 0, 0, 150))
+                painter.setPen(QColor(255, 255, 255, 255))
+                painter.drawText(x + 8, y + max(18, int(image_height * 0.035)), label)
         painter.end()
         directory = os.path.dirname(destination)
         if directory and not os.path.exists(directory):
@@ -188,6 +225,77 @@ def setup_turntable_preview_scene(
         if not sheet.save(destination):
             raise RuntimeError(f"Unable to write contact sheet: {destination}")
         return destination
+
+    def _foreground_metrics(image_path):
+        try:
+            from PySide6.QtGui import QImage
+        except Exception:
+            try:
+                from PySide2.QtGui import QImage
+            except Exception as exc:
+                raise RuntimeError("PySide QImage is required to analyze turntable foreground frames in Maya.") from exc
+
+        image = QImage(image_path)
+        if image.isNull():
+            return {
+                "image_path": image_path,
+                "foreground_pixels": 0,
+                "foreground_coverage": 0.0,
+                "foreground_bbox_pixels": None,
+                "foreground_bbox_normalized": None,
+                "foreground_aspect": None,
+            }
+
+        width = image.width()
+        height = image.height()
+        min_x = width
+        min_y = height
+        max_x = -1
+        max_y = -1
+        count = 0
+        for y in range(height):
+            for x in range(width):
+                color = image.pixelColor(x, y)
+                if color.alphaF() < 0.05:
+                    continue
+                red = color.redF()
+                green = color.greenF()
+                blue = color.blueF()
+                dr = red - background_color[0]
+                dg = green - background_color[1]
+                db = blue - background_color[2]
+                if math.sqrt(dr * dr + dg * dg + db * db) <= foreground_tolerance:
+                    continue
+                count += 1
+                min_x = min(min_x, x)
+                min_y = min(min_y, y)
+                max_x = max(max_x, x)
+                max_y = max(max_y, y)
+
+        if count <= 0:
+            bbox = None
+            normalized = None
+            aspect = None
+        else:
+            bbox = [min_x, min_y, max_x, max_y]
+            normalized = [
+                min_x / float(max(1, width - 1)),
+                min_y / float(max(1, height - 1)),
+                max_x / float(max(1, width - 1)),
+                max_y / float(max(1, height - 1)),
+            ]
+            bbox_width = max_x - min_x + 1
+            bbox_height = max_y - min_y + 1
+            aspect = bbox_width / float(max(1, bbox_height))
+
+        return {
+            "image_path": image_path,
+            "foreground_pixels": count,
+            "foreground_coverage": count / float(max(1, width * height)),
+            "foreground_bbox_pixels": bbox,
+            "foreground_bbox_normalized": normalized,
+            "foreground_aspect": aspect,
+        }
 
     if not name:
         raise ValueError("name is required.")
@@ -213,6 +321,15 @@ def setup_turntable_preview_scene(
     image_height = _validate_image_size(image_height, "image_height")
     if not isinstance(contact_sheet_columns, int) or isinstance(contact_sheet_columns, bool) or contact_sheet_columns < 0:
         raise ValueError("contact_sheet_columns must be an integer greater than or equal to zero.")
+    if not isinstance(refresh_textures, bool):
+        raise ValueError("refresh_textures must be a boolean.")
+    if not isinstance(annotate_contact_sheet, bool):
+        raise ValueError("annotate_contact_sheet must be a boolean.")
+    if not isinstance(analyze_foreground, bool):
+        raise ValueError("analyze_foreground must be a boolean.")
+    foreground_tolerance = _validate_scalar(foreground_tolerance, "foreground_tolerance")
+    if foreground_tolerance < 0.0:
+        raise ValueError("foreground_tolerance must be greater than or equal to zero.")
     transparency_algorithm = transparency_algorithm.strip()
 
     bbox = _combined_bbox(target_objects)
@@ -266,12 +383,7 @@ def setup_turntable_preview_scene(
     except Exception:
         pass
 
-    for file_node in cmds.ls(type="file") or []:
-        try:
-            if cmds.attributeQuery("disableFileLoad", node=file_node, exists=True):
-                cmds.setAttr(f"{file_node}.disableFileLoad", 0)
-        except Exception:
-            pass
+    refreshed_textures = _refresh_file_textures() if refresh_textures else []
 
     panels = cmds.getPanel(type="modelPanel") or []
     configured_panels = []
@@ -337,12 +449,17 @@ def setup_turntable_preview_scene(
             )
             image_paths.append(playblast_result or frame_path)
 
+        foreground_metrics = None
+        if analyze_foreground and (playblast_result or frame_path):
+            foreground_metrics = _foreground_metrics(playblast_result or frame_path)
+
         frame_results.append(
             {
                 "index": index,
                 "angle_degrees": angle,
                 "camera_position": camera_position,
                 "playblast_path": playblast_result or frame_path,
+                "foreground_metrics": foreground_metrics,
             }
         )
 
@@ -350,7 +467,7 @@ def setup_turntable_preview_scene(
     if contact_sheet_path:
         normalized_contact_sheet_path = os.path.normpath(contact_sheet_path)
         columns = contact_sheet_columns if contact_sheet_columns > 0 else int(math.ceil(math.sqrt(len(image_paths))))
-        written_contact_sheet = _make_contact_sheet(image_paths, normalized_contact_sheet_path, columns)
+        written_contact_sheet = _make_contact_sheet(frame_results, normalized_contact_sheet_path, columns)
 
     return {
         "success": True,
@@ -366,6 +483,11 @@ def setup_turntable_preview_scene(
         "background_color": background_color,
         "transparency_algorithm": transparency_algorithm,
         "display_curves": bool(display_curves),
+        "refresh_textures": bool(refresh_textures),
+        "refreshed_textures": refreshed_textures,
+        "annotate_contact_sheet": bool(annotate_contact_sheet),
+        "analyze_foreground": bool(analyze_foreground),
+        "foreground_tolerance": foreground_tolerance,
         "image_width": image_width,
         "image_height": image_height,
         "configured_panels": configured_panels,


### PR DESCRIPTION
﻿﻿﻿﻿﻿﻿﻿## Summary





Adds first-class UV, image texture, curved/profile-conformed labels, curved text, profile-revolved mesh, hollow shell, revolved liquid volume, cylindrical detail band, generic radial deformation, polar mesh deformation, localized radial pattern deformation, product preview setup, and physically-oriented material support to MayaMCP. Together these let MCP clients create real texture-node materials, UV-mapped curved labels that can follow lathed profiles, curved raised or filled text, tube geometry from curves, non-cylindrical lathed forms, smooth resampled contour shells, transparent vessel shells, inset liquid fill volumes with liquid surfaces, repeated flutes/grooves/ridges, coupled polar petal or punt bases, localized dimples or raised dots, cap knurling/ring bands, repeatable product-preview cameras/lights/playblasts, reference image planes, image-silhouette profile extraction, image color-region measurement, reference-region texture extraction, image matte texture extraction, image detail-mask extraction, image component relief deformation, image contour extraction, texture-driven mesh trimming, cylindrical image-driven mesh deformation, transparent glass/liquid-style materials, flood-fill reference background masking, alpha-correct textured labels, and UV texture-driven mesh cutouts, and region-derived alpha mattes, image-derived contour curves, curve-to-tube geometry, and curve-visible product previews without adding a product-specific workflow.





## Changes





- Add `uv_operations` for listing UV sets, creating/switching/deleting UV sets, projection mapping, normalization, and UV layout.


- Add `create_textured_material` to build file-texture materials with `file` and `place2dTexture` nodes and optional assignment to UV-mapped objects.


- Add `extract_image_region_texture` to crop a reference image bbox into a reusable texture file with padding, optional resize, optional aspect preservation, optional front-cylindrical horizontal remap, optional background masking, and overwrite controls.


- Add `extract_image_matte_texture` to crop reference imagery and derive alpha mattes from RGB, hue, foreground, or source-alpha connected components, with exact-match, row-span, or bbox matte modes that preserve internal artwork colors.


- Add `extract_image_detail_mask` to derive dark, bright, absolute-contrast, or edge masks from cropped reference image regions, with high-pass blur, threshold softness, gamma/contrast controls, optional alpha output, and optional front-cylindrical remapping for downstream texture cleanup or geometry relief.


- Add `cylindrical_component_deform` to threshold image masks into connected components, fit them into axis/angle-space local relief features, and apply bounded radial or axis displacement to cylindrical or lathed meshes.


- Add `extract_image_contours` to segment image regions by luminance, alpha, RGB, hue, or foreground, extract connected-component boundary contours, simplify/resample them, and optionally create planar or cylindrical Maya curves.


- Add `create_tube_mesh_from_curves` to convert existing Maya curves or point paths into polygon tube meshes with radius, segment, cap, material, and smoothing controls.


- Extend `setup_product_preview_scene` with `display_curves` so curve extraction and curve-based detail workflows can be visually verified in playblasts.


- Add `trim_mesh_by_texture` to sample image channels through mesh UVs and delete matching polygon faces for generic alpha-cut labels, decals, panels, vents, grates, leaf cards, and masks.


- Extend `extract_image_region_texture` with `mask_background_mode="flood_fill"` so edge-connected background can be made transparent without removing same-colored internal label artwork.


- Extend `create_textured_label` with `use_alpha` and update texture-alpha handling to drive material transparency through a reversed `outAlpha` connection.


- Update `create_textured_material` alpha handling to prefer the same reversed `outAlpha` transparency path for PNGs and other alpha textures.


- Add `create_textured_label` to create a curved polygon label strip with preserved `0..1` UVs and apply an image texture directly to the mesh.


- Extend `create_textured_label` with optional `surface_profile` and `profile_interpolation` so a label can conform by height to a lathed vessel profile instead of using a fixed cylindrical radius.


- Add `create_curved_text` to create cylindrical text curves, raised tube text, or filled polygon text using `geometry_mode` values `curves`, `tube`, and `filled`.


- Add `create_revolved_mesh` to create UV-mapped lathed polygon meshes from radius/height profiles for bottles, cups, vases, and similar forms.


- Extend `create_revolved_mesh` with `height_segments` and `profile_interpolation` so sparse control profiles can generate dense linear or smooth contours.


- Add `create_revolved_shell` to create UV-mapped hollow lathed shells from outer/inner profiles or wall thickness for thick-wall bottles, cups, shades, and vessels.


- Extend `create_revolved_shell` with `height_segments` and `profile_interpolation`, including sampled inner/outer profiles and support for inner profiles with matching height ranges.


- Add `create_revolved_liquid_volume` to create inset axisymmetric liquid volumes from a vessel profile, fill height, optional bottom height, top/bottom caps, and smooth profile resampling.


- Add `extract_revolved_profile_from_image` to sample foreground silhouettes from reference images into lathe-ready `[height, radius]` profiles, with crop, background threshold, axis, side, smoothing, scaling, and optional curve output controls.


- Add `extract_image_color_regions` to find connected RGB, hue, or foreground image regions and report pixel, normalized, horizontal-band, and product-height-space bounds for reference-driven placement of labels, caps, bands, panels, or other colored features.


- Add `create_cylindrical_detail_band` to create UV-mapped cylindrical bands with generic ridges, grooves, corrugation, knurling, or thread-like detail.


- Add `radial_mesh_deform` to apply generic periodic radial grooves, ridges, flutes, or corrugation to polygon meshes while preserving UVs.


- Add `cylindrical_image_deform` to sample an image in angle/height space and drive radial or axis displacement on cylindrical or lathed polygon meshes for generic photo-driven relief, grips, emboss/deboss patterns, dents, and surface texture transfer.


- Add `polar_mesh_deform` to apply coupled angular radial and axis-direction displacement with axis/radius ranges and profiles, supporting generic petal bases, star supports, lobed feet, punted bottoms, and cyclic polar details.


- Add `localized_radial_pattern_deform` to apply bounded angular/axial grids of dimples, raised dots, or emboss/deboss features to cylindrical or lathed polygon meshes while preserving UVs.


- Add `setup_product_preview_scene` to create a repeatable product-preview camera, lights, neutral background, VP2 textured display, depth-peeling transparency, and optional playblast image.


- Add `create_reference_image_plane` to create a textured world-space image plane that can fit to target object bounds for silhouette, proportion, and layout reference comparisons.


- Add `create_pbr_material` for generic PBR-style material presets such as glass, liquid, metal, plastic, rubber, and ceramic. It prefers Arnold `aiStandardSurface`, falls back to Maya `standardSurface`, then to `phong` when needed.


- Harden MCP script argument serialization with `repr(...)` and escape backslashes before wrapping Python in MEL, which is important for Windows texture paths.


- Document the new tools and contour/pattern/liquid-volume/polar-deformation/profiled-label/product-preview support in the README.





## Validation





- Ran `python -m compileall -q src`.


- Verified dynamic tool discovery registers 42 tools, including the UV/texture/image-matte/image-detail-mask/image-component-deform/image-contour/curve-tube/texture-trim/profiled-label/curved-text/revolved-mesh/revolved-shell/revolved-liquid-volume/detail-band/radial-deform/polar-deform/localized-pattern-deform/product-preview/PBR-material tools.


- Verified `setup_product_preview_scene` schema includes target framing, camera controls, lighting controls, background color, VP2 texture display, `depthPeeling` transparency default, playblast path, and image size controls.


- Verified `create_reference_image_plane` schema includes image path, target fitting, explicit center/size controls, image aspect detection, plane-axis selection, offset, opacity, subdivision, locking, and replacement controls.


- Verified `create_textured_label` schema includes `surface_profile` and `profile_interpolation` while preserving fixed-radius label behavior.


- Verified `create_revolved_mesh` and `create_revolved_shell` schemas include `height_segments` and `profile_interpolation` defaults.


- Verified `create_revolved_liquid_volume` schema includes `container_profile`, `fill_height`, `bottom_height`, `radius_offset`, top/bottom cap controls, and profile resampling controls.


- Verified `extract_revolved_profile_from_image` schema includes image path, target height, sample count, background color or corner estimation, tolerance, alpha threshold, crop, axis selection, side selection, smoothing, minimum row pixels, radius scaling/offset, and optional profile-curve output.


- Verified `extract_image_color_regions` schema includes RGB/hue/foreground matching, target color, tolerances, saturation/value gates, crop, alpha threshold, background color or corner estimation, reference bounding box, target height, component filters, band filters, and max region limits.


- Verified `extract_image_region_texture` schema includes pixel or normalized bbox input, padding, output path, output size, stretch or aspect-preserving resize, `horizontal_remap`, `source_arc_degrees`, `remap_center_x`, optional background masking, background color/tolerance, and overwrite control.


- Verified `extract_image_matte_texture` schema includes crop input, output sizing, front-cylindrical remap controls, RGB/hue/foreground/alpha match modes, target/background color controls, seed or largest-component selection, connectivity, component filters, exact/row-span/bbox matte modes, matte expansion, and overwrite controls.


- Verified `extract_image_detail_mask` schema includes pixel or normalized bbox input, padding, output sizing, front-cylindrical remap controls, dark/bright/absolute/edge detail modes, blur radius, threshold/softness, contrast, gamma, alpha output, inversion, and overwrite controls.


- Verified `cylindrical_component_deform` schema includes object/image inputs, axis and angle ranges, radial/axis displacement, sample-channel controls, thresholding, component connectivity and size filters, fitted feature radii, falloff/blend modes, U/V flipping, and smoothing.


- Verified `extract_image_contours` schema includes crop input, luminance/alpha/RGB/hue/foreground matching, component connectivity and filters, simplification/resampling controls, curve creation, image-plane mapping, cylindrical/surface-profile mapping, and curve offsets.


- Verified `create_tube_mesh_from_curves` schema includes curve-name and point-path inputs, tube radius, radial segments, cap control, path cleaning, point decimation, material assignment, and smoothing.


- Verified `setup_product_preview_scene` schema includes `display_curves`.


- Verified `trim_mesh_by_texture` schema includes mesh/image inputs, UV set selection, alpha/luminance/RGB/value/saturation channels, threshold direction, U/V wrapping and flipping, dry-run mode, minimum kept-face safety, and smoothing.


- Verified `extract_image_region_texture` schema includes `mask_background_mode`, and `create_textured_label` schema includes `use_alpha`.


- Verified `cylindrical_image_deform` schema includes target object, image path, center/axis, axis and angle ranges, radial/axis displacement direction, sample channel, inversion, black/white points, threshold/softness, neutral value, gamma, U/V flipping, edge falloffs, and smoothing.


- Verified `polar_mesh_deform` schema includes radial and axis amplitudes, uniform axis displacement, cycle count, phase/sharpness, axis/radius ranges, falloffs, and profiles.


- Verified `localized_radial_pattern_deform` schema includes bounded angle/axis ranges, row/column counts, feature radii, amplitude, falloff, and stagger controls.


- Verified MCP stdio `list_tools` returns the expanded tool set.


- Live-tested through Maya command port: created a fresh scene, created a cylinder, created/switched/deleted a named UV set, ran cylindrical projection, normalized UVs to `0..1`, assigned an image-textured material, and created a curved textured label with `map1` UV range `0..1`.


- Live-tested `setup_product_preview_scene` through MCP on the transparent bottle/liquid/label/cap scene; verified it created camera/lights, configured all model panels, wrote a playblast, and with depth-peeling transparency kept the textured red label visible instead of being greyed out by the transparent shell.


- Live-tested `create_reference_image_plane` through MCP using the official 750x750 Coca-Cola 20oz reference image; verified it reads image dimensions, creates textured reference planes, fits to model bounds, supports behind-model overlay and side-by-side placement, and writes viewport playblasts for direct proportion comparison.


- Live-tested `extract_revolved_profile_from_image` through MCP on the official 750x750 Coca-Cola 20oz reference image; verified it estimated a white background, found foreground bbox `[280, 86, 469, 665]`, returned 96 bottom-to-top profile samples for a 3.59-unit target height, generated a profile curve, then drove `create_revolved_mesh` to produce an image-profiled bottle silhouette preview.


- Live-tested `extract_image_color_regions` through MCP on the official 750x750 Coca-Cola 20oz reference image; verified hue matching finds cap and broad red foreground regions, stricter RGB matching separates the label (`y=288..449`) and cap (`y=90..125`) into product-height-space measurements, and horizontal-band output produces cap/label bounds used to generate a layered bottle preview with reference-derived shell, liquid, label, and cap placement.


- Live-tested `extract_image_region_texture` through MCP by cropping the color-region-derived label bbox from the official 750x750 reference image to `1024x512`, first as a direct crop and then with `horizontal_remap="cylindrical_front"` using a 144-degree source arc; verified the remapped texture reduces the double-curvature distortion when reapplied with `create_textured_label` on the profiled shell.


- Live-tested `extract_image_detail_mask` through MCP by extracting dark and edge detail masks from the official lower-body dimple crop; verified the dark high-pass mask isolated the ring/dot relief more cleanly than raw luminance or dense edge response, then used it as input to `cylindrical_image_deform` for the v7 preview.


- Live-tested `cylindrical_component_deform` through MCP on the official lower-body detail mask; the v10 pass detected 43 components, retained 43 fitted relief features, and moved 586 shell vertices with bounded radial displacement instead of raw per-pixel luminance waves.


- Live-tested `extract_image_contours` through MCP on the lower-body detail mask; it matched 114669 pixels, found 48 components, produced 24 contours, created 24 cylindrical surface curves on the profiled bottle, and generated a v14 playblast with `display_curves=true`.


- Live-tested `create_tube_mesh_from_curves` through MCP on the 24 v14 lower-body contour curves; it generated one polygon tube mesh with 6276 vertices and 6276 faces, assigned a material, saved a v15 scene, and generated a playblast with curve display disabled so the actual tube geometry was visible.


- Live-tested `extract_image_matte_texture` through MCP on the official reference label crop; hue matching found one connected red label component, row-span matte generation preserved internal white and black artwork while alpha-masking side/background regions, then the v13 label mesh was created, alpha-connected, texture-trimmed, and previewed in Maya.


- Live-tested flood-fill label extraction and alpha label creation through MCP; the v10 label texture used edge-connected background masking, local PNG inspection showed about 98.9% transparency in the left/right edge bands and full opacity through the center artwork, and `create_textured_label(use_alpha=True)` created a reverse alpha node for material transparency.


- Live-tested `trim_mesh_by_texture` through MCP on the v10 alpha label mesh; dry-run matched 323 of 2048 faces for deletion, actual trim removed the transparent edge faces, and the label UV range narrowed to about `0.055..0.945` in U while preserving `0..1` V before generating the v11 preview.


- Live-tested `cylindrical_image_deform` through MCP by cropping the official reference image lower-body region and a localized dimple patch into remapped relief masks, then applying luminance-driven radial displacement to the profiled PET shell; verified thousands of vertices were displaced in bounded angle/height ranges and generated viewport previews showing image-driven lower-body relief instead of only procedural grid dimples.


- Live-tested `create_textured_label` through MCP with a `surface_profile` spanning a changing-radius shoulder/body band; verified the returned result includes the profile data and the label conforms to the bottle profile instead of staying on one cylindrical radius.


- Live-tested `create_revolved_mesh` through MCP with a bottle-like profile; verified generated mesh `map1` UV range is `0..1`, then applied the curved texture label to the profiled bottle body.


- Live-tested `create_revolved_shell` through MCP with outer and inner bottle-like profiles; verified the thick-wall shell has `map1` UV range `0..1` and visible shell thickness in the viewport.


- Live-tested smooth profile resampling through MCP using an official Coca-Cola 20oz product-image-derived silhouette profile; verified the generated body has a shoulder, neck, waist, and lower-body contour instead of a cylinder.


- Live-tested `create_revolved_liquid_volume` through MCP using the same vessel profile; verified it creates a single combined liquid object from side/top/bottom source parts, supports inset radius, and displays an internal fill surface inside a transparent shell with an external label overlay.


- Live-tested `radial_mesh_deform` through MCP on both profiled body and thick-wall shell with repeated inward grooves over lower-body and shoulder height ranges; verified UVs remained in `0..1`.


- Live-tested `polar_mesh_deform` through MCP on the profiled bottle body bottom using five angular cycles; verified 10604 vertices moved, front playblast shows PET-style lobed feet, and bottom-view playblast confirms the five-petal polar footprint.


- Live-tested `localized_radial_pattern_deform` through MCP on the profiled bottle body with a bounded lower-body angular patch; verified 56 localized dimple features and 568 moved vertices on the medium mesh, then repeated on a denser resampled shell for cleaner local grip dimples in viewport playblast.


- Live-tested `create_cylindrical_detail_band` through MCP by creating cap knurling and neck/lip ring bands; verified each generated band has `map1` UV range `0..1` and visible repeated detail in the viewport.


- Live-tested `create_curved_text` through MCP in `tube` mode by conforming text curves to a cylindrical shell and generating raised tube geometry; verified the raised text is visible on the curved surface in viewport playblast.


- Live-tested `create_curved_text` through MCP in `filled` mode after switching to direct `planarSrf(..., polygon=1)` mesh generation; verified it creates letter-shaped filled mesh patches instead of rectangular trimmed-surface artifacts.


- Live-tested `create_pbr_material` through MCP in a Maya session where Arnold could not load; verified it fell back to `standardSurface` or explicit `phong`, applied glass, liquid, and plastic-style materials, and assigned them to bottle, liquid, cap, and detail-band meshes.


- Generated local Maya playblasts to visually confirm UV label placement, profile-conformed label placement, non-cylindrical body shape, fluted detail, localized lower-body dimple fields, polar five-petal bottom support, transparent outer shell, internal liquid volume and fill surface, label-over-shell layering, product-preview depth-peeling label visibility, scene-space official-reference overlay and side-by-side comparison planes, image-silhouette-derived profile reconstruction, color-region-derived label and cap placement, reference-cropped label texture mapping, image-driven lower-body relief experiments, visible internal liquid volume, thicker glass-like shell edges, cap knurling, neck ring detail, raised curved text geometry, filled curved text geometry, and a full-body official-profile contour bottle iteration.





























## Latest update: image contour tracing





- Added traced boundary-chain ordering to `extract_image_contours` while keeping `contour_ordering="angle"` as a fallback.


- Added generic contour filters: `min_boundary_points`, `min_bbox_width_pixels`, `min_bbox_height_pixels`, `max_bbox_width_pixels`, and `max_bbox_height_pixels`.


- Updated curve naming to include component and chain indices so multi-contour components do not collide.


- Verified `python -m compileall -q src`, `git diff --check`, and MCP dynamic discovery: 42 tools, with the new contour parameters present in schema.


- Live-tested through Maya command port on the lower-body detail mask: 49 raw components, 36 filtered components, 48 closed trace contours, 48 created curves, and one tube mesh with 3215 vertices / 3215 faces. Generated `mayamcp_official_layered_bottle_v17_trace_tubes.png` and `mayamcp_official_layered_bottle_v17.ma`.








## Latest update: foreground reference crop support





- Extended `extract_image_region_texture` with `auto_bbox_mode="foreground"`, `alpha_threshold`, and `min_foreground_pixels` so references can be cropped from foreground pixels without manually passing a bbox.


- Extended `create_reference_image_plane` with `use_alpha`; PNG alpha is now combined with the plane opacity through utility nodes before driving material transparency.


- Verified `python -m compileall -q src`, `git diff --check`, and MCP dynamic discovery: 42 tools, with the new region-crop/reference-plane parameters present in schema.


- Live-tested through Maya command port on the official 750x750 Coca-Cola bottle reference: auto-cropped bbox `[268, 74, 481, 677]`, wrote `official_full_bottle_foreground_v18.png` at `496x1400`, created an alpha reference plane, hid the stale reference plane, and generated `mayamcp_official_layered_bottle_v19_reference_compare_clean.png` / `.ma` for same-height side-by-side silhouette comparison.








## Latest update: textured label opacity





- Extended `create_textured_label` with generic `opacity` support. The tool now sets constant material transparency, and when `use_alpha=true` it multiplies texture alpha by opacity before driving material transparency.


- Verified `python -m compileall -q src`, `git diff --check`, and MCP dynamic discovery: 42 tools, with `create_textured_label.opacity` present in schema.


- Live-tested through Maya command port by cropping a lower-body reference texture from the official bottle image, creating a profiled semi-transparent lower-body texture layer with `opacity=0.88`, and generating `mayamcp_official_layered_bottle_v21_lower_texture_clean.png` / `.ma`. This makes the lower-body red PET skin, dot field, wave line, and tilted logo texture visibly closer to the official reference while remaining a generic textured-label workflow.








## Latest update: UV texture deformation





- Added `uv_texture_deform`, a generic UV-driven mesh deformation tool. It samples an image through vertex UVs and displaces vertices along normals, world axes, or radial directions, with channel selection, thresholding, gamma, wrapping, V flipping, neutral value, and minimum displacement controls.


- Documented `uv_texture_deform` in the README.


- Verified `python -m compileall -q src`, `git diff --check`, and MCP dynamic discovery: 43 tools, including `uv_texture_deform` with direction/radial-axis/UV-set/min-displacement controls.


- Live-tested through Maya command port by extracting lower-body relief masks from the official reference-derived texture, then applying `uv_texture_deform` to the profiled lower-body texture mesh. The tuned v23 run sampled 2813 vertices, displaced 892 vertices with max displacement `0.015`, and generated `mayamcp_official_layered_bottle_v23_uv_relief_clean.png` / `.ma` with visible geometric relief in the dot field, wave line, tilted logo area, and bottom grooves.











## Latest update: silhouette comparison





- Added `compare_image_silhouettes`, a generic image QA tool that extracts reference/candidate masks, optionally fills holes, normalizes silhouettes with height-preserving scale, writes an overlay, and returns IoU, precision/recall, aspect, centroid, and row-width error metrics.


- Documented `compare_image_silhouettes` in the README.


- Verified `python -m compileall -q src`, `git diff --check`, and MCP dynamic discovery: 44 tools, including `compare_image_silhouettes` with crop, mask, fill-hole, scale, padding, and row-sampling controls.


- Live-tested through Maya command port by comparing the official foreground Coca-Cola bottle reference against the v24 Maya playblast crop. With hole filling enabled, the generated overlay `mayamcp_official_layered_bottle_v24_silhouette_compare_filled.png` reported IoU `0.9588`, aspect error `+0.0108`, mean absolute row-width error `0.0165`, and max row-width error `0.3242`. The test confirms the current gross outer silhouette is measurable, while remaining visual cylinder-like issues are more likely from internal surface relief, label band edges, material layering, and localized cap/base/shoulder mismatches.











## Latest update: profile deformation and band metrics





- Extended `compare_image_silhouettes` with optional `band_edges_normalized` and `band_sample_count`, returning vertical-band width summaries from the full normalized silhouette instead of relying on crop-based comparisons that can be distorted by open slice boundaries.


- Added `radial_profile_deform`, a generic non-periodic axial profile deformation tool. It samples `[position, value]` profiles along an axis and changes mesh radius by scale, offset, or absolute target radius, with normalized/world profile positions, smooth/linear interpolation, blend, and max-displacement controls.


- Documented the new profile deformation tool and expanded silhouette comparison metrics in the README.


- Verified `python -m compileall -q src`, `git diff --check`, and MCP dynamic discovery: 45 tools, including `radial_profile_deform` and the new silhouette band metric parameters.


- Live-tested through Maya command port on the v24 Coca-Cola bottle scene. The band metrics isolated the main silhouette deltas: cap/top remains too wide, shoulder is slightly narrow, label/body is close, and base differences are localized. `radial_profile_deform` then moved 99,820 shell vertices in the v25 profile-refine test and 74,498 shell vertices in the more conservative v26 pass.


- Generated local test previews `mayamcp_official_layered_bottle_v25_profile_refine.png` and `mayamcp_official_layered_bottle_v26_subtle_profile.png`, plus band overlays. v25 showed the tool can break up the cylindrical lower-body read, but also showed that radial deformation on front texture layers pushes them into the transparent shell and darkens them. v26 is the safer current visual test: cap/top error improved and aspect error dropped to about `+0.00175`, while further work should separate front-decal horizontal/profile shaping from true radial shell deformation.











## Latest update: linear profile deformation





- Added `linear_profile_deform`, a generic non-radial profile deformation tool. It samples `[position, value]` profiles along one axis and changes vertex coordinates along another axis, with normalized/world positions, scale/offset/target-coordinate/target-distance modes, blend, interpolation, and max-displacement controls.


- Documented `linear_profile_deform` in the README.


- Verified `python -m compileall -q src`, `git diff --check`, and MCP dynamic discovery: 46 tools, including `linear_profile_deform`.


- Live-tested through Maya command port on the v26 Coca-Cola bottle scene. Applied X-axis profile shaping to the front lower-body photo-skin mesh and trace-tube detail mesh, moving 2,811 and 3,214 vertices respectively, while preserving Z depth so the front texture layer does not get pushed into the transparent shell.


- Generated `mayamcp_official_layered_bottle_v27_linear_decal_profile.png` / `.ma` and `mayamcp_official_layered_bottle_v27_silhouette_compare_bands.png`. The v27 silhouette metrics stayed essentially unchanged from v26 (`IoU ~0.9551`, aspect error `+0.00175`), which is expected: this tool fixes front decal/profile read without changing the true outer bottle silhouette.











## Latest update: silhouette correction profiles





- Extended `compare_image_silhouettes` with optional width correction profile output. It can now sample the normalized full silhouette, compute reference/candidate width ratios, smooth and clamp them, and return `axis_scale_profile_points` sorted bottom-to-top for direct use with generic profile deformation tools.


- Added controls for `correction_profile_sample_count`, `correction_profile_smoothing_radius`, `correction_profile_min_width`, and `correction_profile_scale_range`.


- Documented the expanded profile-correction output in the README.


- Verified `python -m compileall -q src`, `git diff --check`, and MCP dynamic discovery: 46 tools with the new correction-profile schema parameters present.


- Live-tested through Maya command port by comparing the v27 bottle playblast to the official foreground reference, extracting a 17-point correction profile, then feeding it into `radial_profile_deform` on the PET shell and liquid volume to generate `mayamcp_official_layered_bottle_v28_auto_profile_correction.png` / `.ma`.


- The automatic profile-correction loop improved silhouette metrics: IoU increased from about `0.9551` to `0.9603`, mean row-width error dropped from about `0.0163` to `0.0089`, and max row-width error dropped from about `0.2539` to `0.1621`. Remaining visible mismatch is now concentrated in cap/top and localized base/label/material fidelity rather than the broad body silhouette.











## Latest update: bounds fitting, texture refresh, and preview framing





- Added `fit_objects_to_bounds`, a generic bounds-fitting tool for resizing and positioning mesh or curve objects against target world-space bounds using point-level or transform-level application.


- Added `refresh_file_textures`, a generic file-texture refresh utility that re-enables file loading, normalizes/touches `fileTextureName`, dirties file nodes, and resets textured viewport display for reopened scenes and stale VP2 previews.


- Improved `setup_product_preview_scene` so omitted `target_objects` auto-frame visible scene geometry, and camera distance now accounts for focal length/FOV to avoid clipping tall products at high focal lengths.


- Documented the new tools and updated preview behavior in the README.


- Verified `python -m compileall -q src`, `git diff --check`, and MCP dynamic discovery: 48 tools, including `fit_objects_to_bounds` and `refresh_file_textures`.


- Live-tested through Maya command port on the v28 Coca-Cola bottle scene: refreshed 6 file texture nodes with no missing paths, fit the cap knurl mesh to reference-derived cap bounds by moving 2,093 vertices, and generated `mayamcp_official_layered_bottle_v29_cap_bounds_fit_refresh.png` / `.ma`.


- Live-tested `fit_objects_to_bounds(apply_mode="transform")` in a fresh scene on a cube; final bounds exactly matched `[1, 2, 3, 3, 4, 5]`, and preview auto-targeting found the fitted mesh.


- Re-ran silhouette comparison on the v29 refreshed preview: IoU `0.9755`, aspect error `+0.00495`, mean absolute row-width error `0.00739`, and max absolute row-width error `0.08984`. The cap/top is materially closer; remaining work is still visual/material fidelity and local lower-body/base detail, not a special-case workflow gap.











## Latest update: appearance comparison and scene diagnostics





- Hardened `list_objects_by_type` with explicit category mapping for common scene queries: meshes, mesh shapes, curves, geometry, cameras, lights, materials, textures, file textures, shading groups, and shapes. This fixes invalid Maya-flag failures such as `filter_by="meshes"`.


- Extended `set_object_attribute` to support `float3` vector attributes, integer numeric inputs, strings, richer return data, and an explicit `disconnect_existing` option for intentional attribute overrides when a plug is connected.


- Added `compare_image_appearance`, a generic visual QA tool that crops and aligns reference/candidate images, applies alpha or foreground masks, computes RGB/luminance MAE and RMSE, and writes a reference/candidate/heatmap diagnostic.


- Documented the updated scene/object tools and the new appearance comparator in the README.


- Verified `python -m compileall -q src`, `git diff --check`, and MCP dynamic discovery: 49 tools, including `compare_image_appearance`.


- Live-tested `list_objects_by_type` through Maya command port on the current bottle scene: `meshes` returned 8 visible mesh transforms; `geometry` returned 81 visible mesh/curve transforms; `materials` returned 14 materials; `file_textures` returned 6 file texture nodes.


- Live-tested `set_object_attribute` on Maya material attributes: updated lambert `float3` color/transparency successfully, and verified `disconnect_existing=true` can disconnect an incoming alpha reverse node before setting a connected material attribute.


- Generated local v30/v31/v33 bottle iterations using only generic texture-crop, textured-label, material-attribute, texture-refresh, and preview tools. The useful current visual candidate is `mayamcp_official_layered_bottle_v33_lower_alpha_gain.png` / `.ma`; v32 was intentionally discarded because breaking the alpha matte made transparent side regions render as black slabs.


- Live-tested `compare_image_appearance` against the v29 and v31/v33 previews with a fixed reference mask. v29 appearance metrics were RGB MAE `0.2062`, RGB RMSE `0.2772`, luminance MAE `0.1863`, luminance RMSE `0.2470`. v31 improved to RGB MAE `0.1829`, RGB RMSE `0.2514`, luminance MAE `0.1810`, luminance RMSE `0.2373`; v33 was similar with RGB MAE `0.1822` and RGB RMSE `0.2513`.


- The new heatmap shows the remaining largest visual errors are cap material/shape, label artwork scale/placement, lower-body material darkness, and grey shell edge treatment; silhouette remains strong, so the next useful work should target appearance/material/detail fidelity rather than broad outline correction.











## Latest update: regional appearance metrics and material iteration





- Extended `compare_image_appearance` with `band_edges_normalized`, returning per-band RGB/luminance MAE/RMSE, signed luminance error, pixel counts, and max-channel error. This makes appearance mismatches localizable by vertical product regions instead of relying only on a full-image heatmap.


- Documented the vertical-band appearance summaries in the README.


- Verified `python -m compileall -q src`, `git diff --check`, and MCP dynamic discovery: 49 tools, with `compare_image_appearance.band_edges_normalized` present in schema.


- Live-tested band metrics on the current bottle previews with a fixed reference mask. v33 overall RGB MAE was `0.1822`; the highest bands were upper/shoulder and base/lower regions, with band RGB MAE around `0.2022`, `0.1946`, and `0.1913` depending on region.


- Tried two cap photo-skin iterations (`v34`, `v35`) using generic crop/matte/curved-texture tools. Both were rejected by the metrics and visual result: the cap band luminance error rose from about `0.1918` to about `0.254-0.255`, showing that the current cap crop/matte approach introduces a visible rectangular/edge artifact.


- Generated `v36` by making the PET shell clearer and less grey using generic material-attribute edits. This was a meaningful improvement: overall RGB MAE dropped from `0.1822` to `0.1692`, RGB RMSE dropped from `0.2513` to `0.2454`, and lower/body bands improved substantially.


- Generated `v37` by lightly retuning cap material from v36. It is the current best numeric candidate: overall RGB MAE `0.16908`, RGB RMSE `0.24517`, luminance RMSE `0.23436`. Cap top is still not solved, but the material-only cap adjustment is slightly better than v36 and avoids the failed photo-skin artifact.











## Latest update: appearance grid metrics





- Added generic `grid_rows` / `grid_columns` support to `compare_image_appearance` for localized 2D RGB/luminance error summaries.


- Kept the change tool-generic: no Coca-Cola-specific workflow or special-case logic.


- Validation: `python -m compileall -q src`, `git diff --check`, MCP schema load (`tool_count=49`), and live Maya `list_objects_by_type` command-port call.


- Current v37 benchmark vs official foreground reference: RGB MAE `0.169078`, RGB RMSE `0.245166`; 8x4 grid identifies shoulder/upper-label side cells as the largest remaining appearance errors.











## Latest update: appearance auto-crop and v38 bottle test





- Added generic foreground auto-cropping to `compare_image_appearance` with `auto_crop_reference`, `auto_crop_candidate`, and `auto_crop_padding_pixels`.


- Validated the new auto-crop on the v38 candidate render: it found bbox `[365,456,534,955]`, matching manual foreground detection.


- v38 scene iteration reduced the gray cylindrical band by lowering PET shell opacity and extending the lower body photo skin to meet the label bottom using generic bounds fitting.


- Same-crop appearance comparison improved from v37 RGB MAE `0.16794` to v38 RGB MAE `0.16142`; luminance MAE improved from `0.16857` to `0.16505`.


- Validation: `python -m compileall -q src`, `git diff --check`, MCP schema load (`tool_count=49`), and live Maya `compare_image_appearance` auto-crop call.











## Latest update: silhouette auto-crop and v41 shoulder correction





- Added generic foreground auto-cropping to `compare_image_silhouettes` with `auto_crop_reference`, `auto_crop_candidate`, and `auto_crop_padding_pixels`.


- Used the silhouette correction profile to guide a generic radial upper-shoulder deformation on the bottle shell, liquid, and upper photo skin; no Coca-Cola-specific MCP workflow was added.


- v41 improved same-crop appearance vs v38: RGB MAE `0.16142` -> `0.15720`, luminance MAE `0.16505` -> `0.16143`.


- v41 improved silhouette vs v38: IoU `0.89155` -> `0.91391`, mean abs row-width error `0.04840` -> `0.03857`.


- Validation: `python -m compileall -q src`, `git diff --check`, MCP schema load (`tool_count=49`), and live Maya `compare_image_silhouettes` auto-crop call.











## Latest update: texture-trim sampling and v44 photo-skin cutouts



- Extended generic `trim_mesh_by_texture` with `uv_sample_mode` (`center`, `vertices`, `center_vertices`) and `sample_aggregation` (`mean`, `min`, `max`).

- Used the existing alpha-cut workflow to convert transparent photo-skin regions into real mesh cutouts, reducing viewport transparency sorting artifacts.

- v43 center sampling improved over v41: RGB MAE `0.15720` -> `0.14908`, silhouette IoU `0.91391` -> `0.92817`.

- v44 vertex-mean sampling improved slightly further: RGB MAE `0.14883`, luminance MAE `0.15243`, silhouette IoU `0.92829`.

- Validation: `python -m compileall -q src`, `git diff --check`, MCP schema load exposing the new trim parameters, and live Maya v44 trim/preview/appearance/silhouette run.





## Latest update: scene-open force and v46 liquid material tuning



- Added generic `scene_open(force=False)` support so MCP clients can intentionally discard unsaved Maya scene changes when reopening a normal `.ma` / `.mb` scene during iterative validation.

- Kept the change tool-generic; no Coca-Cola-specific workflow or special-case logic was added.

- Used `compare_image_silhouettes` correction profiles plus `radial_profile_deform` to produce v45 from v44. Same-run auto-crop metrics improved silhouette IoU from about `0.92639` to `0.94588`, and mean row-width error from `0.03040` to `0.02258`.

- Isolated the remaining grey cylindrical read to the internal cola liquid volume rather than the PET shell. Hiding the liquid removed the grey side read but hurt silhouette badly, so the accepted v46 keeps the volume and tunes its generic material attributes instead.

- Current local v46 best: RGB MAE `0.13022`, RGB RMSE `0.19253`, luminance MAE `0.13168`, silhouette IoU `0.94588`, mean row-width error `0.02258`. Generated `mayamcp_official_layered_bottle_v46_best.png` / `.ma`.

- Validation: `python -m compileall -q src`, `git diff --check`, MCP schema load exposing `scene_open.force`, and live Maya v45/v46 preview/appearance/silhouette runs.


## Latest update: radial profile sampling and v47 skin coverage

- Added `sample_mesh_radial_profile`, a generic mesh diagnostic/rebuild tool that samples axial radius profiles from existing polygon meshes using max/mean/min/median/percentile radius statistics.
- Extended `create_revolved_liquid_volume` with generic `angle_start` / `angle_end` controls so liquid volumes can be generated as full 360-degree forms or angular sectors for cutaways, partial fills, and front-facing product validation.
- Used the sampled profile from the current liquid volume to live-test angular liquid sectors. The sector generation worked and improved silhouette in some variants, but it did not beat v46 on appearance, so it was not adopted as the current bottle best.
- Used existing generic `fit_objects_to_bounds` to widen the upper and lower front photo-skin layers after grid metrics showed side cells were the main remaining appearance error.
- Current local v47 best: RGB MAE `0.10715`, RGB RMSE `0.16670`, luminance MAE `0.11154`, silhouette IoU `0.95553`, mean row-width error `0.01843`. Generated `mayamcp_official_layered_bottle_v47_best.png` / `.ma`.
- Validation: `python -m compileall -q src`, `git diff --check`, MCP schema load showing 50 tools including `sample_mesh_radial_profile`, live Maya radial-profile sampling, angular liquid-sector creation, bounds-fit iterations, and v47 appearance/silhouette comparisons.


## Latest update: object bounds query and v50 profile fit

- Added `get_object_bounds`, a generic world-space measurement tool for one or more scene objects. It returns per-object bounds, combined bounds, combined center, combined size, and optional hidden-object filtering, so clients can map image/profile measurements onto scene geometry without ad hoc Maya scripts.
- Used `get_object_bounds` with the existing silhouette correction profile output and `radial_profile_deform` to apply a conservative full-product radial correction to the current bottle scene. This remains generic: the MCP change is only object bounds measurement, and the modeling pass uses existing profile tools.
- Current local v50 best: RGB MAE `0.09216`, RGB RMSE `0.15288`, luminance MAE `0.08789`, silhouette IoU `0.95949`, mean row-width error `0.01666`. Generated `mayamcp_official_layered_bottle_v50_best.png` / `.ma`.
- Validation: `python -m compileall -q src`, MCP schema discovery showing `get_object_bounds`, live Maya `get_object_bounds` call on the 7-object bottle assembly, v50 preview generation, and appearance/silhouette comparisons.

